### PR TITLE
Filter library

### DIFF
--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -106,7 +106,7 @@ class Attribution extends BaseModel {
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '') // remove accents
       .replace(/\s/g, '') // remove spaces
-      .replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '') // remove punctuation
+      .replace(/[.,\/#!$%\^&\*;:{}=\-_`~()\']/g, '') // remove punctuation
   }
 
   static async byId (id /*: string */) /*: Promise<any> */ {

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -42,20 +42,33 @@ class Reader extends BaseModel {
 
   static async byId (
     id /*: string */,
-    eager /*: string */,
-    limit /*: number */,
-    offset = 0 /*: number */
+    eager /*: string */
   ) /*: Promise<ReaderType> */ {
     const qb = Reader.query(Reader.knex()).where('id', '=', id)
-    let readers
-    if (limit) {
-      readers = await qb.eager(eager).modifyEager('publications', builder => {
+    const readers = await qb.eager(eager)
+
+    return readers[0]
+  }
+
+  static async getLibrary (
+    readerId /*: string */,
+    limit /*: number */,
+    offset = 0 /*: number */,
+    filter /*: any */
+  ) {
+    const qb = Reader.query(Reader.knex()).where('id', '=', readerId)
+    const eager = '[tags, publications.[tags, attributions]]'
+    const readers = await qb
+      .eager(eager)
+      .modifyEager('publications', builder => {
+        if (filter.title) {
+          builder.whereRaw(
+            'LOWER(name) LIKE ?',
+            '%' + filter.title.toLowerCase() + '%'
+          )
+        }
         builder.limit(limit).offset(offset)
       })
-    } else {
-      readers = await qb.eager(eager)
-    }
-
     return readers[0]
   }
 

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -187,7 +187,6 @@ class Reader extends BaseModel {
 
     const { Note } = require('./Note.js')
     const { Activity } = require('./Activity.js')
-    const { Attribution } = require('./Attribution.js')
     const { Tag } = require('./Tag.js')
     return {
       publications: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,18 +95,23 @@
       "dev": true
     },
     "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
+      "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
       "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+          "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+        },
         "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
@@ -564,9 +569,9 @@
       "dev": true
     },
     "@types/bluebird": {
-      "version": "3.5.25",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.25.tgz",
-      "integrity": "sha512-yfhIBix+AIFTmYGtkC0Bi+XGjSkOINykqKvO/Wqdz/DuXlAKK7HmhLAXdPIGsV4xzKcL3ev/zYc4yLNo+OvGaw=="
+      "version": "3.5.26",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.26.tgz",
+      "integrity": "sha512-aj2mrBLn5ky0GmAg6IPXrQjnN0iB/ulozuJ+oZdrHRAzRbXjGmu4UXsNCjFvPbSaaPZmniocdOzsM392qLOlmQ=="
     },
     "@types/body-parser": {
       "version": "1.17.0",
@@ -3122,6 +3127,11 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
+    },
+    "colorette": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.0.7.tgz",
+      "integrity": "sha512-KeK4klsvAgdODAjFPm6QLzvStizJqlxMBtVo4KQMCgk5tt/tf9rAzxmxLHNRynJg3tJjkKGKbHx3j4HLox27Lw=="
     },
     "colors": {
       "version": "1.3.3",
@@ -5795,20 +5805,30 @@
       }
     },
     "findup-sync": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-      "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
       "requires": {
         "detect-file": "^1.0.0",
-        "is-glob": "^3.1.0",
+        "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        }
       }
     },
     "fined": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.1.tgz",
-      "integrity": "sha512-jQp949ZmEbiYHk3gkbdtpJ0G1+kgtLQBNdP5edFP7Fh+WAYceLQz6yO1SBj72Xkg8GVyTB3bBzAYrHJVh5Xd5g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+      "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
       "requires": {
         "expand-tilde": "^2.0.2",
         "is-plain-object": "^2.0.3",
@@ -6930,6 +6950,11 @@
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
       "dev": true
+    },
+    "getopts": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.3.tgz",
+      "integrity": "sha512-viEcb8TpgeG05+Nqo5EzZ8QR0hxdyrYDp6ZSTZqe2M/h53Bk036NmqG38Vhf5RGirC/Of9Xql+v66B2gp256SQ=="
     },
     "getpass": {
       "version": "0.1.7",
@@ -8700,6 +8725,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.0"
       }
