### PR TITLE
changed type of tags and added tagType

### DIFF
--- a/activityDoc.md
+++ b/activityDoc.md
@@ -12,7 +12,7 @@ These errors can be thrown on various activities
 * 404: 'No reader with id {id}'
 * 403: 'Access to reader {id} disallowed'
 * 400: 'action {action type} not recognized' - action type should be one of 'Create', 'Add', 'Remove', 'Delete', 'Update', 'Read'
-* 400: 'cannot {verb} {type}' e.g. 'cannot delete Document'. Object types can be 'reader:Publication', 'Document', 'Note', 'reader:Stack'. But not all action - object combinations are supported. For example, Update reader:Publication is not supported.
+* 400: 'cannot {verb} {type}' e.g. 'cannot delete Document'. Object types can be 'reader:Publication', 'Document', 'Note', 'reader:Tag'. But not all action - object combinations are supported. For example, Update reader:Publication is not supported.
 
 ## Publications
 
@@ -332,7 +332,8 @@ Possible errors:
 
 ## Tags
 
-Currently, only tags of the type reader:Stack are supported by the API. Those are used to organize publications into stacks or collections.
+Tags of the tagType reader:Stack are used to organize publications into stacks or collections.
+It is possible to create tags with other types.
 
 ### Create a Tag
 
@@ -346,7 +347,8 @@ Example:
   ],
   type: 'Create',
   object: {
-    type: 'reader:Stack',
+    type: 'reader:Tag',
+    tagType: <string> // e.g. 'reader:Stack' for collections
     name: <string>,
     json: {object} // optional
   }
