### PR TITLE
Make sure Base Model doesn't strip tags from JSON

### DIFF
--- a/models/BaseModel.js
+++ b/models/BaseModel.js
@@ -135,6 +135,7 @@ class BaseModel extends guid(DbErrors(Model)) {
       published,
       updated,
       attachment,
+      tags,
       context = {},
       attributedTo = []
     } = original
@@ -143,6 +144,7 @@ class BaseModel extends guid(DbErrors(Model)) {
       id,
       published,
       updated,
+      tags,
       attachment,
       attributedTo
     })


### PR DESCRIPTION
Without this change Publication tags don't appear in the library stream.

I officially dislike the BaseModel.