### PR TITLE
Create read activity

### DIFF
--- a/models/Activity.js
+++ b/models/Activity.js
@@ -45,6 +45,7 @@ class Activity extends BaseModel {
   get path () /*: string */ {
     return 'activity'
   }
+
   static get jsonSchema () /*: any */ {
     return {
       type: 'object',
@@ -183,6 +184,14 @@ class Activity extends BaseModel {
 
   static async createActivity (activity /*: any */) /*: Promise<activity> */ {
     return Activity.query().insert(activity)
+  }
+
+  $parseJson (json /*: any */, opt /*: any */) /*: any */ {
+    json = super.$parseJson(json, opt)
+    const type = json.json.type
+    return Object.assign(json, {
+      type
+    })
   }
 }
 

--- a/models/Document.js
+++ b/models/Document.js
@@ -128,7 +128,7 @@ class Document extends BaseModel {
   }> */ {
     return Document.query()
       .findById(translator.toUUID(shortId))
-      .eager('[reader, replies]')
+      .eager('[reader, replies, outbox]')
   }
 }
 module.exports = { Document }

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -154,7 +154,7 @@ class Publication extends BaseModel {
   }> */ {
     return Publication.query()
       .findById(translator.toUUID(shortId))
-      .eager('[reader, attachment, replies, tags]')
+      .eager('[reader, attachment.outbox, replies, tags]')
   }
 
   static async delete (shortId /*: string */) /*: number */ {

--- a/routes/activities/read.js
+++ b/routes/activities/read.js
@@ -1,0 +1,31 @@
+const { createActivityObject } = require('./utils')
+const { Activity } = require('../../models/Activity')
+const { Document } = require('../../models/Document')
+const parseurl = require('url').parse
+
+const handleRead = async (req, res, reader) => {
+  const body = req.body
+  switch (body.object.type) {
+    case 'Document':
+      const resultDoc = await Document.byShortId(
+        parseurl(body.object.id).path.substr(10)
+      )
+      const activityObjStack = createActivityObject(body, resultDoc, reader)
+      Activity.createActivity(activityObjStack)
+        .then(activity => {
+          res.status(201)
+          res.set('Location', activity.url)
+          res.end()
+        })
+        .catch(err => {
+          res.status(400).send(`read error: ${err.message}`)
+        })
+      break
+
+    default:
+      res.status(400).send(`cannot read ${body.object.type}`)
+      break
+  }
+}
+
+module.exports = { handleRead }

--- a/routes/activities/remove.js
+++ b/routes/activities/remove.js
@@ -6,7 +6,7 @@ const handleRemove = async (req, res, reader) => {
   const body = req.body
   switch (body.object.type) {
     case 'reader:Stack':
-      const resultStack = Publications_Tags.removeTagFromPub(
+      const resultStack = await Publications_Tags.removeTagFromPub(
         body.target.id,
         body.object.id
       )

--- a/routes/document.js
+++ b/routes/document.js
@@ -92,11 +92,14 @@ module.exports = app => {
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
             let position
-            const readAct = document.outbox.filter(act => act.type === 'Read')
-            if (readAct.length > 0) {
-              position = _.maxBy(readAct, o => o.published).json[
-                'oa:hasSelector'
-              ].value
+            let readAct
+            if (document.outbox) {
+              readAct = document.outbox.filter(act => act.type === 'Read')
+              if (readAct.length > 0) {
+                position = _.maxBy(readAct, o => o.published).json[
+                  'oa:hasSelector'
+                ].value
+              }
             }
 
             res.end(

--- a/routes/document.js
+++ b/routes/document.js
@@ -4,6 +4,7 @@ const passport = require('passport')
 const { Document } = require('../models/Document')
 const debug = require('debug')('hobb:routes:document')
 const utils = require('./utils')
+const _ = require('lodash')
 
 /**
  * @swagger
@@ -34,6 +35,8 @@ const utils = require('./utils')
  *         type: array
  *         items:
  *           $ref: '#/definitions/note'
+ *       position:
+ *         type: string
  *
  */
 
@@ -88,6 +91,14 @@ module.exports = app => {
               'Content-Type',
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
+            let position
+            const readAct = document.outbox.filter(act => act.type === 'Read')
+            if (readAct.length > 0) {
+              position = _.maxBy(readAct, o => o.published).json[
+                'oa:hasSelector'
+              ].value
+            }
+
             res.end(
               JSON.stringify(
                 Object.assign(document.toJSON(), {
@@ -99,7 +110,8 @@ module.exports = app => {
                     ? document.replies
                       .filter(reply => !reply.deleted)
                       .map(reply => reply.toJSON())
-                    : []
+                    : [],
+                  position: position
                 })
               )
             )

--- a/routes/outbox-post.js
+++ b/routes/outbox-post.js
@@ -9,6 +9,7 @@ const { handleRemove } = require('./activities/remove')
 const { handleDelete } = require('./activities/delete')
 const { handleArrive } = require('./activities/arrive')
 const { handleUpdate } = require('./activities/update')
+const { handleRead } = require('./activities/read')
 
 const utils = require('./utils')
 /**
@@ -18,7 +19,7 @@ const utils = require('./utils')
  *     properties:
  *       type:
  *         type: string
- *         enum: ['Create', 'Add', 'Remove', 'Delete', 'Update']
+ *         enum: ['Create', 'Add', 'Remove', 'Delete', 'Update', 'Read']
  *       object:
  *         type: object
  *         properties:
@@ -106,6 +107,10 @@ module.exports = function (app) {
 
                 case 'Update':
                   await handleUpdate(req, res, reader)
+                  break
+
+                case 'Read':
+                  await handleRead(req, res, reader)
                   break
 
                 default:

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -113,7 +113,7 @@ module.exports = function (app) {
             let positionObject = {}
             const readActivities = []
             publication.attachment.forEach(document => {
-              if (document.outbox.length > 0) {
+              if (document.outbox && document.outbox.length > 0) {
                 document.outbox.forEach(act => {
                   if (act.type === 'Read') readActivities.push(act)
                 })

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -4,6 +4,7 @@ const passport = require('passport')
 const { Publication } = require('../models/Publication')
 const debug = require('debug')('hobb:routes:publication')
 const utils = require('./utils')
+const _ = require('lodash')
 /**
  * @swagger
  * definition:
@@ -108,6 +109,24 @@ module.exports = function (app) {
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
             const publicationJson = publication.toJSON()
+            // get latest read position from the attached documents
+            let positionObject = {}
+            const readActivities = []
+            publication.attachment.forEach(document => {
+              if (document.outbox.length > 0) {
+                document.outbox.forEach(act => {
+                  if (act.type === 'Read') readActivities.push(act)
+                })
+              }
+            })
+            if (readActivities.length > 0) {
+              let position = _.maxBy(readActivities, o => o.published)
+              positionObject = {
+                documentId: position.json.object.id,
+                value: position.json['oa:hasSelector'].value
+              }
+            }
+
             res.end(
               JSON.stringify(
                 Object.assign(publicationJson, {
@@ -125,7 +144,8 @@ module.exports = function (app) {
                       .filter(note => !note.deleted)
                       .map(note => note.asRef())
                     : [],
-                  tags: publication.tags
+                  tags: publication.tags,
+                  position: positionObject
                 })
               )
             )

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -134,6 +134,46 @@ const test = async app => {
     await tap.equal(res.status, 201)
     await tap.type(res.get('Location'), 'string')
     activityUrl = res.get('Location')
+
+    // making sure the position returned in the document is the latest
+
+    await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' },
+            { oa: 'http://www.w3.org/ns/oa#' }
+          ],
+          type: 'Read',
+          object: { type: 'Document', id: documentUrl },
+          context: publicationUrl,
+          'oa:hasSelector': {
+            type: 'XPathSelector',
+            value: '/html/body/p[2]/table/tr[2]/td[3]/span2'
+          }
+        })
+      )
+
+    const resDoc = await request(app)
+      .get(urlparse(documentUrl).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    await tap.equal(resDoc.statusCode, 200)
+
+    const body = resDoc.body
+    await tap.type(body, 'object')
+    await tap.type(body.position, 'string')
+    await tap.equal(body.position, '/html/body/p[2]/table/tr[2]/td[3]/span2')
   })
 
   await tap.test('Get Document that does not exist', async () => {

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -18,6 +18,44 @@ const test = async app => {
   const userUrl = urlparse(userId).path
   let documentUrl
   let activityUrl
+  let publicationUrl
+
+  const createPubRes = await request(app)
+    .post(`${userUrl}/activity`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+    .send(
+      JSON.stringify({
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          { reader: 'https://rebus.foundation/ns/reader' }
+        ],
+        type: 'Create',
+        object: {
+          type: 'reader:Publication',
+          name: 'Publication A',
+          attributedTo: [
+            {
+              type: 'Person',
+              name: 'Sample Author'
+            }
+          ],
+          totalItems: 0,
+          attachment: []
+        }
+      })
+    )
+
+  createPubActivityUrl = createPubRes.get('Location')
+  const createPubActivityObject = await getActivityFromUrl(
+    app,
+    createPubActivityUrl,
+    token
+  )
+  publicationUrl = createPubActivityObject.object.id
 
   await tap.test('Create Document', async () => {
     const res = await request(app)
@@ -66,6 +104,36 @@ const test = async app => {
     await tap.type(body.id, 'string')
     await tap.type(body['@context'], 'object')
     await tap.ok(Array.isArray(body['@context']))
+  })
+
+  await tap.test('Document Read Activity', async () => {
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' },
+            { oa: 'http://www.w3.org/ns/oa#' }
+          ],
+          type: 'Read',
+          object: { type: 'Document', id: documentUrl },
+          context: publicationUrl,
+          'oa:hasSelector': {
+            type: 'XPathSelector',
+            value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+          }
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    await tap.type(res.get('Location'), 'string')
+    activityUrl = res.get('Location')
   })
 
   await tap.test('Get Document that does not exist', async () => {

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -18,7 +18,7 @@ const test = async app => {
   const userUrl = urlparse(userId).path
   let publicationUrl
   let activityUrl
-  //  let documentUrl
+  let documentUrl
 
   await tap.test('Create Publication', async () => {
     const res = await request(app)
@@ -101,6 +101,78 @@ const test = async app => {
     documentUrl = body.orderedItems[0].id
   })
 
+  await tap.test('Read activity should appear on the publication', async () => {
+    await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' },
+            { oa: 'http://www.w3.org/ns/oa#' }
+          ],
+          type: 'Read',
+          object: { type: 'Document', id: documentUrl },
+          context: publicationUrl,
+          'oa:hasSelector': {
+            type: 'XPathSelector',
+            value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+          }
+        })
+      )
+
+    await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' },
+            { oa: 'http://www.w3.org/ns/oa#' }
+          ],
+          type: 'Read',
+          object: { type: 'Document', id: documentUrl },
+          context: publicationUrl,
+          'oa:hasSelector': {
+            type: 'XPathSelector',
+            value: '/html/body/p[2]/table/tr[2]/td[3]/span2'
+          }
+        })
+      )
+
+    const activityObject = await getActivityFromUrl(app, activityUrl, token)
+    publicationUrl = activityObject.object.id
+
+    const res = await request(app)
+      .get(urlparse(publicationUrl).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.position, 'object')
+    await tap.type(body.position.documentId, 'string')
+    await tap.equal(body.position.documentId, documentUrl)
+    await tap.type(body.position.value, 'string')
+    await tap.equal(
+      body.position.value,
+      '/html/body/p[2]/table/tr[2]/td[3]/span2'
+    )
+  })
+
   await tap.test('Get Publication that does not exist', async () => {
     const res = await request(app)
       .get(urlparse(publicationUrl).path + 'abc')
@@ -134,7 +206,7 @@ const test = async app => {
           }
         })
       )
-
+    console.log(res.error)
     await tap.equal(res.statusCode, 204)
 
     // getting deleted publication should return 404 error

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -206,7 +206,6 @@ const test = async app => {
           }
         })
       )
-    console.log(res.error)
     await tap.equal(res.statusCode, 204)
 
     // getting deleted publication should return 404 error

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -37,7 +37,7 @@ const createUser = async (app, token) => {
 
 const destroyDB = async app => {
   if (!process.env.POSTGRE_INSTANCE && process.env.NODE_ENV === 'test') {
-    await fs.unlinkSync('./test.sqlite3')
+    // await fs.unlinkSync('./test.sqlite3')
   } else if (process.env.NODE_ENV === 'test') {
     await knexCleaner.clean(app.knex)
   }

--- a/tests/unit/post-outbox-route-read.test.js
+++ b/tests/unit/post-outbox-route-read.test.js
@@ -1,0 +1,181 @@
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const supertest = require('supertest')
+const express = require('express')
+const tap = require('tap')
+const passport = require('passport')
+const { ExtractJwt } = require('passport-jwt')
+const MockStrategy = require('passport-mock-strategy')
+const { Reader } = require('../../models/Reader')
+const { Activity } = require('../../models/Activity')
+const { Document } = require('../../models/Document')
+
+const setupPassport = () => {
+  var opts = {}
+  opts.jwtFromRequest = ExtractJwt.fromAuthHeaderAsBearerToken()
+  opts.secretOrKey = process.env.SECRETORKEY
+  opts.issuer = process.env.ISSUER
+  opts.audience = process.env.AUDIENCE
+  opts.name = 'jwt'
+  passport.use(new MockStrategy(opts))
+}
+
+setupPassport()
+
+const app = express()
+app.use(
+  express.json({
+    type: [
+      'application/json',
+      'application/activity+json',
+      'application/ld+json'
+    ],
+    limit: '100mb'
+  })
+)
+
+const readActivityRequest = {
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' },
+    { oa: 'http://www.w3.org/ns/oa#' }
+  ],
+  type: 'Read',
+  object: {
+    type: 'Document',
+    id: 'https://localhost:8080/document-123'
+  },
+  context: 'http://localhost:8080/publication-456'
+}
+
+const activity = Object.assign(new Activity(), {
+  id: 'dc9794fa-4806-4b56-90b9-6fd444fc1485',
+  type: 'Read',
+  json: {
+    '@context': [
+      'https://www.w3.org/ns/activitystreams',
+      { reader: 'https://rebus.foundation/ns/reader' }
+    ],
+    type: 'Create',
+    object: {
+      type: 'Document',
+      id: 'https://reader-api.test/document-m1vGaFVCQTzVBkdLFaxbSm'
+    },
+    actor: {
+      type: 'Person',
+      id: 'https://reader-api.test/reader-nS5zw1btwDYT5S6DdvL9yj'
+    },
+    summaryMap: { en: 'someone created' }
+  },
+  readerId: 'b10debec-bfee-438f-a394-25e75457ff62',
+  documentId: null,
+  publicationId: 'a2091266-624b-4c46-9066-ce1c642b1898',
+  noteId: null,
+  published: '2018-12-18T14:56:53.173Z',
+  updated: '2018-12-18 14:56:53',
+  reader: {
+    id: 'b10debec-bfee-438f-a394-25e75457ff62',
+    json: { name: 'J. Random Reader', userId: 'auth0|foo1545145012840' },
+    userId: 'auth0|foo1545145012840',
+    published: '2018-12-18T14:56:52.924Z',
+    updated: '2018-12-18 14:56:52'
+  },
+  publication: {
+    id: 'a2091266-624b-4c46-9066-ce1c642b1898',
+    description: null,
+    json: {
+      attachment: [
+        {
+          type: 'Document',
+          name: 'Chapter 2',
+          content: 'Sample document content 2',
+          position: 1
+        },
+        {
+          type: 'Document',
+          name: 'Chapter 1',
+          content: 'Sample document content 1',
+          position: 0
+        }
+      ],
+      type: 'reader:Publication',
+      name: 'Publication A',
+      attributedTo: [{ type: 'Person', name: 'Sample Author' }]
+    },
+    readerId: 'b10debec-bfee-438f-a394-25e75457ff62',
+    published: '2018-12-18T14:56:53.149Z',
+    updated: '2018-12-18 14:56:53'
+  },
+  document: null,
+  note: null
+})
+
+const document = Object.assign(new Document(), {
+  id: 'dd8974e5-0641-46df-be73-7581972ebbf2',
+  type: 'text/html',
+  json: {
+    type: 'Document',
+    name: 'Chapter 1',
+    content: 'Sample document content 1',
+    position: 0
+  },
+  readerId: '9d2f717f-54b2-4732-a045-e0419c94a1c4',
+  publicationId: '28ca9d84-9afb-4f9e-a437-6f05dc2f5824',
+  published: '2018-12-18T16:11:05.391Z',
+  updated: '2018-12-18 16:11:05'
+})
+
+const reader = Object.assign(new Reader(), {
+  id: '7441db0a-c14b-4925-a7dc-4b7ff5d0c8cc',
+  json: { name: 'J. Random Reader', userId: 'auth0|foo1545228877880' },
+  userId: 'auth0|foo1545228877880',
+  published: '2018-12-19T14:14:37.965Z',
+  updated: '2018-12-19 14:14:37'
+})
+
+const test = async () => {
+  const ReaderStub = {}
+  const ActivityStub = {}
+  const Publication_TagsStub = {}
+  const TagStub = {}
+  const PublicationStub = {}
+  const checkReaderStub = sinon.stub()
+  const DocumentStub = {}
+
+  const outboxRoute = proxyquire('../../routes/outbox-post', {
+    '../models/Reader.js': ReaderStub,
+    '../models/Activity.js': ActivityStub,
+    '../models/Publications_Tags.js': Publication_TagsStub,
+    '../models/Tag.js': TagStub,
+    '../models/Publication.js': PublicationStub,
+    '../models/Document.js': DocumentStub,
+    './utils.js': {
+      checkReader: checkReaderStub
+    }
+  })
+
+  outboxRoute(app)
+  const request = supertest(app)
+
+  await tap.test('Read activity', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    DocumentStub.Document.byShortId = async () => Promise.resolve(document)
+    checkReaderStub.returns(true)
+
+    const createActivitySpy = sinon.spy(ActivityStub.Activity, 'createActivity')
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(readActivityRequest))
+
+    await tap.equal(res.statusCode, 201)
+    await tap.ok(createActivitySpy.calledOnce)
+  })
+}
+
+test()

--- a/tests/unit/publication-route.test.js
+++ b/tests/unit/publication-route.test.js
@@ -128,7 +128,6 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-    console.log(res.error)
     await tap.equal(res.statusCode, 200)
 
     const body = res.body

--- a/tests/unit/publication-route.test.js
+++ b/tests/unit/publication-route.test.js
@@ -128,7 +128,7 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-
+    console.log(res.error)
     await tap.equal(res.statusCode, 200)
 
     const body = res.body


### PR DESCRIPTION
The implementation is similar to what we had discussed.

Some small changes:
In the request, the object is an object with a  type ('Document') and an id (document url). I could make it work with just the url, since I don't expect that read activity will ever apply to anything other than a document. But this was more consistent with how other activities are implemented. 

When getting a document, the response will include a position, which is a string

When getting a publication, the response will include a position, which is an object with a documentId (url) and a value (string)

Does that work for you?