### PR TITLE
added performance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test-integration": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic --cov tests/integration/index.js",
     "test-google": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic --cov tests/google-integration/index.js",
     "test-models": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -R classic --cov tests/models/index.js",
-    "test-performance": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic tests/performance/index.js",
+    "test-performance": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R min tests/performance/index.js",
     "test": "npm run test-unit && npm run test-integration && npm run test-models && npm run test-google",
     "start": "node index.js",
     "dev-server": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=http://localhost:8080 nodemon dev.js",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test-integration": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic --cov tests/integration/index.js",
     "test-google": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic --cov tests/google-integration/index.js",
     "test-models": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -R classic --cov tests/models/index.js",
+    "test-performance": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic tests/performance/index.js",
     "test": "npm run test-unit && npm run test-integration && npm run test-models && npm run test-google",
     "start": "node index.js",
     "dev-server": "SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=http://localhost:8080 nodemon dev.js",

--- a/tests/integration/library.test.js
+++ b/tests/integration/library.test.js
@@ -26,7 +26,6 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-
     await tap.equal(res.status, 200)
 
     const body = res.body
@@ -87,7 +86,6 @@ const test = async () => {
           }
         })
       )
-
     const res = await request(app)
       .get(`${userUrl}/library`)
       .set('Host', 'reader-api.test')
@@ -95,7 +93,6 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-
     await tap.equal(res.statusCode, 200)
 
     const body = res.body
@@ -253,7 +250,6 @@ const test = async () => {
       )
 
     // get library with filter for collection
-
     const res = await request(app)
       .get(`${userUrl}/library?stack=mystack`)
       .set('Host', 'reader-api.test')

--- a/tests/performance/createDocuments.test.js
+++ b/tests/performance/createDocuments.test.js
@@ -1,12 +1,7 @@
 const request = require('supertest')
 const tap = require('tap')
 const urlparse = require('url').parse
-const {
-  getToken,
-  createUser,
-  destroyDB,
-  getActivityFromUrl
-} = require('../integration/utils')
+const { getToken, createUser, destroyDB } = require('../integration/utils')
 const app = require('../../server').app
 
 const createPublication = require('./utils/createPublication')