@@ -371,7 +373,7 @@ Example:
   type: 'Add',
   object: {
     id: <tagId>
-    type: 'reader:Stack'
+    type: 'reader:Tag'
   },
   target: {
     id: <publicationId>
@@ -407,7 +409,7 @@ Example:
   type: 'Add',
   object: {
     id: <tagId>
-    type: 'reader:Stack'
+    type: 'reader:Tag'
   },
   target: {
     id: <noteId>
@@ -441,7 +443,7 @@ Possible errors:
   type: 'Remove',
   object: {
     id: <tagId>
-    type: 'reader:Stack'
+    type: 'reader:Tag'
   },
   target: {
     id: <publicationId>
@@ -471,7 +473,7 @@ Possible errors:
   type: 'Remove',
   object: {
     id: <tagId>
-    type: 'reader:Stack'
+    type: 'reader:Tag'
   },
   target: {
     id: <noteId>
@@ -494,8 +496,6 @@ Possible errors:
 
 Example:
 
-NOTE: should use reader:Stack but right now uses 'Tag' as the object type. This might change. Avoid using this feature until this is fixed.
-
 ```
 {
   '@context': [
@@ -504,7 +504,7 @@ NOTE: should use reader:Stack but right now uses 'Tag' as the object type. This 
   ],
   type: 'Delete',
   object: {
-    type: 'Tag',
+    type: 'reader:Tag',
     id: <tagUrl>
   }
 }

--- a/doc.json
+++ b/doc.json
@@ -306,7 +306,7 @@
             "Bearer": []
           }
         ],
-        "reponses": {
+        "responses": {
           "302": "redirected to document",
           "403": "Access to publication {id} disallowed",
           "404": "Publication or Document not found"
@@ -783,8 +783,7 @@
               "enum": [
                 "Publication",
                 "Note'",
-                "reader:Stack",
-                "Tag"
+                "reader:Tag"
               ]
             },
             "id": {
@@ -801,8 +800,7 @@
               "enum": [
                 "Publication",
                 "Note'",
-                "reader:Stack",
-                "Tag"
+                "reader:Tag"
               ]
             },
             "id": {
@@ -1120,11 +1118,82 @@
             "Publication"
           ]
         },
+        "summaryMap": {
+          "type": "object",
+          "properties": {
+            "en": {
+              "type": "string"
+            }
+          }
+        },
+        "@context": {
+          "type": "array"
+        },
+        "author": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/annotation"
+          }
+        },
+        "editor": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/annotation"
+          }
+        },
+        "replies": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "url"
+          }
+        },
+        "description": {
+          "type": "string"
+        },
+        "datePublished": {
+          "type": "string",
+          "format": "timestamp"
+        },
+        "readerId": {
+          "type": "string",
+          "format": "url"
+        },
+        "published": {
+          "type": "string",
+          "format": "timestamp"
+        },
+        "updated": {
+          "type": "string",
+          "format": "timestamp"
+        }
+      }
+    },
+    "tag": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "url"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "reader:Tag"
+          ]
+        },
         "name": {
           "type": "string"
         },
-        "attributedTo": {
-          "type": "array"
+        "tagType": {
+          "type": "string"
+        },
+        "published": {
+          "type": "string",
+          "format": "timestamp"
+        },
+        "updated": {
+          "type": "string",
+          "format": "timestamp"
         }
       }
     },
@@ -1150,6 +1219,12 @@
         },
         "@context": {
           "type": "array"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/tag"
+          }
         },
         "totalItems": {
           "type": "integer"

--- a/docs/index.html
+++ b/docs/index.html
@@ -1778,13 +1778,13 @@ fetch(<span class="hljs-string">'/activity-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
   },
   <span class="hljs-attr">"summaryMap"</span>: {
     <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
   },
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
 }
 </code></pre>
 <h3 id="get__activity-{id}-responses">Responses</h3>
@@ -2089,11 +2089,7 @@ fetch(<span class="hljs-string">'/activity-{id}'</span>,
 </tr>
 <tr>
 <td>type</td>
-<td>reader:Stack</td>
-</tr>
-<tr>
-<td>type</td>
-<td>Tag</td>
+<td>reader:Tag</td>
 </tr>
 <tr>
 <td>type</td>
@@ -2105,11 +2101,7 @@ fetch(<span class="hljs-string">'/activity-{id}'</span>,
 </tr>
 <tr>
 <td>type</td>
-<td>reader:Stack</td>
-</tr>
-<tr>
-<td>type</td>
-<td>Tag</td>
+<td>reader:Tag</td>
 </tr>
 <tr>
 <td>type</td>
@@ -2334,13 +2326,13 @@ fetch(<span class="hljs-string">'/reader-{id}/activity'</span>,
         <span class="hljs-attr">"profile"</span>: {},
         <span class="hljs-attr">"preferences"</span>: {},
         <span class="hljs-attr">"json"</span>: {},
-        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
       },
       <span class="hljs-attr">"summaryMap"</span>: {
         <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
       },
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
     }
   ]
 }
@@ -2700,11 +2692,7 @@ fetch(<span class="hljs-string">'/reader-{id}/activity'</span>,
 </tr>
 <tr>
 <td>type</td>
-<td>reader:Stack</td>
-</tr>
-<tr>
-<td>type</td>
-<td>Tag</td>
+<td>reader:Tag</td>
 </tr>
 <tr>
 <td>type</td>
@@ -2716,11 +2704,7 @@ fetch(<span class="hljs-string">'/reader-{id}/activity'</span>,
 </tr>
 <tr>
 <td>type</td>
-<td>reader:Stack</td>
-</tr>
-<tr>
-<td>type</td>
-<td>Tag</td>
+<td>reader:Tag</td>
 </tr>
 <tr>
 <td>type</td>
@@ -2988,13 +2972,45 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
     <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
   },
   <span class="hljs-attr">"@context"</span>: [],
+  <span class="hljs-attr">"tags"</span>: [
+    {
+      <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"reader:Tag"</span>,
+      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"tagType"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"string"</span>
+    }
+  ],
   <span class="hljs-attr">"totalItems"</span>: <span class="hljs-number">0</span>,
   <span class="hljs-attr">"items"</span>: [
     {
       <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Publication"</span>,
-      <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"attributedTo"</span>: []
+      <span class="hljs-attr">"summaryMap"</span>: {
+        <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
+      },
+      <span class="hljs-attr">"@context"</span>: [],
+      <span class="hljs-attr">"author"</span>: [
+        {
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Person"</span>
+        }
+      ],
+      <span class="hljs-attr">"editor"</span>: [
+        {
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Person"</span>
+        }
+      ],
+      <span class="hljs-attr">"replies"</span>: [
+        <span class="hljs-string">"string"</span>
+      ],
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"datePublished"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"readerId"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"string"</span>
     }
   ]
 }
@@ -3079,6 +3095,55 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <td>none</td>
 </tr>
 <tr>
+<td>» tags</td>
+<td>[<a href="#schema#/definitions/tag">#/definitions/tag</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» id</td>
+<td>string(url)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» type</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» name</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» tagType</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» published</td>
+<td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» updated</td>
+<td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
 <td>» totalItems</td>
 <td>integer</td>
 <td>false</td>
@@ -3107,15 +3172,92 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <td>none</td>
 </tr>
 <tr>
-<td>»» name</td>
+<td>»» summaryMap</td>
+<td>object</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» en</td>
 <td>string</td>
 <td>false</td>
 <td>none</td>
 <td>none</td>
 </tr>
 <tr>
-<td>»» attributedTo</td>
+<td>»» @context</td>
 <td>array</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» author</td>
+<td>[<a href="#schema#/definitions/annotation">#/definitions/annotation</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» name</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» type</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» editor</td>
+<td>[<a href="#schema#/definitions/annotation">#/definitions/annotation</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» replies</td>
+<td>[string]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» datePublished</td>
+<td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» readerId</td>
+<td>string(url)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» published</td>
+<td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» updated</td>
+<td>string(timestamp)</td>
 <td>false</td>
 <td>none</td>
 <td>none</td>
@@ -3137,7 +3279,19 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 </tr>
 <tr>
 <td>type</td>
+<td>reader:Tag</td>
+</tr>
+<tr>
+<td>type</td>
 <td>Publication</td>
+</tr>
+<tr>
+<td>type</td>
+<td>Person</td>
+</tr>
+<tr>
+<td>type</td>
+<td>Organization</td>
 </tr>
 </tbody>
 </table>
@@ -3290,8 +3444,8 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
       <span class="hljs-attr">"oa:hasSelector"</span>: {},
       <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"@context"</span>: [],
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
       <span class="hljs-attr">"inReplyTo"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"context"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"json"</span>: {}
@@ -3561,8 +3715,8 @@ fetch(<span class="hljs-string">'/reader-{id}'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
 }
 </code></pre>
 <h3 id="get__reader-{id}-responses">Responses</h3>
@@ -3861,8 +4015,8 @@ fetch(<span class="hljs-string">'/whoami'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
 }
 </code></pre>
 <h3 id="get__whoami-responses">Responses</h3>
@@ -4077,8 +4231,8 @@ fetch(<span class="hljs-string">'/note-{id}'</span>,
   <span class="hljs-attr">"oa:hasSelector"</span>: {},
   <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"@context"</span>: [],
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
   <span class="hljs-attr">"inReplyTo"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"context"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"json"</span>: {}
@@ -4291,7 +4445,26 @@ fetch(<span class="hljs-string">'/publication-{id}/{path}'</span>,
 <th>Schema</th>
 </tr>
 </thead>
-<tbody></tbody>
+<tbody>
+<tr>
+<td>302</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.4.3">Found</a></td>
+<td>none</td>
+<td>None</td>
+</tr>
+<tr>
+<td>403</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">Forbidden</a></td>
+<td>none</td>
+<td>None</td>
+</tr>
+<tr>
+<td>404</td>
+<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">Not Found</a></td>
+<td>none</td>
+<td>None</td>
+</tr>
+</tbody>
 </table>
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -4561,8 +4734,8 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-05-22T14:23:52Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
   },
   <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"string"</span>

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -94,12 +94,6 @@ class Reader extends BaseModel {
       const readers = await qb
         .skipUndefined()
         .eager('[tags, publications]')
-        .leftJoin('Publication', builder => {
-          builder.on('Publication.readerId', '=', 'Reader.id')
-          if (filter.title) {
-            builder.onIn('Publication.name', [filter.title])
-          }
-        })
         .modifyEager('publications', builder => {
           if (filter.title) {
             const title = filter.title.toLowerCase()

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -54,7 +54,7 @@ class Tag extends BaseModel {
 
   static async createTag (
     readerId /*: string */,
-    tag /*: {type: string, name: string, json?: {}, readerId?: string} */
+    tag /*: {type: string, name: string, tagType: string, json?: {}, readerId?: string} */
   ) /*: Promise<any> */ {
     tag.readerId = readerId
     // reject duplicates TODO: enforce this as the database level?
@@ -68,7 +68,8 @@ class Tag extends BaseModel {
     //   console.log(existing)
     //   if (existing.length > 0) return new Error('duplicate')
     // }
-    const props = _.pick(tag, ['name', 'type', 'json', 'readerId'])
+    const props = _.pick(tag, ['name', 'json', 'readerId'])
+    props.type = tag.tagType
     try {
       return await Tag.query().insert(props)
     } catch (err) {
@@ -101,6 +102,13 @@ class Tag extends BaseModel {
     return Promise.resolve(parent).then(function () {
       doc.updated = new Date().toISOString()
     })
+  }
+
+  $formatJson (json /*: any */) /*: any */ {
+    json = super.$formatJson(json)
+    json.tagType = json.type
+    json.type = 'reader:Tag'
+    return json
   }
 }
 

--- a/routes/activities/add.js
+++ b/routes/activities/add.js
@@ -45,7 +45,7 @@ const handleAdd = async (req, res, next, reader) => {
   }
 
   switch (body.object.type) {
-    case 'reader:Stack':
+    case 'reader:Tag':
       // Determine if the Tag is added to a Publication or a Note
       let resultStack
       if (body.target.type === 'Publication') {
@@ -100,7 +100,7 @@ const handleAdd = async (req, res, next, reader) => {
           case 'no tag':
             return next(
               boom.notFound(`no tag found with id ${body.object.id}`, {
-                type: 'Tag',
+                type: 'reader:Tag',
                 id: body.object.id,
                 activity: `Add Tag to ${body.target.type}`
               })

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -117,7 +117,7 @@ const handleCreate = async (req, res, next, reader) => {
         })
       break
 
-    case 'reader:Stack':
+    case 'reader:Tag':
       const resultStack = await Tag.createTag(reader.id, body.object)
 
       if (resultStack instanceof Error || !resultStack) {
@@ -125,7 +125,7 @@ const handleCreate = async (req, res, next, reader) => {
           return next(
             boom.badRequest(
               `duplicate error: stack ${body.object.name} already exists`,
-              { activity: 'Create Tag', type: 'Tag' }
+              { activity: 'Create Tag', type: 'reader:Tag' }
             )
           )
         }
@@ -133,7 +133,7 @@ const handleCreate = async (req, res, next, reader) => {
         if (resultStack instanceof ValidationError) {
           return next(
             boom.badRequest('Validation error on create Tag: ', {
-              type: 'Tag',
+              type: 'reader:Tag',
               activity: 'Create Tag',
               validation: resultStack.data
             })
@@ -143,7 +143,7 @@ const handleCreate = async (req, res, next, reader) => {
         const message = resultStack
           ? resultStack.message
           : 'stack creation failed'
-        res.status(400).send(`create stack error: ${message}`)
+        res.status(400).send(`create tag error: ${message}`)
       }
 
       const activityObjStack = createActivityObject(body, resultStack, reader)

--- a/routes/activities/delete.js
+++ b/routes/activities/delete.js
@@ -85,7 +85,7 @@ const handleDelete = async (req, res, next, reader) => {
         })
       break
 
-    case 'Tag':
+    case 'reader:Tag':
       const resultTag = await Tag.deleteTag(urlToId(body.object.id))
       if (resultTag === null || resultTag === 0) {
         return next(
@@ -93,7 +93,7 @@ const handleDelete = async (req, res, next, reader) => {
             `tag with id ${
               body.object.id
             } does not exist or has already been deleted`,
-            { type: 'Tag', id: body.object.id, activity: 'Delete Tag' }
+            { type: 'reader:Tag', id: body.object.id, activity: 'Delete Tag' }
           )
         )
       } else if (resultTag instanceof Error || !resultTag) {
@@ -104,7 +104,7 @@ const handleDelete = async (req, res, next, reader) => {
               `tag with id ${
                 body.object.id
               } does not exist or has already been deleted`,
-              { type: 'Tag', id: body.object.id, activity: 'Delete Tag' }
+              { type: 'reader:Tag', id: body.object.id, activity: 'Delete Tag' }
             )
           )
         }

--- a/routes/activities/remove.js
+++ b/routes/activities/remove.js
@@ -44,7 +44,7 @@ const handleRemove = async (req, res, next, reader) => {
   }
 
   let resultStack
-  if (body.object.type !== 'reader:Stack') {
+  if (body.object.type !== 'reader:Tag') {
     return next(
       boom.badRequest(`cannot remove ${body.object.type}`, {
         badParams: ['object.type'],
@@ -88,7 +88,7 @@ const handleRemove = async (req, res, next, reader) => {
       case 'no tag':
         return next(
           boom.notFound(`no tag provided`, {
-            type: 'Tag',
+            type: 'reader:Tag',
             activity: `Remove Tag from ${body.target.type}`
           })
         )

--- a/routes/activity.js
+++ b/routes/activity.js
@@ -25,7 +25,7 @@ const boom = require('@hapi/boom')
  *         properties:
  *           type:
  *             type: string
- *             enum: ['Publication', Note', 'reader:Stack', 'Tag']
+ *             enum: ['Publication', Note', 'reader:Tag']
  *           id:
  *             type: string
  *             format: url
@@ -34,7 +34,7 @@ const boom = require('@hapi/boom')
  *         properties:
  *           type:
  *             type: string
- *             enum: ['Publication', Note', 'reader:Stack', 'Tag']
+ *             enum: ['Publication', Note', 'reader:Tag']
  *           id:
  *             type: string
  *             format: url

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -53,6 +53,24 @@ const boom = require('@hapi/boom')
  *       updated:
  *         type: string
  *         format: timestamp
+ *   tag:
+ *     properties:
+ *       id:
+ *         type: string
+ *         format: url
+ *       type:
+ *         type: string
+ *         enum: ['reader:Tag']
+ *       name:
+ *         type: string
+ *       tagType:
+ *         type: string
+ *       published:
+ *         type: string
+ *         format: timestamp
+ *       updated:
+ *         type: string
+ *         format: timestamp
  *   library:
  *     properties:
  *       id:
@@ -68,6 +86,10 @@ const boom = require('@hapi/boom')
  *             type: string
  *       '@context':
  *         type: array
+ *       tags:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/tag'
  *       totalItems:
  *         type: integer
  *       items:
@@ -160,7 +182,8 @@ module.exports = app => {
         role: req.query.role,
         title: req.query.title,
         orderBy: req.query.orderBy,
-        reverse: req.query.reverse
+        reverse: req.query.reverse,
+        collection: req.query.stack
       }
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything
       Reader.getLibrary(id, req.query.limit, req.skip, filters)

--- a/tests/integration/activity-create.test.js
+++ b/tests/integration/activity-create.test.js
@@ -644,7 +644,7 @@ const test = async app => {
           ],
           type: 'Add',
           object: {
-            type: 'reader:Stack'
+            type: 'reader:Tag'
           },
           target: {
             type: 'SomethingInvalid'
@@ -677,7 +677,7 @@ const test = async app => {
           ],
           type: 'Add',
           object: {
-            type: 'reader:Stack'
+            type: 'reader:Tag'
           },
           target: {
             name: 'something'
@@ -709,7 +709,7 @@ const test = async app => {
           ],
           type: 'Add',
           object: {
-            type: 'reader:Stack'
+            type: 'reader:Tag'
           }
         })
       )
@@ -841,7 +841,7 @@ const test = async app => {
             ],
             type: 'Remove',
             object: {
-              type: 'reader:Stack'
+              type: 'reader:Tag'
             },
             target: {
               type: 'SomethingInvalid'
@@ -875,7 +875,7 @@ const test = async app => {
           ],
           type: 'Remove',
           object: {
-            type: 'reader:Stack'
+            type: 'reader:Tag'
           },
           target: {
             name: 'something'
@@ -907,7 +907,7 @@ const test = async app => {
           ],
           type: 'Remove',
           object: {
-            type: 'reader:Stack'
+            type: 'reader:Tag'
           }
         })
       )

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -63,7 +63,8 @@ const test = async () => {
           ],
           type: 'Create',
           object: {
-            type: 'reader:Stack',
+            type: 'reader:Tag',
+            tagType: 'reader:Stack',
             name: 'mystack'
           }
         })
@@ -92,7 +93,7 @@ const test = async () => {
             { reader: 'https://rebus.foundation/ns/reader' }
           ],
           type: 'Add',
-          object: { id: stack.id, type: 'reader:Stack' },
+          object: { id: stack.id, type: 'reader:Tag' },
           target: { id: publication.id, type: 'Publication' }
         })
       )

--- a/tests/integration/note-delete.test.js
+++ b/tests/integration/note-delete.test.js
@@ -71,7 +71,8 @@ const test = async app => {
   await tap.test('Delete a Note', async () => {
     // Create a tag for testing purposes and add it to the note
     const createdTag = await Tag.createTag(readerId, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'random stack'
     })
 

--- a/tests/integration/publication-delete.test.js
+++ b/tests/integration/publication-delete.test.js
@@ -114,7 +114,8 @@ const test = async app => {
 
     // Create a tag for testing purposes
     const createdTag = await Tag.createTag(reader1.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'mystack'
     })
 

--- a/tests/integration/readerNotes-get.test.js
+++ b/tests/integration/readerNotes-get.test.js
@@ -92,6 +92,7 @@ const test = async app => {
     await tap.equal(body.totalItems, 3)
     await tap.equal(body.items.length, 3)
     await tap.equal(body.items[0].type, 'Note')
+    await tap.ok(body.items[0]['oa:hasSelector'])
   })
 
   await tap.test(

--- a/tests/integration/tag-create.test.js
+++ b/tests/integration/tag-create.test.js
@@ -28,7 +28,36 @@ const test = async app => {
           ],
           type: 'Create',
           object: {
-            type: 'reader:Stack',
+            type: 'reader:Tag',
+            tagType: 'reader:Stack',
+            name: 'mystack',
+            json: { property: 'value' }
+          }
+        })
+      )
+    await tap.equal(res.status, 201)
+    await tap.type(res.get('Location'), 'string')
+    activityUrl = res.get('Location')
+  })
+
+  await tap.test('Create Tag with new type', async () => {
+    const res = await request(app)
+      .post(`${readerUrl}/activity`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify({
+          '@context': [
+            'https://www.w3.org/ns/activitystreams',
+            { reader: 'https://rebus.foundation/ns/reader' }
+          ],
+          type: 'Create',
+          object: {
+            type: 'reader:Tag',
+            tagType: 'newTagType!',
             name: 'mystack',
             json: { property: 'value' }
           }
@@ -55,7 +84,8 @@ const test = async app => {
           ],
           type: 'Create',
           object: {
-            type: 'reader:Stack',
+            type: 'reader:Tag',
+            tagType: 'reader:Stack',
             json: { property: 'value' }
           }
         })
@@ -65,7 +95,7 @@ const test = async app => {
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 400)
     await tap.equal(error.error, 'Bad Request')
-    await tap.equal(error.details.type, 'Tag')
+    await tap.equal(error.details.type, 'reader:Tag')
     await tap.equal(error.details.activity, 'Create Tag')
     await tap.type(error.details.validation, 'object')
     await tap.equal(error.details.validation.name[0].keyword, 'required')
@@ -91,7 +121,8 @@ const test = async app => {
           ],
           type: 'Create',
           object: {
-            type: 'reader:Stack',
+            type: 'reader:Tag',
+            tagType: 'reader:Stack',
             name: 'mystack'
           }
         })
@@ -99,7 +130,7 @@ const test = async app => {
     await tap.equal(res.status, 400)
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 400)
-    await tap.equal(error.details.type, 'Tag')
+    await tap.equal(error.details.type, 'reader:Tag')
     await tap.equal(error.details.activity, 'Create Tag')
   })
 
@@ -116,6 +147,8 @@ const test = async app => {
     const body = res.body
     await tap.ok(Array.isArray(body.tags))
     await tap.type(body.tags[0].name, 'string')
+    await tap.equal(body.tags[0].tagType, 'newTagType!')
+    await tap.equal(body.tags[0].type, 'reader:Tag')
     await tap.type(body.tags[0].json, 'object')
     stack = body.tags[0]
   })

--- a/tests/integration/tag-delete.test.js
+++ b/tests/integration/tag-delete.test.js
@@ -83,7 +83,8 @@ const test = async app => {
         ],
         type: 'Create',
         object: {
-          type: 'reader:Stack',
+          type: 'reader:Tag',
+          tagType: 'reader:Stack',
           name: 'mystack',
           json: { property: 'value' }
         }
@@ -119,7 +120,7 @@ const test = async app => {
             ],
             type: 'Delete',
             object: {
-              type: 'Tag',
+              type: 'reader:Tag',
               id: stack.id + 'blah'
             }
           })
@@ -128,7 +129,7 @@ const test = async app => {
       await tap.equal(res.statusCode, 404)
       const error = JSON.parse(res.text)
       await tap.equal(error.statusCode, 404)
-      await tap.equal(error.details.type, 'Tag')
+      await tap.equal(error.details.type, 'reader:Tag')
       await tap.equal(error.details.activity, 'Delete Tag')
     }
   )
@@ -149,7 +150,7 @@ const test = async app => {
           ],
           type: 'Delete',
           object: {
-            type: 'Tag',
+            type: 'reader:Tag',
             id: null
           }
         })
@@ -158,7 +159,7 @@ const test = async app => {
     await tap.equal(res.statusCode, 404)
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 404)
-    await tap.equal(error.details.type, 'Tag')
+    await tap.equal(error.details.type, 'reader:Tag')
     await tap.equal(error.details.activity, 'Delete Tag')
   })
 
@@ -198,7 +199,7 @@ const test = async app => {
           ],
           type: 'Delete',
           object: {
-            type: 'Tag',
+            type: 'reader:Tag',
             id: stack.id
           }
         })
@@ -239,7 +240,7 @@ const test = async app => {
           ],
           type: 'Delete',
           object: {
-            type: 'Tag',
+            type: 'reader:Tag',
             id: stack.id
           }
         })
@@ -248,7 +249,7 @@ const test = async app => {
     await tap.equal(res.statusCode, 404)
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 404)
-    await tap.equal(error.details.type, 'Tag')
+    await tap.equal(error.details.type, 'reader:Tag')
     await tap.equal(error.details.activity, 'Delete Tag')
   })
 

--- a/tests/integration/tag-note.test.js
+++ b/tests/integration/tag-note.test.js
@@ -81,7 +81,8 @@ const test = async app => {
         ],
         type: 'Create',
         object: {
-          type: 'reader:Stack',
+          type: 'reader:Tag',
+          tagType: 'reader:Stack',
           name: 'mystack',
           json: { property: 'value' }
         }
@@ -133,7 +134,7 @@ const test = async app => {
     const body = tagsForNotes.body
     await tap.ok(Array.isArray(body.tags))
     await tap.equal(body.tags.length, 1)
-    await tap.equal(body.tags[0].type, 'reader:Stack')
+    await tap.equal(body.tags[0].type, 'reader:Tag')
     await tap.equal(body.tags[0].name, 'mystack')
   })
 
@@ -159,7 +160,7 @@ const test = async app => {
     await tap.equal(res.status, 404)
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 404)
-    await tap.equal(error.details.type, 'Tag')
+    await tap.equal(error.details.type, 'reader:Tag')
     await tap.equal(error.details.activity, 'Add Tag to Note')
   })
 
@@ -378,7 +379,7 @@ const test = async app => {
       await tap.equal(res.status, 404)
       const error = JSON.parse(res.text)
       await tap.equal(error.statusCode, 404)
-      await tap.equal(error.details.type, 'Tag')
+      await tap.equal(error.details.type, 'reader:Tag')
       await tap.equal(error.details.activity, 'Remove Tag from Note')
     }
   )

--- a/tests/integration/tag-publication.test.js
+++ b/tests/integration/tag-publication.test.js
@@ -41,7 +41,8 @@ const test = async app => {
         ],
         type: 'Create',
         object: {
-          type: 'reader:Stack',
+          type: 'reader:Tag',
+          tagType: 'reader:Stack',
           name: 'mystack',
           json: { property: 'value' }
         }
@@ -93,7 +94,8 @@ const test = async app => {
     const body = pubres.body
     await tap.ok(Array.isArray(body.tags))
     await tap.equal(body.tags.length, 1)
-    await tap.equal(body.tags[0].type, 'reader:Stack')
+    await tap.equal(body.tags[0].type, 'reader:Tag')
+    await tap.equal(body.tags[0].tagType, 'reader:Stack')
     await tap.equal(body.tags[0].name, 'mystack')
   })
 
@@ -121,7 +123,7 @@ const test = async app => {
       await tap.equal(res.status, 404)
       const error = JSON.parse(res.text)
       await tap.equal(error.statusCode, 404)
-      await tap.equal(error.details.type, 'Tag')
+      await tap.equal(error.details.type, 'reader:Tag')
       await tap.equal(error.details.activity, 'Add Tag to Publication')
     }
   )
@@ -286,7 +288,7 @@ const test = async app => {
       await tap.equal(res.status, 404)
       const error = JSON.parse(res.text)
       await tap.equal(error.statusCode, 404)
-      await tap.equal(error.details.type, 'Tag')
+      await tap.equal(error.details.type, 'reader:Tag')
       await tap.equal(error.details.activity, 'Remove Tag from Publication')
     }
   )

--- a/tests/models/Note.test.js
+++ b/tests/models/Note.test.js
@@ -147,7 +147,8 @@ const test = async app => {
 
   // Create a valid tag
   const newTag = await Tag.createTag(createdReader.id, {
-    type: 'reader:Stack',
+    type: 'reader:Tag',
+    tagType: 'reader:Stack',
     name: 'mystack'
   })
 
@@ -186,11 +187,13 @@ const test = async app => {
   await tap.test('Delete all Note_Tags associated with a note', async () => {
     // Create valid tags
     const tag1 = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'someStack1'
     })
     const tag2 = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'someStack2'
     })
 
@@ -243,7 +246,8 @@ const test = async app => {
   await tap.test('Delete all Note_Tags associated with a Tag', async () => {
     // Create 1 tag, 2 notes, and add this tag to the notes
     const createdTag = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'another random stack'
     })
 
@@ -274,11 +278,13 @@ const test = async app => {
   await tap.test('Remove a valid tag from a valid note', async () => {
     // Create valid tags
     const tag1 = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'MyStack1'
     })
     const tag2 = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'MyStack2'
     })
 
@@ -332,7 +338,8 @@ const test = async app => {
 
   await tap.test('Delete a Note', async () => {
     const tag = await Tag.createTag(createdReader.id, {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'random name for tag'
     })
 

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -113,7 +113,8 @@ const test = async app => {
   }
 
   const createdTag = await Tag.createTag(urlToId(createdReader.id), {
-    type: 'reader:Stack',
+    type: 'reader:Tag',
+    tagType: 'reader:Stack',
     name: 'mystack'
   })
 
@@ -468,12 +469,14 @@ const test = async app => {
     async () => {
       // Create 2 additional tags for testing purposes
       const createdTag2 = await Tag.createTag(urlToId(createdReader.id), {
-        type: 'reader:Stack',
+        type: 'reader:Tag',
+        tagType: 'reader:Stack',
         name: 'mystack2'
       })
 
       const createdTag3 = await Tag.createTag(urlToId(createdReader.id), {
-        type: 'reader:Stack',
+        type: 'reader:Tag',
+        tagType: 'reader:Stack',
         name: 'mystack3'
       })
 
@@ -543,7 +546,8 @@ const test = async app => {
 
     // Add Tag to the publication
     const tagAdded = await Tag.createTag(urlToId(createdReader.id), {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'tagAdded'
     })
 

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -18,7 +18,8 @@ const test = async app => {
   }
 
   const tagObject = {
-    type: 'reader:Stack',
+    type: 'reader:Tag',
+    tagType: 'reader:Stack',
     name: 'mystack',
     json: { property: 1 }
   }
@@ -60,7 +61,8 @@ const test = async app => {
     await tap.ok(responseCreate)
     await tap.ok(responseCreate instanceof Tag)
     await tap.equal(responseCreate.readerId, createdReader.id)
-    await tap.equal(responseCreate.type, 'reader:Stack')
+    // await tap.equal(responseCreate.type, 'reader:Tag')
+    // await tap.equal(responseCreate.tagType, 'reader:Stack') // has not gone through the formatjson yet.
     await tap.equal(responseCreate.name, 'mystack')
     await tap.type(responseCreate.id, 'string')
     await tap.type(responseCreate.json, 'object')
@@ -78,12 +80,14 @@ const test = async app => {
   await tap.test('Delete Publication_Tags of a Tag', async () => {
     // Create 2 additional tags for testing purposes
     const createdTag2 = await Tag.createTag(urlToId(createdReader.id), {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'mystack2'
     })
 
     const createdTag3 = await Tag.createTag(urlToId(createdReader.id), {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'mystack3'
     })
 
@@ -122,7 +126,8 @@ const test = async app => {
     async () => {
       // Create 2 additional tags for testing purposes
       const createdTag4 = await Tag.createTag(urlToId(createdReader.id), {
-        type: 'reader:Stack',
+        type: 'reader:Tag',
+        tagType: 'reader:Stack',
         name: 'mystack4'
       })
 
@@ -150,7 +155,8 @@ const test = async app => {
     async () => {
       // Create 2 additional tags for testing purposes
       const createdTag5 = await Tag.createTag(urlToId(createdReader.id), {
-        type: 'reader:Stack',
+        type: 'reader:Tag',
+        tagType: 'reader:Stack',
         name: 'mystack5'
       })
 
@@ -174,7 +180,8 @@ const test = async app => {
 
   await tap.test('Delete tag by id', async () => {
     const newTagObject = {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'random stack name',
       json: { property: 1 }
     }
@@ -206,7 +213,8 @@ const test = async app => {
 
   await tap.test('Delete tag with an id that does not exist', async () => {
     const newTagObject = {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'random stack name',
       json: { property: 1 }
     }
@@ -220,7 +228,8 @@ const test = async app => {
 
   await tap.test('Delete tag with an invalid id', async () => {
     const newTagObject = {
-      type: 'reader:Stack',
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
       name: 'another random stack name',
       json: { property: 1 }
     }

--- a/tests/performance/addPubToCollection.test.js
+++ b/tests/performance/addPubToCollection.test.js
@@ -48,7 +48,7 @@ const test = async () => {
             { reader: 'https://rebus.foundation/ns/reader' }
           ],
           type: 'Add',
-          object: { id: tagId, type: 'reader:Stack' },
+          object: { id: tagId, type: 'reader:Tag', tagType: 'reader:Stack' },
           target: { id: publicationUrl, type: 'Publication' }
         })
       )
@@ -73,7 +73,7 @@ const test = async () => {
             { reader: 'https://rebus.foundation/ns/reader' }
           ],
           type: 'Remove',
-          object: { id: tagId, type: 'reader:Stack' },
+          object: { id: tagId, type: 'reader:Tag', tagType: 'reader:Stack' },
           target: { id: publicationUrl }
         })
       )

--- a/tests/performance/utils/createTags.js
+++ b/tests/performance/utils/createTags.js
@@ -22,7 +22,8 @@ const createTags = async (token, readerUrl, number = 1) => {
             ],
             type: 'Create',
             object: {
-              type: 'reader:Stack',
+              type: 'reader:Tag',
+              tagType: 'reader:Stack',
               name: crypto.randomBytes(8).toString('hex')
             }
           })


### PR DESCRIPTION
Warning: this is a breaking change.

Before, tag objects had a property type equal to 'reader:Stack'

Now: 
{
type: 'reader:Tag',
tagType: 'reader:Stack' // or anything else
...
}
We are still enforcing uniqueness of tagType + name + readerId

When adding / removing a tag-note or tag-publication link, the object should be: 
{ 
type: 'reader:Tag'
id: tagId
}
no need to specify the tagType
Same for deleting a Tag (or updating a Tag, which is not yet implemented)


