### PR TITLE
soft delete of publication and note

### DIFF
--- a/doc.json
+++ b/doc.json
@@ -593,6 +593,10 @@
           "type": "string",
           "format": "date-time"
         },
+        "deleted": {
+          "type": "string",
+          "format": "date-time"
+        },
         "attributedTo": {
           "type": "array"
         }
@@ -624,6 +628,10 @@
           "format": "date-time"
         },
         "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleted": {
           "type": "string",
           "format": "date-time"
         },
@@ -664,6 +672,10 @@
           "format": "date-time"
         },
         "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleted": {
           "type": "string",
           "format": "date-time"
         },
@@ -760,6 +772,10 @@
           "format": "date-time"
         },
         "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleted": {
           "type": "string",
           "format": "date-time"
         },
@@ -924,6 +940,10 @@
           "format": "date-time"
         },
         "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "deleted": {
           "type": "string",
           "format": "date-time"
         }

--- a/migrations/20190204095234_reader.js
+++ b/migrations/20190204095234_reader.js
@@ -11,6 +11,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095305_publication.js
+++ b/migrations/20190204095305_publication.js
@@ -18,6 +18,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095340_document.js
+++ b/migrations/20190204095340_document.js
@@ -28,6 +28,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095447_note.js
+++ b/migrations/20190204095447_note.js
@@ -30,6 +30,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095522_tag.js
+++ b/migrations/20190204095522_tag.js
@@ -19,6 +19,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095603_activity.js
+++ b/migrations/20190204095603_activity.js
@@ -42,6 +42,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/migrations/20190204095724_attribution.js
+++ b/migrations/20190204095724_attribution.js
@@ -36,6 +36,8 @@ exports.up = function (knex, Promise) {
       .timestamp('updated')
       .defaultTo(knex.fn.now())
       .notNullable()
+    table
+      .timestamp('deleted')
   })
 }
 

--- a/models/BaseModel.js
+++ b/models/BaseModel.js
@@ -96,7 +96,7 @@ class BaseModel extends guid(DbErrors(Model)) {
       json.bto = json.actor
     }
     const canonicalId = getCanonical(json.url)
-    const { userId, inReplyTo, context } = json
+    const { userId, inReplyTo, context, deleted } = json
     // Should get the inReplyTo document id, much like context
     const publicationId = getUUID(context)
     const documentId = getUUID(inReplyTo)
@@ -119,7 +119,8 @@ class BaseModel extends guid(DbErrors(Model)) {
           replies,
           attributedTo,
           publicationId,
-          documentId
+          documentId,
+          deleted
         },
         activityRelation
       )

--- a/models/Note.js
+++ b/models/Note.js
@@ -4,6 +4,7 @@ const Model = require('objection').Model
 const { BaseModel } = require('./BaseModel.js')
 const short = require('short-uuid')
 const translator = short()
+const { Activity } = require('./Activity')
 
 /**
  * @property {Reader} reader - Returns the reader that owns this note. In most cases this should be 'actor' in the activity streams sense
@@ -38,7 +39,8 @@ class Note extends BaseModel {
           additionalProperties: true
         },
         updated: { type: 'string', format: 'date-time' },
-        published: { type: 'string', format: 'date-time' }
+        published: { type: 'string', format: 'date-time' },
+        deleted: { type: 'string', format: 'date-time' }
       },
       additionalProperties: true,
       required: ['json']
@@ -49,7 +51,6 @@ class Note extends BaseModel {
     const { Publication } = require('./Publication.js')
     const { Reader } = require('./Reader.js')
     const { Document } = require('./Document.js')
-    const { Activity } = require('./Activity.js')
     return {
       reader: {
         relation: Model.BelongsToOneRelation,
@@ -111,6 +112,13 @@ class Note extends BaseModel {
 
   asRef () /*: string */ {
     return this.toJSON().id
+  }
+
+  static async delete (shortId /*: string */) /*: Promise<any> */ {
+    const noteId = translator.toUUID(shortId)
+    return await Note.query().patchAndFetchById(noteId, {
+      deleted: new Date().toISOString()
+    })
   }
 }
 

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -37,7 +37,8 @@ class Publication extends BaseModel {
           additionalProperties: true
         },
         updated: { type: 'string', format: 'date-time' },
