### PR TITLE
document POST activities endpoint

### DIFF
--- a/activityDoc.md
+++ b/activityDoc.md
@@ -6,6 +6,14 @@ This document provides examples for different activities that are implemented at
 
 In all cases, the endpoint will return a 201 status and a Location that is the url of the activity created.
 
+General Errors:
+These errors can be thrown on various activities
+
+* 404: 'No reader with id {id}'
+* 403: 'Access to reader {id} disallowed'
+* 400: 'action {action type} not recognized' - action type should be one of 'Create', 'Add', 'Remove', 'Delete', 'Update', 'Read'
+* 400: 'cannot {verb} {type}' e.g. 'cannot delete Document'. Object types can be 'reader:Publication', 'Document', 'Note', 'reader:Stack'. But not all action - object combinations are supported. For example, Update reader:Publication is not supported.
+
 ## Publications
 
 ### Create a Publication
@@ -62,6 +70,11 @@ Required properties:
 
 Documents attached to a publication will also be created and will belong to the publication. Alternatively, they can be created separately through the Create Document activity (see below)
 
+Possible errors:
+
+* 400 'create publication error: {message}' - generic error that occured on createPublication. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
+
 ### Delete a Publication
 
 Example:
@@ -79,6 +92,12 @@ Example:
   }
 }
 ```
+
+Possible errors:
+
+* 404: 'publication with id {id} does not exist or has already been deleted'
+* 400: 'delete publication error: {message}' - generic error that occured on deletePublication. Refer to message for more details
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
 ### Other
 
@@ -110,6 +129,11 @@ Example:
 
 This will create a document that will be attached to the publication specified in object.context
 
+Possible errors:
+
+* 400: 'create document error: {message}' - generic error that occured on createDocument. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
+
 ### Read Activity
 
 Example:
@@ -133,6 +157,11 @@ Example:
 
 Once read activity is attached to a document, getting that document will return the latest read activity for that document position in the 'position' property
 Similarly, getting the publication will return the latest read activity attached to any of its documents.
+
+Possible errors:
+
+* 404: 'document with id {id} not found'
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
 ## Notes
 
@@ -164,6 +193,11 @@ This will create a note that is attached to the document specified in object.inR
 The specific location of the annotation within the document is specified by the oa:hasSelector object
 ADD LINK
 
+Possible errors:
+
+* 400: 'create note error: {message}' - generic error that occured on createNote. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
+
 ### Edit a Note
 
 Example:
@@ -186,6 +220,11 @@ Example:
 
 The API supports changes to either the content or the oa:hasSelector, or both. These properties only need to be included in the object only if they are changed.
 
+Possible errors:
+
+* 404: 'no note found with id {id}'
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
+
 ### Delete a Note
 
 Example:
@@ -203,6 +242,12 @@ Example:
   }
 }
 ```
+
+Possible errors:
+
+* 404: 'note with id {id} does not exist or has already been deleted'
+* 400: 'delete note error: {message}' - generic error taht occured on deleteNote. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
 ## Tags
 
@@ -226,6 +271,11 @@ Example:
 }
 ```
 
+Possible errors:
+
+* 400: 'create stack error: {message}' - generic error that occured on createTag. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
+
 ### Asssign a Tag to a Publication
 
 Example:
@@ -247,11 +297,17 @@ Example:
 }
 ```
 
-If the tag was already assigned to the publication, the API will return error 400: 'publication {publicationId} already associated with tag {tagId} ({tag name})'
-
 object can contain the entire note object, as returned as a reply to the GET document route. But only the id and the type are required.
 
 Similarly, target can contain the entire publication object, but only the id proeprty is required.
+
+Possible errors:
+
+* 404 'no publiation found with id {id}'
+* 404 'no tag found with id {id}'
+* 400 'publication {publicationId} already associated with tag {tagId} ({tag name})'
+* 400: 'add tag to publication error: {message}' - generic error that occured on add tag to publication. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
 ### Remove Tag from Publication
 
