### PR TITLE
creating note requires either a document url or a pubid, not both

### DIFF
--- a/activityDoc.md
+++ b/activityDoc.md
@@ -245,7 +245,6 @@ Example:
     type: 'Note',
     content: <string>,
     'oa:hasSelector': {},
-    context: <publicationUrl>,
     inReplyTo: <documentUrl>,
     noteType: <string>
   }
@@ -266,7 +265,11 @@ Required Properties:
 }
 ```
 
-This will create a note that is (optionally) attached to the document specified in object.inReplyTo, in the context of the publication in object.context (also optional)
+Note that if you want to create a note associated with a particular document, you need to pass in the documentUrl in property inReplyTo.
+To create a note that is associated with a publication, but not a specific document within the publication, pass in the publicationId in property context.
+If you pass in inReplyTo, you do not need to specify the publication under context. If you do, it will be quietly ignored.
+
+It is also possible to create a note that has neither inReplyTo nor context.
 
 The specific location of the annotation within the document is specified by the oa:hasSelector object
 

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -87,6 +87,19 @@ const handleCreate = async (req, res, next, reader) => {
               }
             )
           )
+        } else if (err.message === 'no publication') {
+          return next(
+            boom.notFound(
+              `note creation failed: no publication found with id ${
+                body.object.context
+              }`,
+              {
+                type: 'Publication',
+                id: body.object.context,
+                activity: 'Create Note'
+              }
+            )
+          )
         } else if (err instanceof ValidationError) {
           // rename selector to oa:hasSelector
           if (err.data && err.data.selector) {


### PR DESCRIPTION
That was a pretty quick fix.
So with these changes, notes attached to a document only need the document url in inReplyTo. They do not need a context. The publication id will be extracted from the inReplyTo. 
You can also create a note with only a context and no inReplyTo. Or with neither.

If you create a note with both a inReplyTo and a context, the context provided will overwrite the one  extracted from inReplyTo. It could also give an error if you prefer (but I guess that would be a breaking change for you if we do that). 