### PR TITLE
Updating knexfile.js

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,12 +1,17 @@
 // Update with your config settings.
 
+const path = require('path')
 module.exports = {
   development: {
     client: 'sqlite3',
     connection: {
       filename: process.env.SQLITE_DB || './dev.sqlite3'
     },
-    useNullAsDefault: true
+    useNullAsDefault: true,
+    migrations: {
+      tableName: 'knex_migrations',
+      directory: path.join(__dirname, 'migrations')
+    }
   },
 
   test: {
@@ -29,7 +34,8 @@ module.exports = {
       max: 10
     },
     migrations: {
-      tableName: 'knex_migrations'
+      tableName: 'knex_migrations',
+      directory: path.join(__dirname, 'migrations')
     }
   }
 }


### PR DESCRIPTION
This makes knex.js find the migrations folder based on the relative path from the current module directory instead of the current working directory.

This makes the whole app more reusable as a module.

(As an experiment I'm testing using GitHub to edit and create pull requests for single file fixes. Let me know if it causes any weirdness. If this works nicely then it's an easy way to create pull requests for small, quick fixes.)