--- a/tests/performance/createDocuments.test.js
+++ b/tests/performance/createDocuments.test.js
@@ -1,0 +1,63 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+const createDocument = require('./utils/createDocument')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await createPublication(token, userUrl, 10)
+
+  const res = await request(app)
+    .get(`${userUrl}/library`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+
+  const publicationUrl = res.body.items[0].id
+
+  await tap.test('Create 10 documents', async () => {
+    const testName = 'create 10 documents'
+    console.time(testName)
+    await createDocument(token, userUrl, publicationUrl, 10)
+    console.timeEnd(testName)
+  })
+
+  await tap.test('Create 100 documents', async () => {
+    const testName = 'create 100 documents'
+    console.time(testName)
+    await createDocument(token, userUrl, publicationUrl, 100)
+    console.timeEnd(testName)
+  })
+
+  await tap.test('Create 500 documents', async () => {
+    const testName = 'create 500 documents'
+    console.time(testName)
+    await createDocument(token, userUrl, publicationUrl, 500)
+    console.timeEnd(testName)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/createNotes.test.js
+++ b/tests/performance/createNotes.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+const createDocument = require('./utils/createDocument')
+const createNotes = require('./utils/createNotes')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await createPublication(token, userUrl, 10)
+
+  const res = await request(app)
+    .get(`${userUrl}/library`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+
+  const publicationUrl = res.body.items[0].id
+
+  const resPublication = await request(app)
+    .get(urlparse(publicationUrl).path)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+  const documentUrl = resPublication.body.orderedItems[0].id
+
+  await tap.test('Create 10 notes', async () => {
+    const testName = 'create 10 notes'
+    console.time(testName)
+    await createNotes(token, userUrl, publicationUrl, documentUrl, 10)
+    console.timeEnd(testName)
+  })
+
+  await tap.test('Create 100 notes', async () => {
+    const testName = 'create 100 notes'
+    console.time(testName)
+    await createNotes(token, userUrl, publicationUrl, documentUrl, 100)
+    console.timeEnd(testName)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/createNotes.test.js
+++ b/tests/performance/createNotes.test.js
@@ -1,16 +1,10 @@
 const request = require('supertest')
 const tap = require('tap')
 const urlparse = require('url').parse
-const {
-  getToken,
-  createUser,
-  destroyDB,
-  getActivityFromUrl
-} = require('../integration/utils')
+const { getToken, createUser, destroyDB } = require('../integration/utils')
 const app = require('../../server').app
 
 const createPublication = require('./utils/createPublication')
-const createDocument = require('./utils/createDocument')
 const createNotes = require('./utils/createNotes')
 
 const test = async () => {

--- a/tests/performance/createPublications.test.js
+++ b/tests/performance/createPublications.test.js
@@ -1,0 +1,43 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await tap.test('Create 10 publications', async () => {
+    const testName = 'create 10 publications'
+    console.time(testName)
+    await createPublication(token, userUrl, 10)
+    console.timeEnd(testName)
+  })
+
+  await tap.test('Create 100 publications', async () => {
+    const testName = 'create 100 publications'
+    console.time(testName)
+    await createPublication(token, userUrl, 100)
+    console.timeEnd(testName)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/createTags.test.js
+++ b/tests/performance/createTags.test.js
@@ -3,7 +3,7 @@ const urlparse = require('url').parse
 const { getToken, createUser, destroyDB } = require('../integration/utils')
 const app = require('../../server').app
 
-const createPublication = require('./utils/createPublication')
+const createTags = require('./utils/createTags')
 
 const test = async () => {
   if (!process.env.POSTGRE_INSTANCE) {
@@ -14,17 +14,10 @@ const test = async () => {
   const userId = await createUser(app, token)
   const userUrl = urlparse(userId).path
 
-  await tap.test('Create 10 publications', async () => {
-    const testName = 'create 10 publications'
+  await tap.test('Create 10 tags', async () => {
+    const testName = 'create 10 tags'
     console.time(testName)
-    await createPublication(token, userUrl, 10)
-    console.timeEnd(testName)
-  })
-
-  await tap.test('Create 100 publications', async () => {
-    const testName = 'create 100 publications'
-    console.time(testName)
-    await createPublication(token, userUrl, 100)
+    await createTags(token, userUrl, 10)
     console.timeEnd(testName)
   })
 

--- a/tests/performance/getDocumentWithNotes.test.js
+++ b/tests/performance/getDocumentWithNotes.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+const createDocument = require('./utils/createDocument')
+const createNotes = require('./utils/createNotes')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await createPublication(token, userUrl, 10)
+
+  const res = await request(app)
+    .get(`${userUrl}/library`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+
+  const publicationUrl = res.body.items[0].id
+
+  const resPublication = await request(app)
+    .get(urlparse(publicationUrl).path)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+  const documentUrl = resPublication.body.orderedItems[0].id
+
+  await createNotes(token, userUrl, publicationUrl, documentUrl, 100)
+
+  await tap.test('Get document with 100 notes', async () => {
+    const testName = 'get document with 100 notes'
+
+    console.time(testName)
+    await request(app)
+      .get(urlparse(publicationUrl).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+  })
+
+  await tap.test('Get document with 1000 notes', async () => {
+    const testName = 'get document with 1000 notes'
+    await createNotes(token, userUrl, publicationUrl, documentUrl, 900)
+    console.time(testName)
+    await request(app)
+      .get(urlparse(publicationUrl).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/getUserProfile.test.js
+++ b/tests/performance/getUserProfile.test.js
@@ -1,0 +1,44 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await tap.test('whoami route', async () => {
+    const testName = 'whoami route'
+    await createPublication(token, userUrl, 100)
+
+    console.time(testName)
+    const res = await request(app)
+      .get('/whoami')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/getUserProfile.test.js
+++ b/tests/performance/getUserProfile.test.js
@@ -1,12 +1,7 @@
 const request = require('supertest')
 const tap = require('tap')
 const urlparse = require('url').parse
-const {
-  getToken,
-  createUser,
-  destroyDB,
-  getActivityFromUrl
-} = require('../integration/utils')
+const { getToken, createUser, destroyDB } = require('../integration/utils')
 const app = require('../../server').app
 
 const createPublication = require('./utils/createPublication')
@@ -25,7 +20,7 @@ const test = async () => {
     await createPublication(token, userUrl, 100)
 
     console.time(testName)
-    const res = await request(app)
+    await request(app)
       .get('/whoami')
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -4,6 +4,8 @@ const userProfileTests = require('./getUserProfile.test')
 const createDocumentTests = require('./createDocuments.test')
 const createNotesTests = require('./createNotes.test')
 const getDocumentWithNotesTests = require('./getDocumentWithNotes.test')
+const createTagsTests = require('./createTags.test')
+const addPubToCollectionTests = require('./addPubToCollection.test')
 
 const app = require('../../server').app
 
@@ -24,6 +26,8 @@ const allTests = async () => {
   await createDocumentTests(app)
   await createNotesTests(app)
   await getDocumentWithNotesTests(app)
+  await createTagsTests(app)
+  await addPubToCollectionTests(app)
 
   if (process.env.POSTGRE_INSTANCE) {
     await app.knex.migrate.rollback()

--- a/tests/performance/index.js
+++ b/tests/performance/index.js
@@ -1,0 +1,34 @@
+const libraryTests = require('./library.test')
+const createPublicationTests = require('./createPublications.test')
+const userProfileTests = require('./getUserProfile.test')
+const createDocumentTests = require('./createDocuments.test')
+const createNotesTests = require('./createNotes.test')
+const getDocumentWithNotesTests = require('./getDocumentWithNotes.test')
+
+const app = require('../../server').app
+
+require('dotenv').config()
+
+const allTests = async () => {
+  if (process.env.POSTGRE_INSTANCE) {
+    await app.initialize(true)
+    await app.knex.migrate.rollback()
+    if (process.env.POSTGRE_DB === 'travis_ci_test') {
+      await app.knex.migrate.latest()
+    }
+  }
+
+  await libraryTests(app)
+  await userProfileTests(app)
+  await createPublicationTests(app)
+  await createDocumentTests(app)
+  await createNotesTests(app)
+  await getDocumentWithNotesTests(app)
+
+  if (process.env.POSTGRE_INSTANCE) {
+    await app.knex.migrate.rollback()
+    await app.terminate()
+  }
+}
+
+allTests()

--- a/tests/performance/library.test.js
+++ b/tests/performance/library.test.js
@@ -1,0 +1,95 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  getActivityFromUrl
+} = require('../integration/utils')
+const app = require('../../server').app
+
+const createPublication = require('./utils/createPublication')
+
+const test = async () => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const token = getToken()
+  const userId = await createUser(app, token)
+  const userUrl = urlparse(userId).path
+
+  await tap.test('Get library with 10 publications', async () => {
+    const testName = 'get library with 10 publications'
+    await createPublication(token, userUrl, 10)
+
+    console.time(testName)
+    const res = await request(app)
+      .get(`${userUrl}/library`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.totalItems, 'number')
+    await tap.equal(body.totalItems, 10)
+  })
+
+  await tap.test('Get library with 100 publications', async () => {
+    const testName = 'get library with 100 publications'
+    await createPublication(token, userUrl, 90) // adding to the 10 already there
+
+    console.time(testName)
+    const res = await request(app)
+      .get(`${userUrl}/library`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.totalItems, 'number')
+    await tap.equal(body.totalItems, 100)
+  })
+
+  await tap.test('Get library with 500 publications', async () => {
+    const testName = 'get library with 500 publications'
+    await createPublication(token, userUrl, 400) // adding to the 100 already there
+
+    console.time(testName)
+    const res = await request(app)
+      .get(`${userUrl}/library`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    console.timeEnd(testName)
+
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.totalItems, 'number')
+    await tap.equal(body.totalItems, 500)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/performance/library.test.js
+++ b/tests/performance/library.test.js
@@ -1,12 +1,7 @@
 const request = require('supertest')
 const tap = require('tap')
 const urlparse = require('url').parse
-const {
-  getToken,
-  createUser,
-  destroyDB,
-  getActivityFromUrl
-} = require('../integration/utils')
+const { getToken, createUser, destroyDB } = require('../integration/utils')
 const app = require('../../server').app
 
 const createPublication = require('./utils/createPublication')

--- a/tests/performance/utils/createDocument.js
+++ b/tests/performance/utils/createDocument.js
@@ -1,0 +1,37 @@
+const request = require('supertest')
+const app = require('../../../server').app
+
+const createDocument = async (token, userUrl, publicationUrl, number = 1) => {
+  let promises = []
+
+  for (let i = 0; i < number; i++) {
+    promises.push(
+      request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'Document',
+              context: publicationUrl,
+              name: 'Document A',
+              content: 'This is the content of document A.'
+            }
+          })
+        )
+    )
+  }
+
+  await Promise.all(promises)
+}
+
+module.exports = createDocument

--- a/tests/performance/utils/createNotes.js
+++ b/tests/performance/utils/createNotes.js
@@ -1,0 +1,45 @@
+const request = require('supertest')
+const app = require('../../../server').app
+
+const createNotes = async (
+  token,
+  userUrl,
+  publicationUrl,
+  documentUrl,
+  number = 1
+) => {
+  let promises = []
+
+  for (let i = 0; i < number; i++) {
+    promises.push(
+      request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'Note',
+              content:
+                'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce id felis dui. Ut dictum mauris nulla, ornare feugiat mi facilisis id. Vestibulum non volutpat ante. Etiam eget egestas velit. Duis eget porta leo, vitae varius sem. In fringilla cursus orci, id semper dui imperdiet sit amet. Nulla eget mi non eros pretium faucibus vel sed est. Curabitur aliquet nisl risus, at tempus turpis dictum maximus. Proin tincidunt non lacus nec pulvinar. Duis vulputate metus diam. Donec efficitur orci turpis. Cras tristique eros sed massa efficitur, gravida malesuada turpis egestas. Mauris venenatis ut orci in pharetra.',
+              'oa:hasSelector': {},
+              context: publicationUrl,
+              inReplyTo: documentUrl
+            }
+          })
+        )
+    )
+  }
+
+  await Promise.all(promises)
+}
+
+module.exports = createNotes

--- a/tests/performance/utils/createPublication.js
+++ b/tests/performance/utils/createPublication.js
@@ -1,0 +1,103 @@
+const request = require('supertest')
+const app = require('../../../server').app
+
+const createPublication = async (token, userUrl, number = 1) => {
+  let promises = []
+
+  for (let i = 0; i < number; i++) {
+    promises.push(
+      request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'reader:Publication',
+              name: 'Publication A',
+              attributedTo: [
+                {
+                  type: 'Person',
+                  name: 'Sample Author'
+                }
+              ],
+              totalItems: 3,
+              attachment: [
+                {
+                  type: 'Document',
+                  name: 'Chapter 2',
+                  position: 1
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 0
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 2
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 3
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 4
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 5
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 6
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 7
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 8
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 9
+                },
+                {
+                  type: 'Document',
+                  name: 'Chapter 1',
+                  position: 10
+                },
+                {
+                  type: 'Document',
+                  name: 'Not a Chapter'
+                }
+              ]
+            }
+          })
+        )
+    )
+  }
+
+  await Promise.all(promises)
+}
+
+module.exports = createPublication

--- a/tests/performance/utils/createTags.js
+++ b/tests/performance/utils/createTags.js
@@ -1,0 +1,36 @@
+const request = require('supertest')
+const app = require('../../../server').app
+const crypto = require('crypto')
+
+const createTags = async (token, userUrl, number = 1) => {
+  let promises = []
+
+  for (let i = 0; i < number; i++) {
+    promises.push(
+      request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Create',
+            object: {
+              type: 'reader:Stack',
+              name: crypto.randomBytes(8).toString('hex')
+            }
+          })
+        )
+    )
+  }
+
+  await Promise.all(promises)
+}
+
+module.exports = createTags


### PR DESCRIPTION
There might be a better way to test for performance, but this can be useful to quickly test for problems. 
It is not complete, but it should be easy to add more tests or modify the existing ones as needed. 

Right now the test just logs times to the console. So it doesn't really indicate if the performance has changed since last time... but if we have doubt about any new changes, we can always do a before/after comparison. As long as we remember to test before. 

Some tests might be less than useful (who is going to create 100 notes at once?) but once the setup was done, adding more tests was really easy. :slightly_smiling_face: 
Eventually we can look into doing proper load tests on the api.