### PR TITLE
delete publiation implemented

### DIFF
--- a/models/Publication.js
+++ b/models/Publication.js
@@ -4,6 +4,7 @@ const { BaseModel } = require('./BaseModel.js')
 const short = require('short-uuid')
 const translator = short()
 const _ = require('lodash')
+const { Activity } = require('./Activity')
 
 /**
  * @property {Reader} reader - Returns the reader that owns this publication.
@@ -154,6 +155,14 @@ class Publication extends BaseModel {
     return Publication.query()
       .findById(translator.toUUID(shortId))
       .eager('[reader, attachment, replies, tags]')
+  }
+
+  static async delete (shortId /*: string */) /*: number */ {
+    const publicationId = translator.toUUID(shortId)
+    await Activity.query()
+      .delete()
+      .where({ publicationId })
+    return Publication.query().deleteById(publicationId)
   }
 
   $formatJson (json /*: any */) /*: any */ {

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -47,7 +47,6 @@ class Publication extends BaseModel {
     const { Reader } = require('./Reader')
     const { Document } = require('./Document.js')
     const { Note } = require('./Note.js')
-    const { Activity } = require('./Activity.js')
     const { Attribution } = require('./Attribution.js')
     const { Tag } = require('./Tag.js')
     return {

--- a/routes/outbox-post.js
+++ b/routes/outbox-post.js
@@ -7,6 +7,8 @@ const { Publications_Tags } = require('../models/Publications_Tags')
 const debug = require('debug')('hobb:routes:outbox')
 const jwtAuth = passport.authenticate('jwt', { session: false })
 const { Tag } = require('../models/Tag')
+const { Publication } = require('../models/Publication')
+const parseurl = require('url').parse
 
 const utils = require('./utils')
 /**
@@ -16,7 +18,7 @@ const utils = require('./utils')
  *     properties:
  *       type:
  *         type: string
- *         enum: ['Create', 'Add']
+ *         enum: ['Create', 'Add', 'Remove', 'Delete']
  *       object:
  *         type: object
  *         properties:
@@ -53,7 +55,7 @@ module.exports = function (app) {
    *       201:
    *         description: Created
    *       204:
-   *         description: Successfully added or removed a tag
+   *         description: Successfully added or removed a tag, or successfully deleted
    *       404:
    *         description: 'No Reader with ID {shortId}'
    *       403:
@@ -132,6 +134,21 @@ module.exports = function (app) {
 
                   default:
                     res.status(400).send(`cannot remove ${body.object.type}`)
+                    break
+                }
+                break
+
+              case 'Delete':
+                expectedStatus = 204
+                switch (body.object.type) {
+                  case 'reader:Publication':
+                    pr = Publication.delete(
+                      parseurl(body.object.id).path.substr(13)
+                    )
+                    break
+
+                  default:
+                    res.status(400).send(`cannot delete ${body.object.type}`)
                     break
                 }
                 break

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -110,6 +110,42 @@ const test = async app => {
     await tap.equal(res.statusCode, 404)
   })
 
+  await tap.test('Delete Publication', async () => {
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Delete',
+          object: {
+            type: 'reader:Publication',
+            id: publicationUrl
+          }
+        })
+      )
+
+    await tap.equal(res.statusCode, 204)
+
+    // publication should no longer exist
+    const getres = await request(app)
+      .get(urlparse(publicationUrl).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(getres.statusCode, 404)
+  })
+
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -18,6 +18,7 @@ const test = async app => {
   const userUrl = urlparse(userId).path
   let publicationUrl
   let activityUrl
+  let documentUrl
 
   await tap.test('Create Publication', async () => {
     const res = await request(app)
@@ -72,7 +73,7 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
-  await tap.test('Get Publicaiton', async () => {
+  await tap.test('Get Publication', async () => {
     const activityObject = await getActivityFromUrl(app, activityUrl, token)
     publicationUrl = activityObject.object.id
 
@@ -96,6 +97,8 @@ const test = async app => {
     // check the order of items
     await tap.equal(body.orderedItems[0].name, 'Chapter 1')
     await tap.notOk(body.orderedItems[2])
+
+    documentUrl = body.orderedItems[0].id
   })
 
   await tap.test('Get Publication that does not exist', async () => {
@@ -133,7 +136,6 @@ const test = async app => {
       )
 
     await tap.equal(res.statusCode, 204)
-
     // publication should no longer exist
     const getres = await request(app)
       .get(urlparse(publicationUrl).path)
@@ -144,6 +146,17 @@ const test = async app => {
       )
 
     await tap.equal(getres.statusCode, 404)
+
+    // TODO: should eventually delete the documents as well. And the notes.
+    // const docres = await request(app)
+    //   .get(urlparse(documentUrl).path)
+    //   .set('Host', 'reader-api.test')
+    //   .set('Authorization', `Bearer ${token}`)
+    //   .type(
+    //     'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    //   )
+
+    // await tap.equal(docres.statusCode, 404)
   })
 
   if (!process.env.POSTGRE_INSTANCE) {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -96,6 +96,12 @@ const test = async app => {
     await tap.equal(res.message, 'duplicate')
   })
 
+  await tap.test('Delete publication', async () => {
+    const res = await Publication.delete(publicationId)
+
+    await tap.equal(res, 1)
+  })
+
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }

--- a/tests/unit/post-outbox-route.test.js
+++ b/tests/unit/post-outbox-route.test.js
@@ -445,7 +445,7 @@ const test = async () => {
   })
 
   await tap.test('Detele a publication', async () => {
-    PublicationStub.Publication.delete = async () => Promise.resolve()
+    PublicationStub.Publication.delete = async () => Promise.resolve(1)
     checkReaderStub.returns(true)
 
     const res = await request

--- a/tests/unit/post-outbox-route.test.js
+++ b/tests/unit/post-outbox-route.test.js
@@ -8,6 +8,7 @@ const { ExtractJwt } = require('passport-jwt')
 const MockStrategy = require('passport-mock-strategy')
 const { Reader } = require('../../models/Reader')
 const { Activity } = require('../../models/Activity')
+const { Publication } = require('../../models/Publication')
 
 const setupPassport = () => {
   var opts = {}
@@ -135,6 +136,15 @@ const removeTagFromStackRequest = {
   }
 }
 
+const deletePublicationRequest = {
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  type: 'Delete',
+  object: {
+    type: 'reader:Publication',
+    id: 'https://localhost:8080/publication-123'
+  }
+}
+
 const neutralActivityRequest = {
   '@context': 'https://www.w3.org/ns/activitystreams',
   type: 'Arrive',
@@ -235,6 +245,7 @@ const test = async () => {
   const ActivityStub = {}
   const Publication_TagsStub = {}
   const TagStub = {}
+  const PublicationStub = {}
   const checkReaderStub = sinon.stub()
 
   const outboxRoute = proxyquire('../../routes/outbox-post', {
@@ -242,6 +253,7 @@ const test = async () => {
     '../models/Activity.js': ActivityStub,
     '../models/Publications_Tags.js': Publication_TagsStub,
     '../models/Tag.js': TagStub,
+    '../models/Publication.js': PublicationStub,
     './utils.js': {
       checkReader: checkReaderStub
     }
@@ -430,6 +442,21 @@ const test = async () => {
     await tap.equal(res.statusCode, 204)
     await tap.ok(removeTagFromPubSpy.calledOnce)
     await tap.ok(createActivitySpy.calledOnce)
+  })
+
+  await tap.test('Detele a publication', async () => {
+    PublicationStub.Publication.delete = async () => Promise.resolve()
+    checkReaderStub.returns(true)
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(deletePublicationRequest))
+
+    await tap.equal(res.statusCode, 204)
   })
 
   await tap.test('Try to create an activity for the wrong user', async () => {


### PR DESCRIPTION
This does a hard delete of the publication and all activities associated with the publication id.

This does not delete any documents or notes associated with that publication. 
It also does not delete any tag-publication join.
I don't think any of this will be a problem for now. 

One thing I wanted to do was return a 404 error if trying to delete a publication that does not exist. However, the way the post-outbox route is set up, that kind of thing is getting quite complicated. I will refactor this whole route. I will do that in another pull request to keep this one legible.