@@ -9534,48 +9560,51 @@
       "integrity": "sha1-ARRrNqYhjmTljzqNZt5df8b20FE="
     },
     "knex": {
-      "version": "0.16.3",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.16.3.tgz",
-      "integrity": "sha512-jGTOBW8b7exaBPfCKJSlv5q320IvWw9hEdtnURtbb0k3HusfZrR4UYiEewem8Nl7VqJILoCj99SjCK3W54UNPg==",
+      "version": "0.16.5",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.16.5.tgz",
+      "integrity": "sha512-1RVxMU8zGOBqgmXlAvs8vohg9MD14iiRZZPe0IeQXd554n4xxPmoMkbH4hlFeqfM6eOdFE3AVqVSncL3YuocqA==",
       "requires": {
-        "@babel/polyfill": "^7.0.0",
-        "@types/bluebird": "^3.5.25",
-        "bluebird": "^3.5.3",
-        "chalk": "2.4.1",
-        "commander": "^2.19.0",
-        "debug": "4.1.0",
+        "@babel/polyfill": "^7.4.3",
+        "@types/bluebird": "^3.5.26",
+        "bluebird": "^3.5.4",
+        "colorette": "1.0.7",
+        "commander": "^2.20.0",
+        "debug": "4.1.1",
+        "getopts": "2.2.3",
         "inherits": "~2.0.3",
-        "interpret": "^1.1.0",
-        "liftoff": "2.5.0",
+        "interpret": "^1.2.0",
+        "liftoff": "3.1.0",
         "lodash": "^4.17.11",
-        "minimist": "1.2.0",
         "mkdirp": "^0.5.1",
         "pg-connection-string": "2.0.0",
-        "tarn": "^1.1.4",
+        "tarn": "^1.1.5",
         "tildify": "1.2.0",
         "uuid": "^3.3.2",
-        "v8flags": "^3.1.1"
+        "v8flags": "^3.1.2"
       },
       "dependencies": {
         "bluebird": {
-          "version": "3.5.3",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+          "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
         },
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -9668,12 +9697,12 @@
       }
     },
     "liftoff": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+      "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
       "requires": {
         "extend": "^3.0.0",
-        "findup-sync": "^2.0.0",
+        "findup-sync": "^3.0.0",
         "fined": "^1.0.1",
         "flagged-respawn": "^1.0.0",
         "is-plain-object": "^2.0.4",
@@ -10735,7 +10764,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -16329,9 +16359,9 @@
       }
     },
     "tarn": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.4.tgz",
