### PR TITLE
Update attribution model

### DIFF
--- a/migrations/20190409161233_attribution.js
+++ b/migrations/20190409161233_attribution.js
@@ -1,6 +1,6 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('Attribution', function (table) {
-    table.uuid('id').primary()
+    table.string('id').primary()
     table.string('role').notNullable().index()
     table
       .boolean('isContributor')

--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -2,21 +2,11 @@
 'use strict'
 const Model = require('objection').Model
 const { BaseModel } = require('./BaseModel.js')
+const _ = require('lodash')
 
-/**
- * @property {Document} document - returns the document, if any, that this Person has contributed to.
- * @property {Publication} publication - returns the publication, if any, that this Person has contributed to.
- *
- * This type models all of the creators and contributors that a publication can have.
- *
- * Because of how messy contributor and creator metadata tends to be, these are structured to be specific to the publication (and possibly document) they are found in. To find all publications by an author you need to query for all Attribution objects with the 'name' criteria you have in mind and use eager queries to get the publications and documents that are attributed to them.console. (To speed this up in the future we'll have to add an index for the JSON in Postgresql. [Example from the Objection documentation site.](https://vincit.github.io/objection.js/#indexing-postgresql-jsonb-columns))
- *
- * You should then further group those results based on whichever additional metadata you have such as ORCID and other specific IDs, which would be found as a secondary Link object in the `url` property of the original Activity Streams JSON object using the `canonical` rel value.
- *
- * That url is surfaced in the model as `canonicalId` which should be an ORCID, if available.
- *
- * The `role` property is derived from `schema:` metadata properties on the publication JSON file itself.
- */
+// TODO: add more valid roles
+const attributionRoles = ['author', 'editor']
+
 class Attribution extends BaseModel {
   static get tableName () /*: string */ {
     return 'Attribution'
@@ -28,39 +18,31 @@ class Attribution extends BaseModel {
     return {
       type: 'object',
       properties: {
-        id: { type: 'string', format: 'uuid', maxLength: 255 },
-        readerId: { type: 'string', format: 'uuid', maxLength: 255 },
-        canonicalId: { type: ['string', 'null'], format: 'url' },
+        id: { type: 'string' },
+        role: { type: 'string' },
+        name: { type: 'string ' },
+        normalizedName: { type: 'string' },
+        type: { type: 'string' },
+        readerId: { type: 'string' },
         isContributor: { type: 'boolean' },
-        role: { type: ['string', 'null'] },
-        json: {
-          type: 'object',
-          properties: {
-            type: { type: 'string' },
-            name: { type: 'string' }
-          },
-          additionalProperties: true
-        },
-        updated: { type: 'string', format: 'date-time' },
+        publicationId: { type: 'string' },
         published: { type: 'string', format: 'date-time' }
       },
       additionalProperties: true,
-      required: ['json']
+      required: [
+        'role',
+        'name',
+        'normalizedName',
+        'readerId',
+        'publicationId',
+        'published'
+      ]
     }
   }
   static get relationMappings () /*: any */ {
     const { Publication } = require('./Publication.js')
-    const { Document } = require('./Document.js')
     const { Reader } = require('./Reader')
     return {
-      document: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: Document,
-        join: {
-          from: 'Attribution.documentId',
-          to: 'Document.id'
-        }
-      },
       reader: {
         relation: Model.BelongsToOneRelation,
         modelClass: Reader,
@@ -79,6 +61,62 @@ class Attribution extends BaseModel {
       }
     }
   }
+
+  /*
+  Note: attribution parameter can be either a string (the name of the person) or an object with name, type and isContributor properties (isContributor is optional. Defaults to false)
+  If the attribution is a string, type defaults to 'Person'
+  If attribution is an object, type can be either 'Person' or 'Organization'
+  */
+  static async createAttribution (
+    attribution /*: any */,
+    role /*: string */,
+    publication /*: any */
+  ) {
+    if (_.indexOf(attributionRoles, role.toLowerCase()) === -1) {
+      throw Error(`${role} is not a valid attribution role`)
+    }
+
+    let props
+
+    if (_.isString(attribution)) {
+      props = {
+        name: attribution,
+        type: 'Person',
+        published: undefined,
+        publicationId: undefined,
+        readerId: undefined,
+        normalizedName: undefined,
+        role: undefined
+      }
+    } else {
+      if (
+        attribution.type !== 'Person' &&
+        attribution.type !== 'Organization'
+      ) {
+        throw Error(
+          `${
+            attribution.type
+          } is not a valid attribution type. Only 'Person' and 'Organization' are accepted.`
+        )
+      }
+      props = _.pick(attribution, ['name', 'type', 'isContributor'])
+    }
+
+    const time = new Date().toISOString()
+    props.role = role
+    props.normalizedName = props.name.toLowerCase() // todo: remove accents, etc.
+    props.readerId = publication.readerId
+    props.publicationId = publication.id
+    props.published = time
+
+    return await Attribution.query(Attribution.knex()).insertAndFetch(props)
+  }
+
+  static async byId (id /*: string */) /*: Promise<any> */ {
+    return await Attribution.query().findById(id)
+  }
+
+  // TODO: delete by publicationIdb
 }
 
 module.exports = { Attribution }

--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -83,10 +83,10 @@ class Attribution extends BaseModel {
         name: attribution,
         type: 'Person',
         published: undefined,
-        publicationId: undefined,
-        readerId: undefined,
+        publicationId: publication.id,
+        readerId: publication.readerId,
         normalizedName: undefined,
-        role: undefined
+        role: role
       }
     } else {
       if (
@@ -100,13 +100,13 @@ class Attribution extends BaseModel {
         )
       }
       props = _.pick(attribution, ['name', 'type', 'isContributor'])
+      props.role = role
+      props.readerId = publication.readerId
+      props.publicationId = publication.id
     }
 
     const time = new Date().toISOString()
-    props.role = role
     props.normalizedName = props.name.toLowerCase() // todo: remove accents, etc.
-    props.readerId = publication.readerId
-    props.publicationId = publication.id
     props.published = time
 
     return await Attribution.query(Attribution.knex()).insertAndFetch(props)

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -151,26 +151,26 @@ class Publication extends BaseModel {
     // create attributions
     if (publication.author) {
       createdPublication.author = []
-      publication.author.forEach(async author => {
+      for (const author of publication.author) {
         const createdAuthor = await Attribution.createAttribution(
           author,
           'author',
           createdPublication
         )
         createdPublication.author.push(createdAuthor)
-      })
+      }
     }
 
     if (publication.editor) {
       createdPublication.editor = []
-      publication.editor.forEach(async editor => {
+      for (const editor of publication.editor) {
         const createdEditor = await Attribution.createAttribution(
           editor,
           'editor',
           createdPublication
         )
         createdPublication.editor.push(createdEditor)
-      })
+      }
     }
 
     return createdPublication
@@ -194,6 +194,8 @@ class Publication extends BaseModel {
     if (pub.links) pub.links = pub.links.data
     if (pub.resources) pub.resources = pub.resources.data
 
+    // TODO: missing authors and editors
+    // Need a way to retrieve attribution by pubId and role
     return pub
   }
 

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -151,7 +151,7 @@ class Publication extends BaseModel {
     // if (publication.author) {
     //   createdPublication.author = []
     //   publication.author.forEach(async (author) => {
-    //     const createdAuthor = await Attribution.createAttribution(author, 'author')
+    //     const createdAuthor = await Attribution.createAttribution(author, 'author', createdPublication.id)
     //     createdPublication.author.push(createdAuthor)
     //   })
     // }

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -5,6 +5,7 @@ const short = require('short-uuid')
 const translator = short()
 const _ = require('lodash')
 const { Activity } = require('./Activity')
+const { Attribution } = require('./Attribution')
 
 const metadataProps = ['inLanguage', 'keywords']
 
@@ -147,22 +148,30 @@ class Publication extends BaseModel {
     const createdPublication = await Publication.query(
       Publication.knex()
     ).insertAndFetch(props)
-    // // create attributions
-    // if (publication.author) {
-    //   createdPublication.author = []
-    //   publication.author.forEach(async (author) => {
-    //     const createdAuthor = await Attribution.createAttribution(author, 'author', createdPublication.id)
-    //     createdPublication.author.push(createdAuthor)
-    //   })
-    // }
+    // create attributions
+    if (publication.author) {
+      createdPublication.author = []
+      publication.author.forEach(async author => {
+        const createdAuthor = await Attribution.createAttribution(
+          author,
+          'author',
+          createdPublication
+        )
+        createdPublication.author.push(createdAuthor)
+      })
+    }
 
-    // if (publication.editor) {
-    //   createdPublication.editor = []
-    //   publication.editor.forEach(async (editor) => {
-    //     const createdEditor = await Attribution.createAttribution(editor, 'editor')
-    //     createdPublication.editor.push(createdEditor)
-    //   })
-    // }
+    if (publication.editor) {
+      createdPublication.editor = []
+      publication.editor.forEach(async editor => {
+        const createdEditor = await Attribution.createAttribution(
+          editor,
+          'editor',
+          createdPublication
+        )
+        createdPublication.editor.push(createdEditor)
+      })
+    }
 
     return createdPublication
   }

--- a/tests/models/Attribution.test.js
+++ b/tests/models/Attribution.test.js
@@ -1,0 +1,131 @@
+const tap = require('tap')
+const { destroyDB } = require('../integration/utils')
+const { Reader } = require('../../models/Reader')
+const { Publication } = require('../../models/Publication')
+const { Attribution } = require('../../models/Attribution')
+const { Publications_Tags } = require('../../models/Publications_Tags')
+const { Document } = require('../../models/Document')
+const { urlToShortId } = require('../../routes/utils')
+
+const test = async app => {
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.initialize()
+  }
+
+  const reader = {
+    name: 'J. Random Reader'
+  }
+
+  const createdReader = await Reader.createReader(
+    'auth0|foo1545149538931',
+    reader
+  )
+
+  const simplePublication = {
+    type: 'reader:Publication',
+    name: 'Publication A',
+    readingOrder: [
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'Link',
+        href: 'http://example.org/abc',
+        hreflang: 'en',
+        mediaType: 'text/html',
+        name: 'An example link'
+      },
+      {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        type: 'Link',
+        href: 'http://example.org/abc2',
+        hreflang: 'en',
+        mediaType: 'text/html',
+        name: 'An example link2'
+      }
+    ]
+  }
+
+  const publication = await Publication.createPublication(
+    createdReader,
+    simplePublication
+  )
+
+  const attributionObject = {
+    name: 'Seymour Butts',
+    type: 'Person',
+    isContributor: true
+  }
+
+  const attributionString = 'Jane Doe'
+
+  const invalidAttributionObject = {
+    name: 'Seymour Butts',
+    type: 'Robot'
+  }
+
+  let createdAttribution
+
+  await tap.test('Create Attribution', async () => {
+    let response = await Attribution.createAttribution(
+      attributionObject,
+      'author',
+      publication
+    )
+    await tap.ok(response)
+    await tap.ok(response instanceof Attribution)
+    await tap.equal(response.readerId, createdReader.id)
+    createdAttribution = response
+  })
+
+  await tap.test('Create Attribution with string', async () => {
+    let response = await Attribution.createAttribution(
+      attributionString,
+      'editor',
+      publication
+    )
+    await tap.ok(response)
+    await tap.ok(response instanceof Attribution)
+    await tap.equal(response.type, 'Person')
+    await tap.equal(response.readerId, createdReader.id)
+  })
+
+  await tap.test('Create Attribution with invalid role', async () => {
+    try {
+      await Attribution.createAttribution(
+        attributionObject,
+        'authooor',
+        publication
+      )
+    } catch (err) {
+      await tap.equal(err.message, 'authooor is not a valid attribution role')
+    }
+  })
+
+  await tap.test('Create Attribution with invalid type', async () => {
+    try {
+      await Attribution.createAttribution(
+        invalidAttributionObject,
+        'author',
+        publication
+      )
+    } catch (err) {
+      await tap.equal(
+        err.message,
+        "Robot is not a valid attribution type. Only 'Person' and 'Organization' are accepted."
+      )
+    }
+  })
+
+  await tap.test('Get attribution by Id', async () => {
+    let response = await Attribution.byId(createdAttribution.id)
+
+    await tap.ok(response)
+    await tap.ok(response instanceof Attribution)
+  })
+
+  if (!process.env.POSTGRE_INSTANCE) {
+    await app.terminate()
+  }
+  // await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -5,6 +5,7 @@ const { Publication } = require('../../models/Publication')
 const { Publications_Tags } = require('../../models/Publications_Tags')
 const { Document } = require('../../models/Document')
 const { urlToShortId } = require('../../routes/utils')
+const { Attribution } = require('../../models/Attribution')
 
 const test = async app => {
   if (!process.env.POSTGRE_INSTANCE) {
@@ -16,7 +17,7 @@ const test = async app => {
   }
 
   const createdReader = await Reader.createReader(
-    'auth0|foo1545149568941',
+    'auth0|foo1545149548941',
     reader
   )
 
@@ -129,6 +130,10 @@ const test = async app => {
     await tap.ok(response)
     await tap.ok(response instanceof Publication)
     await tap.equal(response.readerId, createdReader.id)
+    await tap.equal(response.author.length, 2)
+    await tap.ok(response.author[0] instanceof Attribution)
+    await tap.equal(response.editor.length, 1)
+    await tap.ok(response.editor[0] instanceof Attribution)
     publicationId = response.id
   })
 

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -238,7 +238,7 @@ const test = async app => {
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }
-  await destroyDB(app)
+  // await destroyDB(app)
 }
 
 module.exports = test

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -238,7 +238,7 @@ const test = async app => {
   if (!process.env.POSTGRE_INSTANCE) {
     await app.terminate()
   }
-  // await destroyDB(app)
+  await destroyDB(app)
 }
 
 module.exports = test

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -4,6 +4,7 @@ const publicationTests = require('./Publication.test')
 const readerTests = require('./Reader.test')
 const noteTests = require('./Note.test')
 const tagTests = require('./Tag.test')
+const attributionTests = require('./Attribution.test')
 
 const app = require('../../server').app
 
@@ -22,6 +23,7 @@ const allTests = async () => {
   // await activityTests(app)
   // await documentTests(app)
   await publicationTests(app)
+  await attributionTests(app)
   // await readerTests(app)
   // await noteTests(app)
   // await tagTests(app)

--- a/tests/models/index.js
+++ b/tests/models/index.js
@@ -23,7 +23,7 @@ const allTests = async () => {
   // await activityTests(app)
   // await documentTests(app)
   await publicationTests(app)
-  await attributionTests(app)
+  // await attributionTests(app)
   // await readerTests(app)
   // await noteTests(app)
   // await tagTests(app)


### PR DESCRIPTION
For now accepts only roles of 'author' and 'editor'. I know we will need to accept a lot more roles, but that will be easy to expand later. I just wanted to make sure it all works.

@rabhiso There is one method I didn't implement yet: deleteByPublicationId
The reason why we need this is that updates to authors, editors, etc. will be done through updates to the publication. So when people update the list of authors for a publication, the easiest thing for use to do will be to delete all authors for that publication and create new ones. So actually, the method will need to delete all attributions for a particular publicationId and with a particular role ('author', 'editor'). Do you think you can do that? We will need to have tests for it too (in the /tests/models/Attribution.test.js file). You will probably want to use this method: 
https://vincit.github.io/objection.js/api/query-builder/mutate-methods.html#delete
Let me know if you have any questions. 