### PR TITLE
Making Publication#asRef return the full instance

### DIFF
--- a/models/Publication.js
+++ b/models/Publication.js
@@ -106,25 +106,8 @@ class Publication extends BaseModel {
     }
   }
 
-  asRef () /*: {
-    type: string,
-    id: string,
-    name: ?string,
-    attributedTo: {
-      type: string,
-      name: ?string
-    }
-  } */ {
-    const author = this.attributedTo || this.json.attributedTo || null
-    return {
-      type: 'reader:Publication',
-      id: this.url,
-      name: this.name || this.json.name || null,
-      attributedTo: {
-        type: 'Person',
-        name: author ? author.name : null
-      }
-    }
+  asRef () /*: any */ {
+    return this
   }
 
   static async byShortId (


### PR DESCRIPTION
There is no reason for Publication#asRef to exist as the bandwidth savings are nonexistent and it causes a lot of problems as per https://github.com/RebusFoundation/reader-api/issues/79

I made it just return `this` to begin with but long term the right thing to do is just not use asRef