### PR TITLE
Simplify assign collection

### DIFF
--- a/migrations/20190204095340_document.js
+++ b/migrations/20190204095340_document.js
@@ -17,7 +17,7 @@ exports.up = function (knex, Promise) {
       .uuid('publicationId')
       .references('id')
       .inTable('Publication')
-      .nullable()
+      .notNullable()
       .onDelete('CASCADE')
       .index()
     table

--- a/migrations/20190204095340_document.js
+++ b/migrations/20190204095340_document.js
@@ -17,7 +17,8 @@ exports.up = function (knex, Promise) {
       .uuid('publicationId')
       .references('id')
       .inTable('Publication')
-      .notNullable()
+      .nullable()
+     // .notNullable() TODO: migrate
       .onDelete('CASCADE')
       .index()
     table

--- a/migrations/20190204095447_note.js
+++ b/migrations/20190204095447_note.js
@@ -14,13 +14,15 @@ exports.up = function (knex, Promise) {
       .uuid('documentId')
       .references('id')
       .inTable('Document')
-      .notNullable()
+      .nullable()
+      //.notNullable() TODO: migrate
       .index()
     table
       .uuid('publicationId')
       .references('id')
       .inTable('Publication')
-      .notNullable()
+      .nullable()
+      //.notNullable() TODO: migrate
       .index()
     table
       .timestamp('published')

--- a/migrations/20190204095447_note.js
+++ b/migrations/20190204095447_note.js
@@ -14,13 +14,13 @@ exports.up = function (knex, Promise) {
       .uuid('documentId')
       .references('id')
       .inTable('Document')
-      .nullable()
+      .notNullable()
       .index()
     table
       .uuid('publicationId')
       .references('id')
       .inTable('Publication')
-      .nullable()
+      .notNullable()
       .index()
     table
       .timestamp('published')

--- a/migrations/20190204100210_publications_tags.js
+++ b/migrations/20190204100210_publications_tags.js
@@ -4,9 +4,9 @@ exports.up = function(knex, Promise) {
     table.increments('id')
     table
       .uuid('publicationId')
-      .notNullable()
       .references('id')
       .inTable('Publication')
+      .notNullable()
       .onDelete('CASCADE')
       .index()
     table.integer('tagId').references('id').inTable('Tag').notNullable().onDelete('CASCADE').index();

--- a/models/Note.js
+++ b/models/Note.js
@@ -127,9 +127,13 @@ class Note extends BaseModel {
   static async update (object /*: any */) /*: Promise<any> */ {
     // $FlowFixMe
     const noteId = urlToId(object.id)
-    const modifications = _.pick(object, ['content', 'summary', 'oa:hasSelector'])
+    const modifications = _.pick(object, [
+      'content',
+      'summary',
+      'oa:hasSelector'
+    ])
     let note = await Note.query().findById(noteId)
-    if (!note) {
+    if (!note || note.deleted) {
       return null
     }
     note.json = Object.assign(note.json, modifications)

--- a/models/Note.js
+++ b/models/Note.js
@@ -133,7 +133,7 @@ class Note extends BaseModel {
       'oa:hasSelector'
     ])
     let note = await Note.query().findById(noteId)
-    if (!note || note.deleted) {
+    if (!note) {
       return null
     }
     note.json = Object.assign(note.json, modifications)

--- a/models/Publications_Tags.js
+++ b/models/Publications_Tags.js
@@ -1,7 +1,7 @@
 const { Model } = require('objection')
 const { Publication } = require('./Publication')
 const { Tag } = require('./Tag')
-const { urlToShortId } = require('../routes/utils')
+const { urlToShortId, urlToId } = require('../routes/utils')
 
 class Publications_Tags extends Model {
   static get tableName () {
@@ -18,49 +18,57 @@ class Publications_Tags extends Model {
   ) /*: any */ {
     // check publication
     if (!publicationUrl) return new Error('no publication')
-    let publicationShortId = urlToShortId(publicationUrl)
-    const publication = await Publication.byShortId(publicationShortId)
-    if (!publication) return new Error('no publication')
+    const publicationId = await urlToId(publicationUrl)
 
     // check tag
     if (!tagId) return new Error('no tag')
-    const tag = await Tag.byId(tagId)
-    if (!tag) return new Error('no tag')
-    // check if already exists
-    const result = await Publications_Tags.query().where({
-      publicationId: publication.id,
-      tagId
-    })
-    if (result.length > 0) {
-      return new Error('duplicate')
+
+    // // check if already exists - SKIPPED FOR NOW
+    // const result = await Publications_Tags.query().where({
+    //   publicationId: publication.id,
+    //   tagId
+    // })
+    // if (result.length > 0) {
+    //   return new Error('duplicate')
+
+    try {
+      return await Publications_Tags.query().insert({
+        publicationId: publicationId,
+        tagId
+      })
+    } catch (err) {
+      if (err.constraint === 'publications_tags_tagid_foreign') {
+        return new Error('no tag')
+      } else if (err.constraint === 'publications_tags_publicationid_foreign') {
+        return new Error('no publication')
+      }
     }
-    return await Publications_Tags.query().insert({
-      publicationId: publication.id,
-      tagId
-    })
   }
 
   static async removeTagFromPub (
     publicationUrl /*: string */,
     tagId /*: string */
   ) /*: number */ {
+    const publicationId = await urlToId(publicationUrl)
+
     // check publication
     if (!publicationUrl) return new Error('no publication')
-    let publicationShortId = urlToShortId(publicationUrl)
-    const publication = await Publication.byShortId(publicationShortId)
-    if (!publication) return new Error('no publication')
 
     // check tag
     if (!tagId) return new Error('no tag')
-    const tag = await Tag.byId(tagId)
-    if (!tag) return new Error('no tag')
 
-    return await Publications_Tags.query()
+    const result = await Publications_Tags.query()
       .delete()
       .where({
-        publicationId: publication.id,
+        publicationId: publicationId,
         tagId
       })
+
+    if (result === 0) {
+      return new Error('not found')
+    } else {
+      return result
+    }
   }
 }
 

--- a/models/Publications_Tags.js
+++ b/models/Publications_Tags.js
@@ -1,7 +1,5 @@
 const { Model } = require('objection')
-const { Publication } = require('./Publication')
-const { Tag } = require('./Tag')
-const { urlToShortId, urlToId } = require('../routes/utils')
+const { urlToId } = require('../routes/utils')
 
 class Publications_Tags extends Model {
   static get tableName () {
@@ -49,10 +47,10 @@ class Publications_Tags extends Model {
     publicationUrl /*: string */,
     tagId /*: string */
   ) /*: number */ {
-    const publicationId = await urlToId(publicationUrl)
-
     // check publication
     if (!publicationUrl) return new Error('no publication')
+
+    const publicationId = await urlToId(publicationUrl)
 
     // check tag
     if (!tagId) return new Error('no tag')

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -5,7 +5,7 @@ const short = require('short-uuid')
 const translator = short()
 const _ = require('lodash')
 const { Publication } = require('./Publication')
-const { urlToId, urlToShortId } = require('../routes/utils')
+const { urlToId } = require('../routes/utils')
 
 const personAttrs = [
   'attachment',

--- a/routes/activities/remove.js
+++ b/routes/activities/remove.js
@@ -13,13 +13,21 @@ const handleRemove = async (req, res, reader) => {
       if (resultStack instanceof Error) {
         switch (resultStack.message) {
           case 'no publication':
-            res
-              .status(404)
-              .send(`no publication found with id ${body.target.id}`)
+            res.status(404).send(`no publication provided`)
             break
 
           case 'no tag':
-            res.status(404).send(`no tag found with id ${body.object.id}`)
+            res.status(404).send(`no tag provided`)
+            break
+
+          case 'not found':
+            res
+              .status(404)
+              .send(
+                `no relationship found between tag ${
+                  body.object.id
+                } and publication ${body.target.id}`
+              )
             break
 
           default:

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -85,35 +85,36 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
-  await tap.test(
-    'Try to create Document with invalid publication context',
-    async () => {
-      const res = await request(app)
-        .post(`${userUrl}/activity`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-        .send(
-          JSON.stringify({
-            '@context': [
-              'https://www.w3.org/ns/activitystreams',
-              { reader: 'https://rebus.foundation/ns/reader' }
-            ],
-            type: 'Create',
-            object: {
-              type: 'Document',
-              context: 'notanid',
-              name: 'Document A',
-              content: 'This is the content of document A.'
-            }
-          })
-        )
-      await tap.equal(res.status, 404)
-      await tap.ok(res.error.text.startsWith('no publication found for'))
-    }
-  )
+  // TODO: migrate
+  // await tap.test(
+  //   'Try to create Document with invalid publication context',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`${userUrl}/activity`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token}`)
+  //       .type(
+  //         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //       )
+  //       .send(
+  //         JSON.stringify({
+  //           '@context': [
+  //             'https://www.w3.org/ns/activitystreams',
+  //             { reader: 'https://rebus.foundation/ns/reader' }
+  //           ],
+  //           type: 'Create',
+  //           object: {
+  //             type: 'Document',
+  //             context: 'notanid',
+  //             name: 'Document A',
+  //             content: 'This is the content of document A.'
+  //           }
+  //         })
+  //       )
+  //     await tap.equal(res.status, 404)
+  //     await tap.ok(res.error.text.startsWith('no publication found for'))
+  //   }
+  // )
 
   await tap.test('Get Document', async () => {
     const activityObject = await getActivityFromUrl(app, activityUrl, token)

--- a/tests/integration/document.test.js
+++ b/tests/integration/document.test.js
@@ -104,7 +104,7 @@ const test = async app => {
             type: 'Create',
             object: {
               type: 'Document',
-              context: undefined,
+              context: 'notanid',
               name: 'Document A',
               content: 'This is the content of document A.'
             }

--- a/tests/integration/note.test.js
+++ b/tests/integration/note.test.js
@@ -97,67 +97,69 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
-  await tap.test(
-    'Try to create Note with invalid Publication context',
-    async () => {
-      const res = await request(app)
-        .post(`${userUrl}/activity`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-        .send(
-          JSON.stringify({
-            '@context': [
-              'https://www.w3.org/ns/activitystreams',
-              { reader: 'https://rebus.foundation/ns/reader' }
-            ],
-            type: 'Create',
-            object: {
-              type: 'Note',
-              content: 'This is the content of note A.',
-              'oa:hasSelector': {},
-              context: publicationUrl + '123',
-              inReplyTo: documentUrl
-            }
-          })
-        )
+  // TODO: migrate
+  // await tap.test(
+  //   'Try to create Note with invalid Publication context',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`${userUrl}/activity`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token}`)
+  //       .type(
+  //         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //       )
+  //       .send(
+  //         JSON.stringify({
+  //           '@context': [
+  //             'https://www.w3.org/ns/activitystreams',
+  //             { reader: 'https://rebus.foundation/ns/reader' }
+  //           ],
+  //           type: 'Create',
+  //           object: {
+  //             type: 'Note',
+  //             content: 'This is the content of note A.',
+  //             'oa:hasSelector': {},
+  //             context: publicationUrl + '123',
+  //             inReplyTo: documentUrl
+  //           }
+  //         })
+  //       )
 
-      await tap.equal(res.status, 404)
-    }
-  )
+  //     await tap.equal(res.status, 404)
+  //   }
+  // )
 
-  await tap.test(
-    'Try to create Note with invalid inReplyTo Document',
-    async () => {
-      const res = await request(app)
-        .post(`${userUrl}/activity`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-        .send(
-          JSON.stringify({
-            '@context': [
-              'https://www.w3.org/ns/activitystreams',
-              { reader: 'https://rebus.foundation/ns/reader' }
-            ],
-            type: 'Create',
-            object: {
-              type: 'Note',
-              content: 'This is the content of note A.',
-              'oa:hasSelector': {},
-              context: publicationUrl,
-              inReplyTo: documentUrl + '123'
-            }
-          })
-        )
+  // TODO: migrate
+  // await tap.test(
+  //   'Try to create Note with invalid inReplyTo Document',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`${userUrl}/activity`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token}`)
+  //       .type(
+  //         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //       )
+  //       .send(
+  //         JSON.stringify({
+  //           '@context': [
+  //             'https://www.w3.org/ns/activitystreams',
+  //             { reader: 'https://rebus.foundation/ns/reader' }
+  //           ],
+  //           type: 'Create',
+  //           object: {
+  //             type: 'Note',
+  //             content: 'This is the content of note A.',
+  //             'oa:hasSelector': {},
+  //             context: publicationUrl,
+  //             inReplyTo: documentUrl + '123'
+  //           }
+  //         })
+  //       )
 
-      await tap.equal(res.status, 404)
-    }
-  )
+  //     await tap.equal(res.status, 404)
+  //   }
+  // )
 
   await tap.test('Get note', async () => {
     const activityObject = await getActivityFromUrl(app, activityUrl, token)

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -84,30 +84,30 @@ const test = async app => {
     activityUrl = res.get('Location')
   })
 
-  await tap.test('Try to create a duplicate Tag', async () => {
-    const res = await request(app)
-      .post(`${userUrl}/activity`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
-      .send(
-        JSON.stringify({
-          '@context': [
-            'https://www.w3.org/ns/activitystreams',
-            { reader: 'https://rebus.foundation/ns/reader' }
-          ],
-          type: 'Create',
-          object: {
-            type: 'reader:Stack',
-            name: 'mystack'
-          }
-        })
-      )
-    await tap.equal(res.status, 400)
-    await tap.ok(res.error.text.startsWith('duplicate error:'))
-  })
+  // await tap.test('Try to create a duplicate Tag', async () => {
+  //   const res = await request(app)
+  //     .post(`${userUrl}/activity`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type(
+  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //     )
+  //     .send(
+  //       JSON.stringify({
+  //         '@context': [
+  //           'https://www.w3.org/ns/activitystreams',
+  //           { reader: 'https://rebus.foundation/ns/reader' }
+  //         ],
+  //         type: 'Create',
+  //         object: {
+  //           type: 'reader:Stack',
+  //           name: 'mystack'
+  //         }
+  //       })
+  //     )
+  //   await tap.equal(res.status, 400)
+  //   await tap.ok(res.error.text.startsWith('duplicate error:'))
+  // })
 
   await tap.test('Get tag when fetching library', async () => {
     const res = await request(app)
@@ -178,7 +178,7 @@ const test = async app => {
               { reader: 'https://rebus.foundation/ns/reader' }
             ],
             type: 'Add',
-            object: { id: undefined, type: stack.type },
+            object: { id: 999, type: stack.type },
             target: { id: publication.id }
           })
         )
@@ -204,7 +204,7 @@ const test = async app => {
             ],
             type: 'Add',
             object: { id: stack.id, type: stack.type },
-            target: { id: undefined }
+            target: { id: 'notanid' }
           })
         )
       await tap.equal(res.status, 404)
@@ -212,6 +212,19 @@ const test = async app => {
   )
 
   await tap.test('remove tag from publication', async () => {
+    const pubresbefore = await request(app)
+      .get(urlparse(publication.id).path)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(pubresbefore.status, 200)
+    const bodybefore = pubresbefore.body
+    await tap.ok(Array.isArray(bodybefore.tags))
+    await tap.equal(bodybefore.tags.length, 1)
+
     const res = await request(app)
       .post(`${userUrl}/activity`)
       .set('Host', 'reader-api.test')
@@ -264,7 +277,7 @@ const test = async app => {
               { reader: 'https://rebus.foundation/ns/reader' }
             ],
             type: 'Remove',
-            object: { id: undefined, type: stack.type },
+            object: { id: 12345, type: stack.type },
             target: { id: publication.id }
           })
         )
@@ -272,92 +285,94 @@ const test = async app => {
     }
   )
 
-  await tap.test(
-    'Try to remove a tag from a publication with invalid publication',
-    async () => {
-      const res = await request(app)
-        .post(`${userUrl}/activity`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-        .send(
-          JSON.stringify({
-            '@context': [
-              'https://www.w3.org/ns/activitystreams',
-              { reader: 'https://rebus.foundation/ns/reader' }
-            ],
-            type: 'Remove',
-            object: { id: stack.id, type: stack.type },
-            target: { id: undefined }
-          })
-        )
-      await tap.equal(res.status, 404)
-    }
-  )
+  // await tap.test(
+  //   'Try to remove a tag from a publication with invalid publication',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`${userUrl}/activity`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token}`)
+  //       .type(
+  //         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //       )
+  //       .send(
+  //         JSON.stringify({
+  //           '@context': [
+  //             'https://www.w3.org/ns/activitystreams',
+  //             { reader: 'https://rebus.foundation/ns/reader' }
+  //           ],
+  //           type: 'Remove',
+  //           object: { id: stack.id, type: stack.type },
+  //           target: { id: 'notanid' }
+  //         })
+  //       )
+  //     await tap.equal(res.status, 404)
+  //   }
+  // )
 
-  await tap.test('Try to assign publication to tag twice', async () => {
-    await request(app)
-      .post(`${userUrl}/activity`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
-      .send(
-        JSON.stringify({
-          '@context': [
-            'https://www.w3.org/ns/activitystreams',
-            { reader: 'https://rebus.foundation/ns/reader' }
-          ],
-          type: 'Add',
-          object: stack,
-          target: publication
-        })
-      )
+  // error disabled for now
 
-    const res = await request(app)
-      .post(`${userUrl}/activity`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
-      .send(
-        JSON.stringify({
-          '@context': [
-            'https://www.w3.org/ns/activitystreams',
-            { reader: 'https://rebus.foundation/ns/reader' }
-          ],
-          type: 'Add',
-          object: stack,
-          target: publication
-        })
-      )
-    await tap.equal(res.status, 400)
+  // await tap.test('Try to assign publication to tag twice', async () => {
+  //   await request(app)
+  //     .post(`${userUrl}/activity`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type(
+  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //     )
+  //     .send(
+  //       JSON.stringify({
+  //         '@context': [
+  //           'https://www.w3.org/ns/activitystreams',
+  //           { reader: 'https://rebus.foundation/ns/reader' }
+  //         ],
+  //         type: 'Add',
+  //         object: stack,
+  //         target: publication
+  //       })
+  //     )
 
-    // doesn't affect the publication
-    const pubres = await request(app)
-      .get(urlparse(publication.id).path)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
+  //   const res = await request(app)
+  //     .post(`${userUrl}/activity`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type(
+  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //     )
+  //     .send(
+  //       JSON.stringify({
+  //         '@context': [
+  //           'https://www.w3.org/ns/activitystreams',
+  //           { reader: 'https://rebus.foundation/ns/reader' }
+  //         ],
+  //         type: 'Add',
+  //         object: stack,
+  //         target: publication
+  //       })
+  //     )
+  //   await tap.equal(res.status, 400)
 
-    await tap.equal(pubres.status, 200)
-    const body = pubres.body
-    await tap.ok(Array.isArray(body.tags))
-    await tap.equal(body.tags.length, 1)
-    await tap.equal(body.tags[0].type, 'reader:Stack')
-    await tap.equal(body.tags[0].name, 'mystack')
-  })
+  //   // doesn't affect the publication
+  //   const pubres = await request(app)
+  //     .get(urlparse(publication.id).path)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type(
+  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+  //     )
+
+  //   await tap.equal(pubres.status, 200)
+  //   const body = pubres.body
+  //   await tap.ok(Array.isArray(body.tags))
+  //   await tap.equal(body.tags.length, 1)
+  //   await tap.equal(body.tags[0].type, 'reader:Stack')
+  //   await tap.equal(body.tags[0].name, 'mystack')
+  // })
 
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }
-  await destroyDB(app)
+  // await destroyDB(app)
 }
 
 module.exports = test

--- a/tests/integration/tag.test.js
+++ b/tests/integration/tag.test.js
@@ -285,30 +285,30 @@ const test = async app => {
     }
   )
 
-  // await tap.test(
-  //   'Try to remove a tag from a publication with invalid publication',
-  //   async () => {
-  //     const res = await request(app)
-  //       .post(`${userUrl}/activity`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token}`)
-  //       .type(
-  //         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-  //       )
-  //       .send(
-  //         JSON.stringify({
-  //           '@context': [
-  //             'https://www.w3.org/ns/activitystreams',
-  //             { reader: 'https://rebus.foundation/ns/reader' }
-  //           ],
-  //           type: 'Remove',
-  //           object: { id: stack.id, type: stack.type },
-  //           target: { id: 'notanid' }
-  //         })
-  //       )
-  //     await tap.equal(res.status, 404)
-  //   }
-  // )
+  await tap.test(
+    'Try to remove a tag from a publication with invalid publication',
+    async () => {
+      const res = await request(app)
+        .post(`${userUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Remove',
+            object: { id: stack.id, type: stack.type },
+            target: { id: 'notanid' }
+          })
+        )
+      await tap.equal(res.status, 404)
+    }
+  )
 
   // error disabled for now
 
@@ -372,7 +372,7 @@ const test = async app => {
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }
-  // await destroyDB(app)
+  await destroyDB(app)
 }
 
 module.exports = test

--- a/tests/models/Note.test.js
+++ b/tests/models/Note.test.js
@@ -70,27 +70,29 @@ const test = async app => {
     noteUrl = response.url
   })
 
-  await tap.test(
-    'Try to Create Note with invalid inReplyTo Document',
-    async () => {
-      const badNote = Object.assign({}, noteObject, { inReplyTo: undefined })
+  // TODO: migrate
+  // await tap.test(
+  //   'Try to Create Note with invalid inReplyTo Document',
+  //   async () => {
+  //     const badNote = Object.assign({}, noteObject, { inReplyTo: undefined })
 
-      let response = await Reader.addNote(createdReader, badNote)
-      await tap.ok(typeof response, Error)
-      await tap.equal(response.message, 'no document')
-    }
-  )
+  //     let response = await Reader.addNote(createdReader, badNote)
+  //     await tap.ok(typeof response, Error)
+  //     await tap.equal(response.message, 'no document')
+  //   }
+  // )
 
-  await tap.test(
-    'Try to Create Note with invalid Publication context',
-    async () => {
-      const badNote = Object.assign({}, noteObject, { context: undefined })
+  // TODO: migrate
+  // await tap.test(
+  //   'Try to Create Note with invalid Publication context',
+  //   async () => {
+  //     const badNote = Object.assign({}, noteObject, { context: undefined })
 
-      let response = await Reader.addNote(createdReader, badNote)
-      await tap.ok(typeof response, Error)
-      await tap.equal(response.message, 'no publication')
-    }
-  )
+  //     let response = await Reader.addNote(createdReader, badNote)
+  //     await tap.ok(typeof response, Error)
+  //     await tap.equal(response.message, 'no publication')
+  //   }
+  // )
 
   await tap.test('Get note by short id', async () => {
     note = await Note.byShortId(noteId)

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -109,7 +109,7 @@ const test = async app => {
     )
 
     await tap.ok(typeof res, Error)
-    await tap.equal(res.message, 'no tag')
+    await tap.equal(res.message, 'not found')
   })
 
   await tap.test('removeTagFromPub with invalid publication id ', async () => {
@@ -122,16 +122,16 @@ const test = async app => {
     await tap.equal(res.message, 'no publication')
   })
 
-  await tap.test('Try to assign same tag twice', async () => {
-    await Publications_Tags.addTagToPub(publication.url, createdTag.id)
+  // await tap.test('Try to assign same tag twice', async () => {
+  //   await Publications_Tags.addTagToPub(publication.url, createdTag.id)
 
-    const res = await Publications_Tags.addTagToPub(
-      publication.url,
-      createdTag.id
-    )
+  //   const res = await Publications_Tags.addTagToPub(
+  //     publication.url,
+  //     createdTag.id
+  //   )
 
-    await tap.equal(res.message, 'duplicate')
-  })
+  //   await tap.equal(res.message, 'duplicate')
+  // })
 
   await tap.test('Delete publication', async () => {
     const res = await Publication.delete(publicationId)

--- a/tests/unit/post-outbox-route-remove.test.js
+++ b/tests/unit/post-outbox-route-remove.test.js
@@ -189,7 +189,7 @@ const test = async () => {
         .send(JSON.stringify(removeTagFromStackRequest))
 
       await tap.equal(res.statusCode, 404)
-      await tap.ok(res.error.text.startsWith('no publication found with id'))
+      await tap.ok(res.error.text.startsWith('no publication'))
       await tap.ok(removeTagFromPubSpy.calledOnce)
     }
   )
@@ -216,7 +216,7 @@ const test = async () => {
         .send(JSON.stringify(removeTagFromStackRequest))
 
       await tap.equal(res.statusCode, 404)
-      await tap.ok(res.error.text.startsWith('no tag found with id'))
+      await tap.ok(res.error.text.startsWith('no tag'))
       await tap.ok(removeTagFromPubSpy.calledOnce)
     }
   )


### PR DESCRIPTION
This should improve the performance for:
- assigning a tag to a publication
- removing a tag from a publication
- creating notes
- creating documents
The goal here was to reduce back-and-forth communication between the api and the database. 

it removes checks for:
- creating notes for document that does not exist*
- creating notes for publication that does not exist*
- creating document for publication that does not exist*
- creating notes where the document and publication do not match**
- creating duplicate associations between tags and documents
(* will be reintroduced when we migrate the database)
(** might be able to reintroduce that one. Will also necessitate migration of database)

it maintains checks for:
- assigning a tag to a publication that does not exist
- assigning a tag that does not exist to a publication
- removing a tag-publication association that does not exist.