### PR TITLE
Library order by

### DIFF
--- a/models/Reader.js
+++ b/models/Reader.js
@@ -70,6 +70,13 @@ class Reader extends BaseModel {
             .joinRelation('attributions')
             .where('attributions.normalizedName', 'like', `%${attribution}%`)
             .andWhere('attributions.role', '=', filter.role)
+          if (filter.orderBy === 'title') {
+            if (filter.reverse) {
+              builder.orderBy('name', 'desc')
+            } else {
+              builder.orderBy('name')
+            }
+          }
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -87,6 +94,13 @@ class Reader extends BaseModel {
           builder
             .joinRelation('attributions')
             .where('attributions.normalizedName', 'like', `%${attribution}%`)
+          if (filter.orderBy === 'title') {
+            if (filter.reverse) {
+              builder.orderBy('name', 'desc')
+            } else {
+              builder.orderBy('name')
+            }
+          }
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -105,6 +119,13 @@ class Reader extends BaseModel {
             .joinRelation('attributions')
             .where('attributions.normalizedName', '=', attribution)
             .andWhere('attributions.role', '=', 'author')
+          if (filter.orderBy === 'title') {
+            if (filter.reverse) {
+              builder.orderBy('name', 'desc')
+            } else {
+              builder.orderBy('name')
+            }
+          }
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -122,6 +143,13 @@ class Reader extends BaseModel {
             'LOWER(name) LIKE ?',
             '%' + filter.title.toLowerCase() + '%'
           )
+        }
+        if (filter.orderBy === 'title') {
+          if (filter.reverse) {
+            builder.orderBy('name', 'desc')
+          } else {
+            builder.orderBy('name')
+          }
         }
         builder.limit(limit).offset(offset)
       })

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -61,6 +61,23 @@ class Reader extends BaseModel {
   ) {
     const qb = Reader.query(Reader.knex()).where('id', '=', readerId)
 
+    const orderBuilder = builder => {
+      if (filter.orderBy === 'title') {
+        if (filter.reverse) {
+          builder.orderBy('name', 'desc')
+        } else {
+          builder.orderBy('name')
+        }
+      }
+
+      if (filter.orderBy === 'datePublished') {
+        if (filter.reverse) {
+          builder.orderByRaw('"datePublished" NULLS FIRST')
+        } else {
+          builder.orderByRaw('"datePublished" DESC NULLS LAST')
+        }
+      }
+    }
     if (filter.attribution && filter.role) {
       const attribution = Attribution.normalizeName(filter.attribution)
       const readers = await qb
@@ -70,13 +87,7 @@ class Reader extends BaseModel {
             .joinRelation('attributions')
             .where('attributions.normalizedName', 'like', `%${attribution}%`)
             .andWhere('attributions.role', '=', filter.role)
-          if (filter.orderBy === 'title') {
-            if (filter.reverse) {
-              builder.orderBy('name', 'desc')
-            } else {
-              builder.orderBy('name')
-            }
-          }
+          orderBuilder(builder)
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -94,13 +105,7 @@ class Reader extends BaseModel {
           builder
             .joinRelation('attributions')
             .where('attributions.normalizedName', 'like', `%${attribution}%`)
-          if (filter.orderBy === 'title') {
-            if (filter.reverse) {
-              builder.orderBy('name', 'desc')
-            } else {
-              builder.orderBy('name')
-            }
-          }
+          orderBuilder(builder)
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -119,13 +124,7 @@ class Reader extends BaseModel {
             .joinRelation('attributions')
             .where('attributions.normalizedName', '=', attribution)
             .andWhere('attributions.role', '=', 'author')
-          if (filter.orderBy === 'title') {
-            if (filter.reverse) {
-              builder.orderBy('name', 'desc')
-            } else {
-              builder.orderBy('name')
-            }
-          }
+          orderBuilder(builder)
           builder
             .eager('[tags, attributions]')
             .limit(limit)
@@ -144,13 +143,7 @@ class Reader extends BaseModel {
             '%' + filter.title.toLowerCase() + '%'
           )
         }
-        if (filter.orderBy === 'title') {
-          if (filter.reverse) {
-            builder.orderBy('name', 'desc')
-          } else {
-            builder.orderBy('name')
-          }
-        }
+        orderBuilder(builder)
         builder.limit(limit).offset(offset)
       })
     return readers[0]

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -116,7 +116,9 @@ module.exports = app => {
         author: req.query.author,
         attribution: req.query.attribution,
         role: req.query.role,
-        title: req.query.title
+        title: req.query.title,
+        orderBy: req.query.orderBy,
+        reverse: req.query.reverse
       }
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything
       Reader.getLibrary(id, req.query.limit, req.skip, filters)

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -89,6 +89,17 @@ module.exports = app => {
    *         schema:
    *           type: string
    *         description: will return only exact matches.
+   *       - in: query
+   *         name: orderBy
+   *         schema:
+   *           type: string
+   *           enum: ['title', 'datePublished']
+   *         description: used to order either alphabetically by title or by date published (most recent first)
+   *       - in: query
+   *         name: reverse
+   *         schema:
+   *           type: boolean
+   *         description: a modifier to use with orderBy to reverse the order
    *     security:
    *       - Bearer: []
    *     produces:


### PR DESCRIPTION

new query parameters for the library route:
orderBy - can be either 'title' or 'datePublished'
reverse=true 

by default, datePublished will return most recent first. 
as discussed earlier, publications with no datePublished will be considered to be the oldest. 

They work with other filters and with pagination.

let me know if you ever want me to rename the parameters. For example I could use ascending / descending instead of reverse. 