@@ -271,3 +327,10 @@ Similarly, target can contain the entire publication object, but only the id pro
   }
 }
 ```
+
+Possible errors:
+
+* 404 'no publication found with id {id}'
+* 404 'no tag found with id {id}'
+* 400 'remove tag from publication error: {message}' - generic error that occured on remove tag from publication. Refer to message for more details.
+* 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.

--- a/activityDoc.md
+++ b/activityDoc.md
@@ -1,0 +1,273 @@
+# Activity Documentation
+
+The main documentation for the API endpoints can be found [here](https://rebusfoundation.github.io/reader-api). However, since we are using the activityPub standard, the POST /{readerId}/outbox endpoint encompasses a lot of different activities.
+
+This document provides examples for different activities that are implemented at the POST /{readerId}/outbox endpoint.
+
+In all cases, the endpoint will return a 201 status and a Location that is the url of the activity created.
+
+## Publications
+
+### Create a Publication
+
+Example:
+
+```
+{
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      { "reader": "https://rebus.foundation/ns/reader" }
+    ],
+    "type": "Create",
+    "object": {
+      "type": "reader:Publication",
+      "name": "Publication A",
+      "attributedTo": [
+        {
+          "type": "Person",
+          "name": "Sample Author"
+        }
+      ],
+      "attachment": [
+        {
+          "type": "Document",
+          "name": "Chapter 9",
+          "position": 1,
+          "content": "Sample document content 1"
+        },
+        {
+          "type": "Document",
+          "name": "Chapter 2",
+          "position": 0,
+          "content": "Sample document content 2"
+        }
+      ]
+    }
+  }
+```
+
+Required properties:
+
+```
+"@context": [
+    "https://www.w3.org/ns/activitystreams",
+    { "reader": "https://rebus.foundation/ns/reader" }
+  ],
+  "type": "Create",
+"object": {
+  "type": "reader:Publication",
+  "name": <string>
+}
+```
+
+Documents attached to a publication will also be created and will belong to the publication. Alternatively, they can be created separately through the Create Document activity (see below)
+
+### Delete a Publication
+
+Example:
+
+```
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    { "reader": "https://rebus.foundation/ns/reader" }
+  ],
+  "type": "Delete",
+  "object": {
+    "type": "reader:Publication",
+    "id": <publicationUrl>
+  }
+}
+```
+
+### Other
+
+Other activities related to Publications:
+create document (see documents section)
+assign tag to publication (see tags section)
+
+## Documents
+
+### Create a Document
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Create',
+  object: {
+    type: 'Document',
+    name: 'Document A',
+    content: 'This is the content of document A.',
+    context: <PublicationUrl>
+  }
+}
+```
+
+This will create a document that will be attached to the publication specified in object.context
+
+### Read Activity
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' },
+    { oa: 'http://www.w3.org/ns/oa#' }
+  ],
+  type: 'Read',
+  object: { type: 'Document', id: <documentUrl> },
+  context: <publicationUrl>,
+  'oa:hasSelector': {
+    type: 'XPathSelector',
+    value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+  }
+}
+```
+
+Once read activity is attached to a document, getting that document will return the latest read activity for that document position in the 'position' property
+Similarly, getting the publication will return the latest read activity attached to any of its documents.
+
+## Notes
+
+Also known as annotations
+
+### Create a Note
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Create',
+  object: {
+    type: 'Note',
+    content: <string>,
+    'oa:hasSelector': {},
+    context: <publicationUrl>,
+    inReplyTo: <documentUrl>
+  }
+}
+```
+
+This will create a note that is attached to the document specified in object.inReplyTo, in the context of the publication in object.context
+
+The specific location of the annotation within the document is specified by the oa:hasSelector object
+ADD LINK
+
+### Edit a Note
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Update',
+  object: {
+    type: 'Note',
+    id: <noteUrl>,
+    content: <string>,
+    'oa:hasSelector': {}
+  }
+}
+```
+
+The API supports changes to either the content or the oa:hasSelector, or both. These properties only need to be included in the object only if they are changed.
+
+### Delete a Note
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Delete',
+  object: {
+    type: 'Note',
+    id: <noteUrl>
+  }
+}
+```
+
+## Tags
+
+Currently, only tags of the type reader:Stack are supported by the API. Those are used to organize publications into stacks or collections.
+
+### Create a Tag
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Create',
+  object: {
+    type: 'reader:Stack',
+    name: <string>
+  }
+}
+```
+
+### Asssign a Tag to a Publication
+
+Example:
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Add',
+  object: {
+    id: <noteId>
+    type: 'reader:Stack'
+  },
+  target: {
+    id: <publicationId>
+  }
+}
+```
+
+If the tag was already assigned to the publication, the API will return error 400: 'publication {publicationId} already associated with tag {tagId} ({tag name})'
+
+object can contain the entire note object, as returned as a reply to the GET document route. But only the id and the type are required.
+
+Similarly, target can contain the entire publication object, but only the id proeprty is required.
+
+### Remove Tag from Publication
+
+```
+{
+  '@context': [
+    'https://www.w3.org/ns/activitystreams',
+    { reader: 'https://rebus.foundation/ns/reader' }
+  ],
+  type: 'Remove',
+  object: {
+    id: <noteId>
+    type: 'reader:Stack'
+  },
+  target: {
+    id: <publicationId>
+  }
+}
+```

--- a/activityDoc.md
+++ b/activityDoc.md
@@ -131,6 +131,7 @@ This will create a document that will be attached to the publication specified i
 
 Possible errors:
 
+* 404: 'no publication found for {publicaitonId}. Document must belong to an existing publication'
 * 400: 'create document error: {message}' - generic error that occured on createDocument. Refer to message for more details.
 * 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
@@ -195,6 +196,9 @@ ADD LINK
 
 Possible errors:
 
+* 404: 'note creation failed: no publication found with id {id}' - publication id in note.context must point to an existing publication
+* 404: 'note creation failed: no document found with id {id}' - document id in note.inReplyTo must point to an existing document
+* 400: 'note creation failed: document {id} does not belong to publication {id}' - the document id in note.inReplyTo must belong to the publication in note.context
 * 400: 'create note error: {message}' - generic error that occured on createNote. Refer to message for more details.
 * 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 

--- a/activityDoc.md
+++ b/activityDoc.md
@@ -276,7 +276,7 @@ Possible errors:
 * 400: 'create stack error: {message}' - generic error that occured on createTag. Refer to message for more details.
 * 400 'create activity error: {message}' - generic error that occured on createActivity. Refer to message for more details.
 
-### Asssign a Tag to a Publication
+### Assign a Tag to a Publication
 
 Example:
 

