### PR TITLE
fixed objectToId

### DIFF
--- a/models/BaseModel.js
+++ b/models/BaseModel.js
@@ -177,7 +177,7 @@ function objectToId (obj) {
   const url = getIdURL(obj)
   let type
   try {
-    const pathname = new URL(url).pathname
+    const pathname = url.replace(process.env.DOMAIN, '')
     type = pathname.split('-')[0].slice(1)
   } catch (err) {
     return undefined


### PR DESCRIPTION
I tested it by changing the domain for the tests to https://reader-api.test/api . With that domain, one of the test was failing. After I added the fix you suggested, no more test failures. 