-      "integrity": "sha512-j4samMCQCP5+6Il9/cxCqBd3x4vvlLeVdoyGex0KixPKl4F8LpNbDSC6NDhjianZgUngElRr9UI1ryZqJDhwGg=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.5.tgz",
+      "integrity": "sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g=="
     },
     "teeny-request": {
       "version": "3.11.0",
@@ -17306,9 +17336,9 @@
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-      "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "express": "^4.16.3",
     "express-paginate": "^1.0.0",
     "helmet": "^3.13.0",
-    "knex": "^0.16.3",
+    "knex": "^0.16.5",
     "lodash": "^4.17.11",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",

--- a/routes/user-library.js
+++ b/routes/user-library.js
@@ -77,10 +77,18 @@ module.exports = app => {
    *         name: attribution
    *         schema:
    *           type: string
+   *         description: a search in the attribution field. Will also return partial matches.
+   *       - in: query
+   *         name: role
+   *         schema:
+   *           type: string
+   *           enum: ['author', 'editor']
+   *         description: a modifier for attribution to specify the type of attribution
    *       - in: query
    *         name: author
    *         schema:
    *           type: string
+   *         description: will return only exact matches.
    *     security:
    *       - Bearer: []
    *     produces:
@@ -108,6 +116,7 @@ module.exports = app => {
       const filters = {
         author: req.query.author,
         attribution: req.query.attribution,
+        role: req.query.role,
         title: req.query.title
       }
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything

--- a/routes/user-library.js
+++ b/routes/user-library.js
@@ -97,13 +97,13 @@ module.exports = app => {
     passport.authenticate('jwt', { session: false }),
     function (req, res, next) {
       const id = req.params.id
+      const filters = {
+        author: req.query.author,
+        attribution: req.query.attribution,
+        title: req.query.title
+      }
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything
-      Reader.byId(
-        id,
-        '[tags, publications.[tags, attributions]]',
-        req.query.limit,
-        req.skip
-      )
+      Reader.getLibrary(id, req.query.limit, req.skip, filters)
         .then(reader => {
           if (!reader) {
             res.status(404).send(`No reader with ID ${id}`)

--- a/routes/user-library.js
+++ b/routes/user-library.js
@@ -73,6 +73,14 @@ module.exports = app => {
    *         schema:
    *           type: number
    *           default: 1
+   *       - in: query
+   *         name: attribution
+   *         schema:
+   *           type: string
+   *       - in: query
+   *         name: author
+   *         schema:
+   *           type: string
    *     security:
    *       - Bearer: []
    *     produces:

--- a/tests/integration/library.test.js
+++ b/tests/integration/library.test.js
@@ -332,8 +332,18 @@ const test = async () => {
 
     await tap.equal(res2.body.totalItems, 10)
 
-    // should return 0 items if none found
     const res3 = await request(app)
+      .get(`${userUrl}/library?title=publication&limit=11`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res3.body.totalItems, 11)
+
+    // should return 0 items if none found
+    const res4 = await request(app)
       .get(`${userUrl}/library?title=ansoiwereow`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
@@ -341,7 +351,7 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res3.body.totalItems, 0)
+    await tap.equal(res4.body.totalItems, 0)
   })
 
   await tap.test('filter library by attribution', async () => {
@@ -379,6 +389,95 @@ const test = async () => {
     await tap.notOk(body.items[0].readingOrder)
     await tap.notOk(body.items[0].links)
     await tap.notOk(body.items[0].json)
+
+    // should work with partial match
+    const res1 = await request(app)
+      .get(`${userUrl}/library?attribution=John d`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res1.body.items.length, 3)
+
+    // should work with limit
+    await createPublication('new book 4', 'Jane Smith', 'John Doe')
+    await createPublication('new book 5', 'Jane Smith', 'John Doe')
+    await createPublication('new book 6', 'Jane Smith', 'John Doe')
+    await createPublication('new book 7', 'Jane Smith', 'John Doe')
+    await createPublication('new book 8', 'Jane Smith', 'John Doe')
+    await createPublication('new book 9', 'Jane Smith', 'John Doe')
+    await createPublication('new book 10', 'Jane Smith', 'John Doe')
+    await createPublication('new book 11', 'Jane Smith', 'John Doe')
+    await createPublication('new book 12', 'Jane Smith', 'John Doe')
+    await createPublication('new book 13', 'Jane Smith', 'John Doe')
+    await createPublication('new book 14', 'Jane Smith', 'John Doe')
+    await createPublication('new book 15', 'Jane Smith', 'John Doe')
+
+    const res2 = await request(app)
+      .get(`${userUrl}/library?attribution=John%20Doe`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res2.body.items.length, 10)
+
+    const res3 = await request(app)
+      .get(`${userUrl}/library?attribution=John%20Doe&limit=11`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res3.body.items.length, 11)
+
+    const res4 = await request(app)
+      .get(`${userUrl}/library?attribution=John%20Doe&limit=11&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res4.body.items.length, 4)
+  })
+
+  await tap.test('filter library by attribution with role', async () => {
+    const res = await request(app)
+      .get(`${userUrl}/library?attribution=John%20D&role=author`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.items.length, 2)
+
+    // should work with editor and with pagination
+    const res2 = await request(app)
+      .get(`${userUrl}/library?attribution=John%20D&role=editor`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res2.body.items.length, 10)
+
+    const res3 = await request(app)
+      .get(`${userUrl}/library?attribution=John%20D&role=editor&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res3.body.items.length, 3)
   })
 
   await tap.test('filter library by author', async () => {
@@ -412,6 +511,37 @@ const test = async () => {
     await tap.notOk(body.items[0].readingOrder)
     await tap.notOk(body.items[0].links)
     await tap.notOk(body.items[0].json)
+
+    // should work with limit
+    const res2 = await request(app)
+      .get(`${userUrl}/library?author=JaneSmith`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res2.body.items.length, 10)
+
+    const res3 = await request(app)
+      .get(`${userUrl}/library?author=JaneSmith&limit=11`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res3.body.items.length, 11)
+
+    const res4 = await request(app)
+      .get(`${userUrl}/library?author=JaneSmith&limit=11&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res4.body.items.length, 1)
   })
 
   await tap.test(

--- a/tests/integration/library.test.js
+++ b/tests/integration/library.test.js
@@ -19,7 +19,7 @@ const test = async () => {
   const userCompleteUrl = await createUser(app, token)
   const userUrl = urlparse(userCompleteUrl).path
 
-  const createPublication = async number => {
+  const createPublication = async title => {
     return await request(app)
       .post(`${userUrl}/activity`)
       .set('Host', 'reader-api.test')
@@ -36,7 +36,7 @@ const test = async () => {
           type: 'Create',
           object: {
             type: 'Publication',
-            name: `Publication ${number}`,
+            name: title,
             author: ['John Smith'],
             editor: 'Jane Doe',
             description: 'this is a description!!',
@@ -58,7 +58,6 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-    console.log(res.error)
     await tap.equal(res.status, 200)
 
     const body = res.body
@@ -138,7 +137,7 @@ const test = async () => {
   await tap.test('filter library by collection', async () => {
     // add more publications
     // publication 2
-    const pubBres = await createPublication(2)
+    const pubBres = await createPublication('Publication 2')
 
     const pubActivityUrl = pubBres.get('Location')
     const pubActivityObject = await getActivityFromUrl(
@@ -149,7 +148,7 @@ const test = async () => {
     const publication = pubActivityObject.object
 
     // publication 3
-    await createPublication(3)
+    await createPublication('Publication 3')
 
     // create a stack
     const stackRes = await request(app)
@@ -197,7 +196,7 @@ const test = async () => {
           ],
           type: 'Add',
           object: { id: stack.id, type: 'reader:Stack' },
-          target: { id: publication.id }
+          target: { id: publication.id, type: 'Publication' }
         })
       )
 
@@ -222,16 +221,16 @@ const test = async () => {
 
   await tap.test('paginate library', async () => {
     // add more publications
-    await createPublication(4)
-    await createPublication(5)
-    await createPublication(6)
-    await createPublication(7)
-    await createPublication(8)
-    await createPublication(9)
-    await createPublication(10)
-    await createPublication(11)
-    await createPublication(12)
-    await createPublication(13)
+    await createPublication('Publication 4')
+    await createPublication('Publication 5')
+    await createPublication('Publication 6')
+    await createPublication('Publication 7')
+    await createPublication('Publication 8')
+    await createPublication('Publication 9')
+    await createPublication('Publication 10')
+    await createPublication('Publication 11')
+    await createPublication('Publication 12')
+    await createPublication('Publication 13')
 
     // get library with pagination
     const res = await request(app)
@@ -298,6 +297,47 @@ const test = async () => {
       )
 
     await tap.equal(res4.body.totalItems, 10)
+  })
+
+  await tap.test('filter library by title', async () => {
+    await createPublication('superbook')
+    await createPublication('Super great book!')
+
+    const res = await request(app)
+      .get(`${userUrl}/library?title=super`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 2)
+    await tap.ok(res.body.items)
+    await tap.equal(res.body.items[0].name, 'Super great book!')
+
+    // should work with limit
+    const res2 = await request(app)
+      .get(`${userUrl}/library?title=publication`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res2.body.totalItems, 10)
+
+    // should return 0 items if none found
+    const res3 = await request(app)
+      .get(`${userUrl}/library?title=ansoiwereow`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res3.body.totalItems, 0)
   })
 
   await tap.test(

--- a/tests/unit/user-library-route.test.js
+++ b/tests/unit/user-library-route.test.js
@@ -73,7 +73,7 @@ const test = async () => {
   const request = supertest(app)
 
   await tap.test('Get Reader Library', async () => {
-    ReaderStub.Reader.byId = async () => Promise.resolve(readerLibrary)
+    ReaderStub.Reader.getLibrary = async () => Promise.resolve(readerLibrary)
     checkReaderStub.returns(true)
 
     const res = await request
@@ -102,7 +102,7 @@ const test = async () => {
   })
 
   await tap.test('Get Reader Library, filtering by tag', async () => {
-    ReaderStub.Reader.byId = async () => Promise.resolve(readerLibrary)
+    ReaderStub.Reader.getLibrary = async () => Promise.resolve(readerLibrary)
     checkReaderStub.returns(true)
 
     const res = await request
@@ -134,7 +134,7 @@ const test = async () => {
   await tap.test(
     'Get Reader Library that belongs to another reader',
     async () => {
-      ReaderStub.Reader.byId = async () => Promise.resolve(readerLibrary)
+      ReaderStub.Reader.getLibrary = async () => Promise.resolve(readerLibrary)
       checkReaderStub.returns(false)
 
       const res = await request
@@ -151,7 +151,7 @@ const test = async () => {
   await tap.test(
     'Get Reader Library for a user that does not exist',
     async () => {
-      ReaderStub.Reader.byId = async () => Promise.resolve(null)
+      ReaderStub.Reader.getLibrary = async () => Promise.resolve(null)
       checkReaderStub.returns(true)
 
       const res = await request


### PR DESCRIPTION
query filters added to library:
**title** (name of publication)
**attribution** (name of author / editor /... ). This is a search and will return partial matches. For example searching for 'Smith' will return publications by 'John Smith', 'Jane Smith', etc.
e.g. /reader-123/library?attribution=smith
**role** (attribution role. Can be any accepted attribution role. Right now only author and editor but others will be added). This is a modifier for attribution. Does not do anything if used without attribution query.
e.g. /reader-123/library?attribution=smith&role=author
**author** (name of author). This will return 'exact' matches for attribution with role of author. Author name is normalized (removing accents, punctuation, uppercase letters...) before matching. So a query for author John A. Smith will return books by John a smith.
e.g. /reader-123/library?author=John%20A%20Smith

Also works with pagination. 
e.g. /reader-123/library?attribution=smith&limit=20&page=2