--- a/models/Note.js
+++ b/models/Note.js
@@ -119,7 +119,7 @@ class Note extends BaseModel {
   static async delete (shortId /*: string */) /*: Promise<any> */ {
     const noteId = translator.toUUID(shortId)
     let note = await Note.query().findById(noteId)
-    if (!note) return null
+    if (!note || note.deleted) return null
     note.deleted = new Date().toISOString()
     return await Note.query().updateAndFetchById(noteId, note)
   }
@@ -130,7 +130,7 @@ class Note extends BaseModel {
     const modifications = _.pick(object, ['content', 'oa:hasSelector'])
     let note = await Note.query().findById(noteId)
     if (!note) {
-      return undefined
+      return null
     }
     note.json = Object.assign(note.json, modifications)
     return await Note.query().updateAndFetchById(noteId, note)

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -160,7 +160,7 @@ class Publication extends BaseModel {
   static async delete (shortId /*: string */) /*: number */ {
     const publicationId = translator.toUUID(shortId)
     let publication = await Publication.query().findById(publicationId)
-    if (!publication) {
+    if (!publication || publication.deleted) {
       return null
     }
     publication.deleted = new Date().toISOString()

--- a/models/Publications_Tags.js
+++ b/models/Publications_Tags.js
@@ -1,6 +1,7 @@
 const { Model } = require('objection')
 const parseurl = require('url').parse
 const { Publication } = require('./Publication')
+const { Tag } = require('./Tag')
 
 class Publications_Tags extends Model {
   static get tableName () {
@@ -17,6 +18,9 @@ class Publications_Tags extends Model {
   ) /*: any */ {
     let publicationShortId = parseurl(publicationUrl).path.substr(13)
     const publication = await Publication.byShortId(publicationShortId)
+    if (!publication) return new Error('no publication')
+    const tag = await Tag.byId(tagId)
+    if (!tag) return new Error('no tag')
     // check if already exists
     const result = await Publications_Tags.query().where({
       publicationId: publication.id,
@@ -37,6 +41,9 @@ class Publications_Tags extends Model {
   ) /*: number */ {
     let publicationShortId = parseurl(publicationUrl).path.substr(13)
     const publication = await Publication.byShortId(publicationShortId)
+    if (!publication) return new Error('no publication')
+    const tag = await Tag.byId(tagId)
+    if (!tag) return new Error('no tag')
     return await Publications_Tags.query()
       .delete()
       .where({

--- a/models/Publications_Tags.js
+++ b/models/Publications_Tags.js
@@ -16,9 +16,14 @@ class Publications_Tags extends Model {
     publicationUrl /*: string */,
     tagId /*: number */
   ) /*: any */ {
+    // check publication
+    if (!publicationUrl) return new Error('no publication')
     let publicationShortId = parseurl(publicationUrl).path.substr(13)
     const publication = await Publication.byShortId(publicationShortId)
     if (!publication) return new Error('no publication')
+
+    // check tag
+    if (!tagId) return new Error('no tag')
     const tag = await Tag.byId(tagId)
     if (!tag) return new Error('no tag')
     // check if already exists
@@ -39,11 +44,17 @@ class Publications_Tags extends Model {
     publicationUrl /*: string */,
     tagId /*: string */
   ) /*: number */ {
+    // check publication
+    if (!publicationUrl) return new Error('no publication')
     let publicationShortId = parseurl(publicationUrl).path.substr(13)
     const publication = await Publication.byShortId(publicationShortId)
     if (!publication) return new Error('no publication')
+
+    // check tag
+    if (!tagId) return new Error('no tag')
     const tag = await Tag.byId(tagId)
     if (!tag) return new Error('no tag')
+
     return await Publications_Tags.query()
       .delete()
       .where({

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -4,6 +4,7 @@ const { Model } = require('objection')
 const short = require('short-uuid')
 const translator = short()
 const _ = require('lodash')
+const parseurl = require('url').parse
 
 const personAttrs = [
   'attachment',
@@ -124,6 +125,11 @@ class Reader extends BaseModel {
     reader /*: any */,
     document /*: any */
   ) /*: Promise<any> */ {
+    if (document.context) {
+      document.publicationId = translator.toUUID(
+        parseurl(document.context).path.substr(13)
+      )
+    }
     return reader.$relatedQuery('documents').insert(document)
   }
 

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -144,10 +144,14 @@ class Reader extends BaseModel {
     // check that document exists, publication exists and document belongs to publication
 
     const { Document } = require('./Document')
+
+    if (!note.inReplyTo) return new Error('no document')
     const document = await Document.byShortId(
       parseurl(note.inReplyTo).path.substr(10)
     )
     if (!document) return new Error('no document')
+
+    if (!note.context) return new Error('no publication')
     const publication = await Publication.byShortId(
       parseurl(note.context).path.substr(13)
     )

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -26,6 +26,10 @@ class Tag extends Model {
     tag.readerId = readerId
     return await Tag.query().insert(tag)
   }
+
+  static async byId (id /*: string */) /*: any */ {
+    return await Tag.query().findById(id)
+  }
 }
 
 module.exports = { Tag }

--- a/routes/activities/add.js
+++ b/routes/activities/add.js
@@ -10,16 +10,35 @@ const handleAdd = async (req, res, reader) => {
         body.target.id,
         body.object.id
       )
-      if (resultStack instanceof Error && resultStack.message === 'duplicate') {
-        res
-          .status(400)
-          .send(
-            `publication ${body.target.id} already asssociated with tag ${
-              body.object.id
-            } (${body.object.name})`
-          )
+      if (resultStack instanceof Error) {
+        switch (resultStack.message) {
+          case 'duplicate':
+            res
+              .status(400)
+              .send(
+                `publication ${body.target.id} already asssociated with tag ${
+                  body.object.id
+                } (${body.object.name})`
+              )
+            break
+
+          case 'no publication':
+            res
+              .status(404)
+              .send(`no publication found with id ${body.target.id}`)
+            break
+
+          case 'no tag':
+            res.status(404).send(`no tag found with id ${body.object.id}`)
+            break
+
+          default:
+            res.status(400).send(`add tag to publication error: ${err.message}`)
+            break
+        }
         break
       }
+
       const activityObjStack = createActivityObject(body, resultStack, reader)
       Activity.createActivity(activityObjStack)
         .then(activity => {
@@ -28,7 +47,7 @@ const handleAdd = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`add tag to publication error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -39,12 +39,14 @@ const handleCreate = async (req, res, reader) => {
               body.object.context
             }. Document must belong to an existing publication.`
           )
+        break
       }
       if (resultDoc instanceof Error || !resultDoc) {
         const message = resultDoc
           ? resultDoc.message
           : 'document creation failed'
         res.status(400).send(`create document error: ${message}`)
+        break
       }
       const activityObjDoc = createActivityObject(body, resultDoc, reader)
       Activity.createActivity(activityObjDoc)

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -8,6 +8,12 @@ const handleCreate = async (req, res, reader) => {
   switch (body.object.type) {
     case 'reader:Publication':
       const resultPub = await Reader.addPublication(reader, body.object)
+      if (resultPub instanceof Error || !resultPub) {
+        const message = resultPub
+          ? resultPub.message
+          : 'publication creation failed'
+        res.status(400).send(`create publication error: ${message}`)
+      }
       const activityObjPub = createActivityObject(body, resultPub, reader)
       Activity.createActivity(activityObjPub)
         .then(activity => {
@@ -16,12 +22,18 @@ const handleCreate = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`create publication error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 
     case 'Document':
       const resultDoc = await Reader.addDocument(reader, body.object)
+      if (resultDoc instanceof Error || !resultDoc) {
+        const message = resultDoc
+          ? resultDoc.message
+          : 'document creation failed'
+        res.status(400).send(`create document error: ${message}`)
+      }
       const activityObjDoc = createActivityObject(body, resultDoc, reader)
       Activity.createActivity(activityObjDoc)
         .then(activity => {
@@ -30,12 +42,16 @@ const handleCreate = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`create document error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 
     case 'Note':
       const resultNote = await Reader.addNote(reader, body.object)
+      if (resultNote instanceof Error || !resultNote) {
+        const message = resultNote ? resultNote.message : 'note creation failed'
+        res.status(400).send(`create note error: ${message}`)
+      }
       const activityObjNote = createActivityObject(body, resultNote, reader)
       Activity.createActivity(activityObjNote)
         .then(activity => {
@@ -44,12 +60,18 @@ const handleCreate = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`create note error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 
     case 'reader:Stack':
       const resultStack = await Tag.createTag(reader.id, body.object)
+      if (resultStack instanceof Error || !resultStack) {
+        const message = resultStack
+          ? resultStack.message
+          : 'stack creation failed'
+        res.status(400).send(`create stack error: ${message}`)
+      }
       const activityObjStack = createActivityObject(body, resultStack, reader)
       Activity.createActivity(activityObjStack)
         .then(activity => {
@@ -58,7 +80,7 @@ const handleCreate = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`create stack error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/delete.js
+++ b/routes/activities/delete.js
@@ -11,6 +11,22 @@ const handleDelete = async (req, res, reader) => {
       const returned = await Publication.delete(
         parseurl(body.object.id).path.substr(13)
       )
+      if (returned === null) {
+        res
+          .status(404)
+          .send(
+            `publication with id ${
+              body.object.id
+            } does not exist or has already been deleted`
+          )
+        break
+      } else if (returned instanceof Error || !returned) {
+        const message = returned
+          ? returned.message
+          : 'publication deletion failed'
+        res.status(400).send(`delete publication error: ${message}`)
+        break
+      }
       const activityObjPub = createActivityObject(body, returned, reader)
       Activity.createActivity(activityObjPub)
         .then(activity => {
@@ -19,7 +35,7 @@ const handleDelete = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`delete publication error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 
@@ -27,6 +43,20 @@ const handleDelete = async (req, res, reader) => {
       const resultNote = await Note.delete(
         parseurl(body.object.id).path.substr(6)
       )
+      if (resultNote === null) {
+        res
+          .status(404)
+          .send(
+            `note with id ${
+              body.object.id
+            } does not exist or has already been deleted`
+          )
+        break
+      } else if (resultNote instanceof Error || !resultNote) {
+        const message = resultNote ? resultNote.message : 'note deletion failed'
+        res.status(400).send(`delete note error: ${message}`)
+        break
+      }
       const activityObjNote = createActivityObject(body, resultNote, reader)
       Activity.createActivity(activityObjNote)
         .then(activity => {
@@ -35,7 +65,7 @@ const handleDelete = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`delete note error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/read.js
+++ b/routes/activities/read.js
@@ -12,6 +12,7 @@ const handleRead = async (req, res, reader) => {
       )
       if (!resultDoc) {
         res.status(404).send(`document with id ${body.object.id} not found`)
+        break
       }
       const activityObjStack = createActivityObject(body, resultDoc, reader)
       Activity.createActivity(activityObjStack)

--- a/routes/activities/read.js
+++ b/routes/activities/read.js
@@ -10,6 +10,9 @@ const handleRead = async (req, res, reader) => {
       const resultDoc = await Document.byShortId(
         parseurl(body.object.id).path.substr(10)
       )
+      if (!resultDoc) {
+        res.status(404).send(`document with id ${body.object.id} not found`)
+      }
       const activityObjStack = createActivityObject(body, resultDoc, reader)
       Activity.createActivity(activityObjStack)
         .then(activity => {
@@ -18,7 +21,7 @@ const handleRead = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`read error: ${err.message}`)
+          res.status(400).send(`create read activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/remove.js
+++ b/routes/activities/remove.js
@@ -10,6 +10,26 @@ const handleRemove = async (req, res, reader) => {
         body.target.id,
         body.object.id
       )
+      if (resultStack instanceof Error) {
+        switch (resultStack.message) {
+          case 'no publication':
+            res
+              .status(404)
+              .send(`no publication found with id ${body.target.id}`)
+            break
+
+          case 'no tag':
+            res.status(404).send(`no tag found with id ${body.object.id}`)
+            break
+
+          default:
+            res
+              .status(400)
+              .send(`remove tag from publication error: ${err.message}`)
+            break
+        }
+        break
+      }
       const activityObjStack = createActivityObject(body, resultStack, reader)
       Activity.createActivity(activityObjStack)
         .then(activity => {
@@ -18,9 +38,7 @@ const handleRemove = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res
-            .status(400)
-            .send(`remove tag from publication error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/update.js
+++ b/routes/activities/update.js
@@ -7,6 +7,7 @@ const handleUpdate = async (req, res, reader) => {
   switch (body.object.type) {
     case 'Note':
       const resultNote = await Note.update(body.object)
+      if (resultNote === null) { res.status(404).send(`no note found with id ${body.object.id}`) }
       const activityObjNote = createActivityObject(body, resultNote, reader)
       Activity.createActivity(activityObjNote)
         .then(activity => {
@@ -15,7 +16,7 @@ const handleUpdate = async (req, res, reader) => {
           res.end()
         })
         .catch(err => {
-          res.status(400).send(`update note error: ${err.message}`)
+          res.status(400).send(`create activity error: ${err.message}`)
         })
       break
 

--- a/routes/activities/update.js
+++ b/routes/activities/update.js
@@ -7,7 +7,10 @@ const handleUpdate = async (req, res, reader) => {
   switch (body.object.type) {
     case 'Note':
       const resultNote = await Note.update(body.object)
-      if (resultNote === null) { res.status(404).send(`no note found with id ${body.object.id}`) }
+      if (resultNote === null) {
+        res.status(404).send(`no note found with id ${body.object.id}`)
+        break
+      }
       const activityObjNote = createActivityObject(body, resultNote, reader)
       Activity.createActivity(activityObjNote)
         .then(activity => {

--- a/routes/outbox-post.js
+++ b/routes/outbox-post.js
@@ -114,7 +114,7 @@ module.exports = function (app) {
                   break
 
                 default:
-                  res.status(400).send(`action ${body.type} not reconized`)
+                  res.status(400).send(`action ${body.type} not recognized`)
               }
             }
             return handleActivity()

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -68,7 +68,6 @@ const test = async app => {
         }
       })
     )
-
   const activityUrl = resActivity.get('Location')
   const activityObject = await getActivityFromUrl(app, activityUrl, token)
   const publicationUrl = activityObject.object.id

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -85,6 +85,36 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
+  await tap.test(
+    'Try to create Document with invalid publication context',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'Document',
+              context: undefined,
+              name: 'Document A',
+              content: 'This is the content of document A.'
+            }
+          })
+        )
+      await tap.equal(res.status, 404)
+      await tap.ok(res.error.text.startsWith('no publication found for'))
+    }
+  )
+
   await tap.test('Get Document', async () => {
     const activityObject = await getActivityFromUrl(app, activityUrl, token)
     documentUrl = activityObject.object.id
@@ -191,6 +221,35 @@ const test = async app => {
     await tap.type(body, 'object')
     await tap.type(body.position, 'string')
     await tap.equal(body.position, '/html/body/p[2]/table/tr[2]/td[3]/span2')
+  })
+
+  await tap.test('Document Read activity for invalid document id', async () => {
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' },
+            { oa: 'http://www.w3.org/ns/oa#' }
+          ],
+          type: 'Read',
+          object: { type: 'Document', id: documentUrl + '123' },
+          context: publicationUrl,
+          'oa:hasSelector': {
+            type: 'XPathSelector',
+            value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+          }
+        })
+      )
+
+    await tap.equal(res.statusCode, 404)
+    await tap.ok(res.error.text.startsWith('document with id'))
   })
 
   await tap.test('Get Document that does not exist', async () => {

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -80,7 +80,6 @@ const test = async app => {
           }
         })
       )
-
     await tap.equal(res.status, 201)
     await tap.type(res.get('Location'), 'string')
     activityUrl = res.get('Location')

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -74,6 +74,7 @@ const test = async app => {
           type: 'Create',
           object: {
             type: 'Document',
+            context: publicationUrl,
             name: 'Document A',
             content: 'This is the content of document A.'
           }
@@ -105,6 +106,23 @@ const test = async app => {
     await tap.type(body['@context'], 'object')
     await tap.ok(Array.isArray(body['@context']))
   })
+
+  await tap.test(
+    'Publication context should now include the document',
+    async () => {
+      const res = await request(app)
+        .get(urlparse(publicationUrl).path)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+    }
+  )
 
   await tap.test('Document Read Activity', async () => {
     const res = await request(app)

--- a/tests/integration/note.test.js
+++ b/tests/integration/note.test.js
@@ -377,6 +377,55 @@ const test = async app => {
     await tap.equal(docres.body.replies.length, 0)
   })
 
+  await tap.test('Try to delete a Note that does not exist', async () => {
+    // already deleted
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Delete',
+          object: {
+            type: 'Note',
+            id: noteUrl
+          }
+        })
+      )
+
+    await tap.equal(res.statusCode, 404)
+
+    const res1 = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Delete',
+          object: {
+            type: 'Note',
+            id: noteUrl + '123'
+          }
+        })
+      )
+
+    await tap.equal(res1.statusCode, 404)
+  })
+
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }

--- a/tests/integration/note.test.js
+++ b/tests/integration/note.test.js
@@ -190,7 +190,7 @@ const test = async app => {
               type: 'Document',
               name: 'Document B',
               content: 'This is the content of document B.',
-              publicationId: publicationUrl
+              context: publicationUrl
             }
           })
         )

--- a/tests/integration/note.test.js
+++ b/tests/integration/note.test.js
@@ -97,6 +97,68 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
+  await tap.test(
+    'Try to create Note with invalid Publication context',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'Note',
+              content: 'This is the content of note A.',
+              'oa:hasSelector': {},
+              context: publicationUrl + '123',
+              inReplyTo: documentUrl
+            }
+          })
+        )
+
+      await tap.equal(res.status, 404)
+    }
+  )
+
+  await tap.test(
+    'Try to create Note with invalid inReplyTo Document',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'Note',
+              content: 'This is the content of note A.',
+              'oa:hasSelector': {},
+              context: publicationUrl,
+              inReplyTo: documentUrl + '123'
+            }
+          })
+        )
+
+      await tap.equal(res.status, 404)
+    }
+  )
+
   await tap.test('Get note', async () => {
     const activityObject = await getActivityFromUrl(app, activityUrl, token)
     noteUrl = activityObject.object.id
@@ -295,6 +357,31 @@ const test = async app => {
     await tap.type(body['oa:hasSelector'], 'object')
     await tap.type(body['@context'], 'object')
     await tap.ok(Array.isArray(body['@context']))
+  })
+
+  await tap.test('Try to update a Note that does not exist', async () => {
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Update',
+          object: {
+            type: 'Note',
+            id: noteUrl + 'abc',
+            content: 'new content!!'
+          }
+        })
+      )
+    await tap.equal(res.statusCode, 404)
   })
 
   await tap.test('Delete a Note', async () => {

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -44,7 +44,6 @@ const test = async app => {
                 name: 'Sample Author'
               }
             ],
-            totalItems: 2,
             attachment: [
               {
                 type: 'Document',

--- a/tests/integration/publication.test.js
+++ b/tests/integration/publication.test.js
@@ -245,6 +245,54 @@ const test = async app => {
     // await tap.equal(docres.statusCode, 404)
   })
 
+  await tap.test('delete publication that does not exist', async () => {
+    // already deleted
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Delete',
+          object: {
+            type: 'reader:Publication',
+            id: publicationUrl
+          }
+        })
+      )
+    await tap.equal(res.statusCode, 404)
+
+    // never existed
+    const res1 = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Delete',
+          object: {
+            type: 'reader:Publication',
+            id: publicationUrl + '123'
+          }
+        })
+      )
+    await tap.equal(res1.statusCode, 404)
+  })
+
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -118,7 +118,6 @@ const test = async app => {
           target: { id: publication.id }
         })
       )
