### PR TITLE
Filter library

### DIFF
--- a/models/Tag.js
+++ b/models/Tag.js
@@ -24,6 +24,13 @@ class Tag extends Model {
     tag /*: {type: string, name: string, readerId: ?string} */
   ) /*: any */ {
     tag.readerId = readerId
+    // reject duplicates
+    const existing = await Tag.query().where({
+      readerId: tag.readerId,
+      type: tag.type,
+      name: tag.name
+    })
+    if (existing.length > 0) return new Error('duplicate')
     return await Tag.query().insert(tag)
   }
 

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -119,6 +119,11 @@ const handleCreate = async (req, res, reader) => {
 
     case 'reader:Stack':
       const resultStack = await Tag.createTag(reader.id, body.object)
+      if (resultStack instanceof Error && resultStack.message === 'duplicate') {
+        res
+          .status(400)
+          .send(`duplicate error: stack ${body.object.name} already exists`)
+      }
       if (resultStack instanceof Error || !resultStack) {
         const message = resultStack
           ? resultStack.message

--- a/routes/activities/utils.js
+++ b/routes/activities/utils.js
@@ -8,8 +8,8 @@ const createActivityObject = (body, result, reader) => {
   if (result) {
     props = Object.assign(props, {
       object: {
-        type: result.json ? result.json.type : null,
-        id: result.url
+        type: result.json ? result.json.type : result.type,
+        id: result.url || result.id
       }
     })
   }

--- a/tests/integration/library.test.js
+++ b/tests/integration/library.test.js
@@ -113,6 +113,10 @@ const test = async () => {
     await tap.notOk(body.items[0].orderedItems)
   })
 
+  await tap.test('filter library by collection', async () => {
+    // add more publications
+  })
+
   await tap.test(
     'Try to get library for user that does not exist',
     async () => {

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -84,6 +84,31 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
+  await tap.test('Try to create a duplicate Tag', async () => {
+    const res = await request(app)
+      .post(`${userUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Create',
+          object: {
+            type: 'reader:Stack',
+            name: 'mystack'
+          }
+        })
+      )
+    await tap.equal(res.status, 400)
+    await tap.ok(res.error.text.startsWith('duplicate error:'))
+  })
+
   await tap.test('Get tag when fetching library', async () => {
     const res = await request(app)
       .get(`${userUrl}/library`)


### PR DESCRIPTION
I thought about filtering at the level of the database query,  but that is a little complicated since the query is for the reader. 

You can now request the library by adding `?stack=stackname` to the url. 

One small change: I have made it an error for a reader to create more than one stack with the same name. If we ever have other types of tags, the name can be reused for another type. 
In summary, when creating tags, the combination of readerId, name and type must be unique. 