-        published: { type: 'string', format: 'date-time' }
+        published: { type: 'string', format: 'date-time' },
+        deleted: { type: 'string', format: 'date-time' }
       },
       additionalProperties: true,
       required: ['json']
@@ -158,10 +159,9 @@ class Publication extends BaseModel {
 
   static async delete (shortId /*: string */) /*: number */ {
     const publicationId = translator.toUUID(shortId)
-    await Activity.query()
-      .delete()
-      .where({ publicationId })
-    return Publication.query().deleteById(publicationId)
+    return await Publication.query().patchAndFetchById(publicationId, {
+      deleted: new Date().toISOString()
+    })
   }
 
   $formatJson (json /*: any */) /*: any */ {

--- a/routes/activities/delete.js
+++ b/routes/activities/delete.js
@@ -2,15 +2,16 @@ const { createActivityObject } = require('./utils')
 const { Publication } = require('../../models/Publication')
 const parseurl = require('url').parse
 const { Activity } = require('../../models/Activity')
+const { Note } = require('../../models/Note')
 
 const handleDelete = async (req, res, reader) => {
   const body = req.body
   switch (body.object.type) {
     case 'reader:Publication':
-      const resultPub = await Publication.delete(
+      const returned = await Publication.delete(
         parseurl(body.object.id).path.substr(13)
       )
-      const activityObjPub = createActivityObject(body, resultPub, reader)
+      const activityObjPub = createActivityObject(body, returned, reader)
       Activity.createActivity(activityObjPub)
         .then(activity => {
           res.status(204)
@@ -19,6 +20,22 @@ const handleDelete = async (req, res, reader) => {
         })
         .catch(err => {
           res.status(400).send(`delete publication error: ${err.message}`)
+        })
+      break
+
+    case 'Note':
+      const resultNote = await Note.delete(
+        parseurl(body.object.id).path.substr(6)
+      )
+      const activityObjNote = createActivityObject(body, resultNote, reader)
+      Activity.createActivity(activityObjNote)
+        .then(activity => {
+          res.status(204)
+          res.set('Location', activity.url)
+          res.end()
+        })
+        .catch(err => {
+          res.status(400).send(`delete note error: ${err.message}`)
         })
       break
 

--- a/routes/document.js
+++ b/routes/document.js
@@ -96,7 +96,9 @@ module.exports = app => {
                     { reader: 'https://rebus.foundation/ns/reader' }
                   ],
                   replies: document.replies
-                    ? document.replies.map(reply => reply.toJSON())
+                    ? document.replies
+                      .filter(reply => !reply.deleted)
+                      .map(reply => reply.toJSON())
                     : []
                 })
               )

--- a/routes/note.js
+++ b/routes/note.js
@@ -80,7 +80,7 @@ module.exports = app => {
       const shortId = req.params.shortId
       Note.byShortId(shortId)
         .then(note => {
-          if (!note) {
+          if (!note || note.deleted) {
             res.status(404).send(`No note with ID ${shortId}`)
           } else if (!utils.checkReader(req, note.reader)) {
             res.status(403).send(`Access to note ${shortId} disallowed`)

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -97,7 +97,7 @@ module.exports = function (app) {
       const shortId = req.params.shortId
       Publication.byShortId(shortId)
         .then(publication => {
-          if (!publication) {
+          if (!publication || publication.deleted) {
             res.status(404).send(`No publication with ID ${shortId}`)
           } else if (!utils.checkReader(req, publication.reader)) {
             res.status(403).send(`Access to publication ${shortId} disallowed`)
@@ -121,7 +121,9 @@ module.exports = function (app) {
                     { schema: 'https://schema.org/' }
                   ],
                   replies: publication.replies
-                    ? publication.replies.map(note => note.asRef())
+                    ? publication.replies
+                      .filter(note => !note.deleted)
+                      .map(note => note.asRef())
                     : [],
                   tags: publication.tags
                 })

--- a/routes/user-library.js
+++ b/routes/user-library.js
@@ -90,6 +90,9 @@ module.exports = app => {
               'Content-Type',
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
+            const publications = reader.publications.filter(
+              pub => !pub.json.deleted
+            )
             res.end(
               JSON.stringify({
                 '@context': 'https://www.w3.org/ns/activitystreams',
@@ -98,8 +101,8 @@ module.exports = app => {
                 },
                 type: 'Collection',
                 id: getId(`/reader-${shortId}/library`),
-                totalItems: reader.publications.length,
-                items: reader.publications.map(pub => pub.asRef()),
+                totalItems: publications.length,
+                items: publications.map(pub => pub.asRef()),
                 tags: reader.tags
               })
             )

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -80,6 +80,7 @@ const test = async app => {
     .type(
       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
     )
+
   const documentUrl = resPublication.body.orderedItems[0].id
   // create Note for user 1
 

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -137,7 +137,7 @@ const test = async app => {
 
     await tap.equal(res.statusCode, 204)
 
-    // publication should no longer exist
+    // getting deleted publication should return 404 error
     const getres = await request(app)
       .get(urlparse(publicationUrl).path)
       .set('Host', 'reader-api.test')
@@ -147,6 +147,21 @@ const test = async app => {
       )
 
     await tap.equal(getres.statusCode, 404)
+
+    // publication should no longer be in the reader library
+    const libraryres = await request(app)
+      .get(`${userUrl}/library`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(libraryres.status, 200)
+    const body = libraryres.body
+    await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 0)
+    await tap.equal(body.totalItems, 0)
 
     // TODO: should eventually delete the documents as well. And the notes.
     // const docres = await request(app)

--- a/tests/models/Note.test.js
+++ b/tests/models/Note.test.js
@@ -78,6 +78,16 @@ const test = async app => {
     await tap.type(noteRef, 'string')
   })
 
+  await tap.test('Delete Note', async () => {
+    const res = await Note.delete(noteId)
+    await tap.ok(res.deleted)
+  })
+
+  await tap.test('Delete Note that does not exist', async () => {
+    const res = await Note.delete('123')
+    await tap.notOk(res)
+  })
+
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -98,8 +98,12 @@ const test = async app => {
 
   await tap.test('Delete publication', async () => {
     const res = await Publication.delete(publicationId)
+    await tap.ok(res.deleted)
+  })
 
-    await tap.equal(res, 1)
+  await tap.test('Delete publication that does not exist', async () => {
+    const res = await Publication.delete('123')
+    await tap.notOk(res)
   })
 
   if (!process.env.POSTGRE_INSTANCE) {

--- a/tests/unit/post-outbox-route-delete.test.js
+++ b/tests/unit/post-outbox-route-delete.test.js
@@ -42,6 +42,15 @@ const deletePublicationRequest = {
   }
 }
 
+const deleteNoteRequest = {
+  '@context': 'https://www.w3.org/ns/activitystreams',
+  type: 'Delete',
+  object: {
+    type: 'Note',
+    id: 'https://localhost:8080/note-123'
+  }
+}
+
 const activity = Object.assign(new Activity(), {
   id: 'dc9794fa-4806-4b56-90b9-6fd444fc1485',
   type: 'Activity',
@@ -118,6 +127,7 @@ const test = async () => {
   const Publication_TagsStub = {}
   const TagStub = {}
   const PublicationStub = {}
+  const NoteStub = {}
   const checkReaderStub = sinon.stub()
 
   const outboxRoute = proxyquire('../../routes/outbox-post', {
@@ -126,6 +136,7 @@ const test = async () => {
     '../models/Publications_Tags.js': Publication_TagsStub,
     '../models/Tag.js': TagStub,
     '../models/Publication.js': PublicationStub,
+    '../models/Note.js': NoteStub,
     './utils.js': {
       checkReader: checkReaderStub
     }
@@ -148,6 +159,23 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
       .send(JSON.stringify(deletePublicationRequest))
+
+    await tap.equal(res.statusCode, 204)
+  })
+
+  await tap.test('Detele a note', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    NoteStub.Note.delete = async () => Promise.resolve(1)
+    checkReaderStub.returns(true)
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(deleteNoteRequest))
 
     await tap.equal(res.statusCode, 204)
   })


### PR DESCRIPTION
Added a deleted timestamp, which will give us the option later on to set some sort of expiry. 

Delete works for publication and notes
I tested that the library does not return deleted publications
And Publications and Documents do not return deleted notes

Also trying to get a deleted publication or note directly will return a 404 error, of course.