-    console.log(res.error)
     await tap.equal(res.status, 204)
 
     const pubres = await request(app)

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -118,6 +118,7 @@ const test = async app => {
           target: { id: publication.id }
         })
       )
+    console.log(res.error)
     await tap.equal(res.status, 204)
 
     const pubres = await request(app)

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -136,6 +136,56 @@ const test = async app => {
     await tap.equal(body.tags[0].name, 'mystack')
   })
 
+  await tap.test(
+    'Try to assign publication to tag with invalid tag',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Add',
+            object: { id: undefined, type: stack.type },
+            target: { id: publication.id }
+          })
+        )
+      await tap.equal(res.status, 404)
+    }
+  )
+
+  await tap.test(
+    'Try to assign publication to tag with invalid publication',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Add',
+            object: { id: stack.id, type: stack.type },
+            target: { id: undefined }
+          })
+        )
+      await tap.equal(res.status, 404)
+    }
+  )
+
   await tap.test('remove tag from publication', async () => {
     const res = await request(app)
       .post(`${userUrl}/activity`)
@@ -171,6 +221,56 @@ const test = async app => {
     await tap.ok(Array.isArray(body.tags))
     await tap.equal(body.tags.length, 0)
   })
+
+  await tap.test(
+    'Try to remove a tag from a publication with invalid tag',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Remove',
+            object: { id: undefined, type: stack.type },
+            target: { id: publication.id }
+          })
+        )
+      await tap.equal(res.status, 404)
+    }
+  )
+
+  await tap.test(
+    'Try to remove a tag from a publication with invalid publication',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Remove',
+            object: { id: stack.id, type: stack.type },
+            target: { id: undefined }
+          })
+        )
+      await tap.equal(res.status, 404)
+    }
+  )
 
   await tap.test('Try to assign publication to tag twice', async () => {
     await request(app)

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -114,8 +114,8 @@ const test = async app => {
             { reader: 'https://rebus.foundation/ns/reader' }
           ],
           type: 'Add',
-          object: stack,
-          target: publication
+          object: { id: stack.id, type: stack.type },
+          target: { id: publication.id }
         })
       )
     await tap.equal(res.status, 204)

--- a/tests/integration/utils.js
+++ b/tests/integration/utils.js
@@ -37,7 +37,7 @@ const createUser = async (app, token) => {
 
 const destroyDB = async app => {
   if (!process.env.POSTGRE_INSTANCE && process.env.NODE_ENV === 'test') {
-    // await fs.unlinkSync('./test.sqlite3')
+    await fs.unlinkSync('./test.sqlite3')
   } else if (process.env.NODE_ENV === 'test') {
     await knexCleaner.clean(app.knex)
   }

--- a/tests/models/Document.test.js
+++ b/tests/models/Document.test.js
@@ -3,6 +3,8 @@ const { destroyDB } = require('../integration/utils')
 const { Reader } = require('../../models/Reader')
 const { Document } = require('../../models/Document')
 const parseurl = require('url').parse
+const short = require('short-uuid')
+const translator = short()
 
 const test = async app => {
   if (!process.env.POSTGRE_INSTANCE) {
@@ -37,8 +39,9 @@ const test = async app => {
     createdReader,
     publicationObject
   )
-  documentObject.publicationId = publication.id
 
+  let publicationShortId = translator.fromUUID(publication.id)
+  documentObject.context = `http://localhost:8080/publication-${publicationShortId}`
   let documentId
   let document
 

--- a/tests/models/Document.test.js
+++ b/tests/models/Document.test.js
@@ -54,6 +54,17 @@ const test = async app => {
     documentId = parseurl(response.url).path.substr(10)
   })
 
+  await tap.test(
+    'Try to create Document with no publication context',
+    async () => {
+      let badDocument = Object.assign(documentObject, { context: undefined })
+      const response = await Reader.addDocument(createdReader, badDocument)
+
+      await tap.ok(typeof response, Error)
+      await tap.equal(response.message, 'no publication')
+    }
+  )
+
   await tap.test('Get document by short id', async () => {
     document = await Document.byShortId(documentId)
     await tap.type(document, 'object')

--- a/tests/models/Note.test.js
+++ b/tests/models/Note.test.js
@@ -70,6 +70,28 @@ const test = async app => {
     noteUrl = response.url
   })
 
+  await tap.test(
+    'Try to Create Note with invalid inReplyTo Document',
+    async () => {
+      const badNote = Object.assign({}, noteObject, { inReplyTo: undefined })
+
+      let response = await Reader.addNote(createdReader, badNote)
+      await tap.ok(typeof response, Error)
+      await tap.equal(response.message, 'no document')
+    }
+  )
+
+  await tap.test(
+    'Try to Create Note with invalid Publication context',
+    async () => {
+      const badNote = Object.assign({}, noteObject, { context: undefined })
+
+      let response = await Reader.addNote(createdReader, badNote)
+      await tap.ok(typeof response, Error)
+      await tap.equal(response.message, 'no publication')
+    }
+  )
+
   await tap.test('Get note by short id', async () => {
     note = await Note.byShortId(noteId)
     await tap.type(note, 'object')
@@ -91,15 +113,23 @@ const test = async app => {
     await tap.ok(res.deleted)
   })
 
-  await tap.test('Delete Note that does not exist', async () => {
+  await tap.test('Try to delete a note that does not exist', async () => {
     const res = await Note.delete('123')
-    await tap.notOk(res)
+    await tap.equal(res, null)
   })
 
   await tap.test('Update Note', async () => {
     const res = await Note.update({ id: noteUrl, content: 'new content' })
     await tap.ok(res)
     await tap.equal(res.json.content, 'new content')
+  })
+
+  await tap.test('Try to update a note that does not exist', async () => {
+    const res = await Note.update({
+      id: noteUrl + '123',
+      content: 'new content'
+    })
+    await tap.equal(res, null)
   })
 
   if (!process.env.POSTGRE_INSTANCE) {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -77,12 +77,49 @@ const test = async app => {
     await tap.equal(res.tagId, createdTag.id)
   })
 
+  await tap.test('addTagToPub with invalid tag id ', async () => {
+    const res = await Publications_Tags.addTagToPub(
+      publication.url,
+      createdTag.id + '123'
+    )
+
+    await tap.ok(typeof res, Error)
+    await tap.equal(res.message, 'no tag')
+  })
+
+  await tap.test('addTagToPub with invalid publication id ', async () => {
+    const res = await Publications_Tags.addTagToPub(undefined, createdTag.id)
+
+    await tap.ok(typeof res, Error)
+    await tap.equal(res.message, 'no publication')
+  })
+
   await tap.test('Publication remove tag', async () => {
     const res = await Publications_Tags.removeTagFromPub(
       publication.url,
       createdTag.id
     )
     await tap.equal(res, 1)
+  })
+
+  await tap.test('removeTagFromPub with invalid tag id ', async () => {
+    const res = await Publications_Tags.removeTagFromPub(
+      publication.url,
+      createdTag.id + '123'
+    )
+
+    await tap.ok(typeof res, Error)
+    await tap.equal(res.message, 'no tag')
+  })
+
+  await tap.test('removeTagFromPub with invalid publication id ', async () => {
+    const res = await Publications_Tags.removeTagFromPub(
+      undefined,
+      createdTag.id
+    )
+
+    await tap.ok(typeof res, Error)
+    await tap.equal(res.message, 'no publication')
   })
 
   await tap.test('Try to assign same tag twice', async () => {

--- a/tests/unit/post-outbox-route-add.test.js
+++ b/tests/unit/post-outbox-route-add.test.js
@@ -196,6 +196,55 @@ const test = async () => {
     await tap.equal(res.statusCode, 400)
     await tap.ok(addTagToPubSpy.calledOnce)
   })
+
+  await tap.test('Add publication to stack that does not exist', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    Publication_TagsStub.Publications_Tags.addTagToPub = async () =>
+      Promise.resolve(new Error('no tag'))
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    checkReaderStub.returns(true)
+
+    const addTagToPubSpy = sinon.spy(
+      Publication_TagsStub.Publications_Tags,
+      'addTagToPub'
+    )
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(addPubToStackRequest))
+    await tap.equal(res.statusCode, 404)
+    await tap.ok(res.error.text.startsWith('no tag found with id'))
+    await tap.ok(addTagToPubSpy.calledOnce)
+  })
+
+  await tap.test('Add publication that does not exist to a stack', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    Publication_TagsStub.Publications_Tags.addTagToPub = async () =>
+      Promise.resolve(new Error('no publication'))
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    checkReaderStub.returns(true)
+
+    const addTagToPubSpy = sinon.spy(
+      Publication_TagsStub.Publications_Tags,
+      'addTagToPub'
+    )
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(addPubToStackRequest))
+
+    await tap.equal(res.statusCode, 404)
+    await tap.ok(res.error.text.startsWith('no publication found with id'))
+    await tap.ok(addTagToPubSpy.calledOnce)
+  })
 }
 
 test()

--- a/tests/unit/post-outbox-route-add.test.js
+++ b/tests/unit/post-outbox-route-add.test.js
@@ -198,7 +198,6 @@ const test = async () => {
   })
 
   await tap.test('Add publication to stack that does not exist', async () => {
-    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
     Publication_TagsStub.Publications_Tags.addTagToPub = async () =>
       Promise.resolve(new Error('no tag'))
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
@@ -222,7 +221,6 @@ const test = async () => {
   })
 
   await tap.test('Add publication that does not exist to a stack', async () => {
-    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
     Publication_TagsStub.Publications_Tags.addTagToPub = async () =>
       Promise.resolve(new Error('no publication'))
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)

--- a/tests/unit/post-outbox-route-create.test.js
+++ b/tests/unit/post-outbox-route-create.test.js
@@ -280,8 +280,6 @@ const test = async () => {
   await tap.test(
     'Try to create document with no (or invalid) publication context',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.addDocument = async () =>
         Promise.resolve(new Error('no publication'))
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
@@ -328,8 +326,6 @@ const test = async () => {
   await tap.test(
     'Try to create a note with no (or invalid) publication context',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.addNote = async () =>
         Promise.resolve(new Error('no publication'))
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
@@ -358,8 +354,6 @@ const test = async () => {
   await tap.test(
     'Try to create a note with no (or invalid) document inReplyTo',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.addNote = async () =>
         Promise.resolve(new Error('no document'))
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
@@ -388,8 +382,6 @@ const test = async () => {
   await tap.test(
     'Try to create a note where the inReplyTo document does not belong to the context publication',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.addNote = async () =>
         Promise.resolve(new Error('wrong publication'))
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)

--- a/tests/unit/post-outbox-route-delete.test.js
+++ b/tests/unit/post-outbox-route-delete.test.js
@@ -166,8 +166,6 @@ const test = async () => {
   await tap.test(
     'Try to delete a publication that does not exist',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
       PublicationStub.Publication.delete = async () => Promise.resolve(null)
       checkReaderStub.returns(true)
@@ -202,7 +200,6 @@ const test = async () => {
   })
 
   await tap.test('Try to delete a note that does not exist', async () => {
-    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
     NoteStub.Note.delete = async () => Promise.resolve(null)
     checkReaderStub.returns(true)

--- a/tests/unit/post-outbox-route-delete.test.js
+++ b/tests/unit/post-outbox-route-delete.test.js
@@ -145,7 +145,7 @@ const test = async () => {
   outboxRoute(app)
   const request = supertest(app)
 
-  await tap.test('Detele a publication', async () => {
+  await tap.test('Delete a publication', async () => {
     ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
 
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
@@ -163,7 +163,28 @@ const test = async () => {
     await tap.equal(res.statusCode, 204)
   })
 
-  await tap.test('Detele a note', async () => {
+  await tap.test(
+    'Try to delete a publication that does not exist',
+    async () => {
+      ActivityStub.Activity.createActivity = async () =>
+        Promise.resolve(activity)
+      ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+      PublicationStub.Publication.delete = async () => Promise.resolve(null)
+      checkReaderStub.returns(true)
+
+      const res = await request
+        .post('/reader-123/activity')
+        .set('Host', 'reader-api.test')
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(JSON.stringify(deletePublicationRequest))
+
+      await tap.equal(res.statusCode, 404)
+    }
+  )
+
+  await tap.test('Delete a note', async () => {
     ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
     NoteStub.Note.delete = async () => Promise.resolve(1)
@@ -178,6 +199,23 @@ const test = async () => {
       .send(JSON.stringify(deleteNoteRequest))
 
     await tap.equal(res.statusCode, 204)
+  })
+
+  await tap.test('Try to delete a note that does not exist', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    NoteStub.Note.delete = async () => Promise.resolve(null)
+    checkReaderStub.returns(true)
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(deleteNoteRequest))
+
+    await tap.equal(res.statusCode, 404)
   })
 }
 

--- a/tests/unit/post-outbox-route-read.test.js
+++ b/tests/unit/post-outbox-route-read.test.js
@@ -176,6 +176,27 @@ const test = async () => {
     await tap.equal(res.statusCode, 201)
     await tap.ok(createActivitySpy.calledOnce)
   })
+
+  await tap.test(
+    'Read activity on a document that does not exist',
+    async () => {
+      ActivityStub.Activity.createActivity = async () =>
+        Promise.resolve(activity)
+      ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+      DocumentStub.Document.byShortId = async () => Promise.resolve(null)
+      checkReaderStub.returns(true)
+
+      const res = await request
+        .post('/reader-123/activity')
+        .set('Host', 'reader-api.test')
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(JSON.stringify(readActivityRequest))
+
+      await tap.equal(res.statusCode, 404)
+    }
+  )
 }
 
 test()

--- a/tests/unit/post-outbox-route-read.test.js
+++ b/tests/unit/post-outbox-route-read.test.js
@@ -180,8 +180,6 @@ const test = async () => {
   await tap.test(
     'Read activity on a document that does not exist',
     async () => {
-      ActivityStub.Activity.createActivity = async () =>
-        Promise.resolve(activity)
       ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
       DocumentStub.Document.byShortId = async () => Promise.resolve(null)
       checkReaderStub.returns(true)

--- a/tests/unit/post-outbox-route-update.test.js
+++ b/tests/unit/post-outbox-route-update.test.js
@@ -145,13 +145,11 @@ const test = async () => {
   })
 
   await tap.test('Try to update a note that does not exist', async () => {
-    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
     NoteStub.Note.update = async () => Promise.resolve(null)
     ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
     checkReaderStub.returns(true)
 
     const updateSpy = sinon.spy(NoteStub.Note, 'update')
-    const createActivitySpy = sinon.spy(ActivityStub.Activity, 'createActivity')
 
     const res = await request
       .post('/reader-123/activity')

--- a/tests/unit/post-outbox-route-update.test.js
+++ b/tests/unit/post-outbox-route-update.test.js
@@ -143,6 +143,28 @@ const test = async () => {
     await tap.ok(updateSpy.calledOnce)
     await tap.ok(createActivitySpy.calledOnce)
   })
+
+  await tap.test('Try to update a note that does not exist', async () => {
+    ActivityStub.Activity.createActivity = async () => Promise.resolve(activity)
+    NoteStub.Note.update = async () => Promise.resolve(null)
+    ReaderStub.Reader.byShortId = async () => Promise.resolve(reader)
+    checkReaderStub.returns(true)
+
+    const updateSpy = sinon.spy(NoteStub.Note, 'update')
+    const createActivitySpy = sinon.spy(ActivityStub.Activity, 'createActivity')
+
+    const res = await request
+      .post('/reader-123/activity')
+      .set('Host', 'reader-api.test')
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(JSON.stringify(updateNoteRequest))
+
+    await tap.equal(res.statusCode, 404)
+    await tap.ok(res.error.text.startsWith('no note found with id'))
+    await tap.ok(updateSpy.calledOnce)
+  })
 }
 
 test()


### PR DESCRIPTION
So swagger is doing a good job of documenting single-purpose endpoints, but with our POST /outbox endpoint handling so many different activities, it wasn't really clear. 

As a supplement to the swagger doc, I have created a simple .md file 
Later, I might want to use postman to document the example (which would have the added benefit of being testable, so we would know that the examples do work) but that seems complicated and it does repeat a lot of what swagger already does. 

By doing the documentation, I did notice that it wasn't really clear how creating a document for a publication worked. It was working if you specified the publicationId (the actual id that is in the database) but I fixed it so that using `context: publicationUrl` now works. Which makes more sense. (publicationId still works, but officially the requirement is context)

I also noticed that there are problem with error handling. I will fix that and document it in the same md file. I will also create a link to the activity documentation on the readme and documentation pages. 