### PR TITLE
Temporary fix for library filters

### DIFF
--- a/models/Reader.js
+++ b/models/Reader.js
@@ -62,86 +62,191 @@ class Reader extends BaseModel {
     offset = !offset ? 0 : offset
     const qb = Reader.query(Reader.knex()).where('Reader.id', '=', readerId)
 
-    const orderBuilder = builder => {
-      if (filter.orderBy === 'title') {
-        if (filter.reverse) {
-          builder.orderBy('name', 'desc')
-        } else {
-          builder.orderBy('name')
-        }
-      } else if (filter.orderBy === 'datePublished') {
-        if (filter.reverse) {
-          builder.orderByRaw('"datePublished" NULLS FIRST')
-        } else {
-          builder.orderByRaw('"datePublished" DESC NULLS LAST')
-        }
-      } else {
-        if (filter.reverse) {
-          builder.orderBy('updated')
-        } else {
-          builder.orderBy('updated', 'desc')
-        }
-      }
-    }
-
-    if (filter.author || filter.attribution) {
-      let author, attribution
-      if (filter.author) author = Attribution.normalizeName(filter.author)
-      if (filter.attribution) {
-        attribution = Attribution.normalizeName(filter.attribution)
-      }
-
+    if (!filter.author && !filter.attribution && !filter.collection) {
       const readers = await qb
-        .skipUndefined()
-        .eager('[tags, publications]')
+        .eager('[tags, publications.[tags, attributions]]')
         .modifyEager('publications', builder => {
           if (filter.title) {
-            const title = filter.title.toLowerCase()
-            builder.where('Publication.name', 'like', `%${title}%`)
-          }
-          builder.leftJoin(
-            'Attribution',
-            'Attribution.publicationId',
-            '=',
-            'Publication.id'
-          )
-          if (filter.author) {
-            builder
-              .where('Attribution.normalizedName', '=', author)
-              .andWhere('Attribution.role', '=', 'author')
-          }
-          if (filter.attribution) {
-            builder.where(
-              'Attribution.normalizedName',
-              'like',
-              `%${attribution}%`
+            builder.whereRaw(
+              'LOWER(name) LIKE ?',
+              '%' + filter.title.toLowerCase() + '%'
             )
-            if (filter.role) {
-              builder.andWhere('Attribution.role', '=', filter.role)
+          }
+          if (filter.orderBy === 'title') {
+            if (filter.reverse) {
+              builder.orderBy('name', 'desc')
+            } else {
+              builder.orderBy('name')
+            }
+          } else if (filter.orderBy === 'datePublished') {
+            if (filter.reverse) {
+              builder.orderByRaw('"datePublished" NULLS FIRST')
+            } else {
+              builder.orderByRaw('"datePublished" DESC NULLS LAST')
+            }
+          } else {
+            if (filter.reverse) {
+              builder.orderBy('updated')
+            } else {
+              builder.orderBy('updated', 'desc')
             }
           }
-          builder.eager('[tags, attributions]')
-          orderBuilder(builder)
-          builder.limit(limit)
-          builder.offset(offset)
+          builder.limit(limit).offset(offset)
         })
-
       return readers[0]
     }
 
-    const readers = await qb
-      .eager('[tags, publications.[tags, attributions]]')
-      .modifyEager('publications', builder => {
-        if (filter.title) {
-          builder.whereRaw(
-            'LOWER(name) LIKE ?',
-            '%' + filter.title.toLowerCase() + '%'
-          )
-        }
-        orderBuilder(builder)
-        builder.limit(limit).offset(offset)
+    // temporary fix. TODO: make this into a SQL query
+    const readers = await qb.eager('[tags, publications.[tags, attributions]]')
+    if (!readers[0]) return null
+    let publications = readers[0].publications
+    if (filter.author) {
+      const author = Attribution.normalizeName(filter.author)
+      publications = publications.filter(pub => {
+        return !!_.find(pub.attributions, {
+          normalizedName: author,
+          role: 'author'
+        })
       })
+    }
+    if (filter.attribution && filter.role) {
+      const attribution = Attribution.normalizeName(filter.attribution)
+      publications = publications.filter(pub => {
+        return !!_.find(pub.attributions, attr => {
+          return (
+            attr.normalizedName.includes(attribution) &&
+            attr.role === filter.role
+          )
+        })
+      })
+    } else if (filter.attribution) {
+      const attribution = Attribution.normalizeName(filter.attribution)
+      publications = publications.filter(pub => {
+        return !!_.find(pub.attributions, attr => {
+          return attr.normalizedName.includes(attribution)
+        })
+      })
+    }
+
+    // other filters
+    if (filter.title) {
+      publications = publications.filter(pub => {
+        return pub.name.toLowerCase().includes(filter.title.toLowerCase())
+      })
+    }
+
+    if (filter.collection) {
+      publications = publications.filter(pub => {
+        return !!_.find(pub.tags, {
+          name: filter.collection,
+          type: 'reader:Stack'
+        })
+      })
+    }
+
+    // order
+    if (filter.orderBy === 'title') {
+      if (filter.reverse) {
+        publications = _.orderBy(
+          publications,
+          pub => {
+            return pub.name.toLowerCase()
+          },
+          ['desc']
+        )
+      } else {
+        publications = _.orderBy(
+          publications,
+          pub => {
+            return pub.name.toLowerCase()
+          },
+          ['asc']
+        )
+      }
+    } else if (filter.orderBy === 'datePublished') {
+      if (filter.reverse) {
+        publications = _.orderBy(
+          publications,
+          [
+            o => {
+              return o.datePublished === null ? -1 : 1
+            },
+            'datePublished'
+          ],
+          ['asc']
+        )
+      } else {
+        publications = _.orderBy(
+          publications,
+          [o => o.datePublished || ''],
+          ['desc']
+        )
+      }
+    } else {
+      if (filter.reverse) {
+        publications = _.orderBy(publications, ['updated'], ['asc'])
+      } else {
+        publications = _.orderBy(publications, ['updated'], ['desc'])
+      }
+    }
+
+    // paginate
+    publications = _.take(_.drop(publications, offset), limit)
+
+    readers[0].publications = publications
+
     return readers[0]
+
+    // This was almost working. Almost.
+    // if (filter.author || filter.attribution || filter.collection) {
+    //   let author, attribution
+    //   if (filter.author) author = Attribution.normalizeName(filter.author)
+    //   if (filter.attribution) {
+    //     attribution = Attribution.normalizeName(filter.attribution)
+    //   }
+
+    //   const readers = await qb
+    //     .skipUndefined()
+    //     .eager('[tags, publications]')
+    //     .modifyEager('publications', builder => {
+    //       if (filter.title) {
+    //         const title = filter.title.toLowerCase()
+    //         builder.where('Publication.name', 'like', `%${title}%`)
+    //       }
+    //       builder.leftJoin(
+    //         'Attribution',
+    //         'Attribution.publicationId',
+    //         '=',
+    //         'Publication.id'
+    //       )
+    //       if (filter.author) {
+    //         builder
+    //           .where('Attribution.normalizedName', '=', author)
+    //           .andWhere('Attribution.role', '=', 'author')
+    //       }
+    //       if (filter.attribution) {
+    //         builder.where(
+    //           'Attribution.normalizedName',
+    //           'like',
+    //           `%${attribution}%`
+    //         )
+    //         if (filter.role) {
+    //           builder.andWhere('Attribution.role', '=', filter.role)
+    //         }
+    //       }
+    //       builder.eager('[tags, attributions]')
+    //       if (filter.collection) {
+    //         builder
+    //           .where('Tag.name', '=', filter.collection)
+    //           .andWhere('Tag.type', '=', 'reader:Stack')
+    //       }
+    //       orderBuilder(builder)
+    //       builder.limit(limit)
+    //       builder.offset(offset)
+    //     })
+
+    //   return readers[0]
+    // }
   }
 
   static async checkIfExistsByAuthId (

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -66,6 +66,7 @@ class Reader extends BaseModel {
       const readers = await qb
         .eager('[tags, publications.[tags, attributions]]')
         .modifyEager('publications', builder => {
+          builder.whereNull('deleted')
           if (filter.title) {
             builder.whereRaw(
               'LOWER(name) LIKE ?',
@@ -100,6 +101,7 @@ class Reader extends BaseModel {
     const readers = await qb.eager('[tags, publications.[tags, attributions]]')
     if (!readers[0]) return null
     let publications = readers[0].publications
+    publications = publications.filter(pub => !pub.deleted)
     if (filter.author) {
       const author = Attribution.normalizeName(filter.author)
       publications = publications.filter(pub => {

--- a/routes/middleware/error-handling.js
+++ b/routes/middleware/error-handling.js
@@ -7,6 +7,7 @@ const errorHandling = (err, req, res, next) => {
     } else if (err.statusCode) {
       return res.status(err.statusCode).json(err.data)
     }
+    console.log(err)
     return res.status(500).send(err)
   }
 }

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -209,17 +209,17 @@ module.exports = app => {
               'Content-Type',
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
-            let publications = reader.publications.filter(pub => !pub.deleted)
-            if (req.query.stack) {
-              publications = publications.filter(pub => {
-                const result = _.find(pub.tags, tag => {
-                  return (
-                    tag.type === 'reader:Stack' && tag.name === req.query.stack
-                  )
-                })
-                return result
-              })
-            }
+            let publications = reader.publications.filter(pub => !pub.deleted) // TODO: move to database query
+            // if (req.query.stack) {
+            //   publications = publications.filter(pub => {
+            //     const result = _.find(pub.tags, tag => {
+            //       return (
+            //         tag.type === 'reader:Stack' && tag.name === req.query.stack
+            //       )
+            //     })
+            //     return result
+            //   })
+            // }
             res.end(
               JSON.stringify({
                 '@context': 'https://www.w3.org/ns/activitystreams',

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -4,7 +4,6 @@ const passport = require('passport')
 const { Reader } = require('../models/Reader')
 const { getId } = require('../utils/get-id.js')
 const utils = require('../utils/utils')
-const _ = require('lodash')
 const paginate = require('./middleware/paginate')
 const boom = require('@hapi/boom')
 
@@ -209,17 +208,6 @@ module.exports = app => {
               'Content-Type',
               'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
             )
-            let publications = reader.publications.filter(pub => !pub.deleted) // TODO: move to database query
-            // if (req.query.stack) {
-            //   publications = publications.filter(pub => {
-            //     const result = _.find(pub.tags, tag => {
-            //       return (
-            //         tag.type === 'reader:Stack' && tag.name === req.query.stack
-            //       )
-            //     })
-            //     return result
-            //   })
-            // }
             res.end(
               JSON.stringify({
                 '@context': 'https://www.w3.org/ns/activitystreams',
@@ -228,8 +216,8 @@ module.exports = app => {
                 },
                 type: 'Collection',
                 id: getId(`/reader-${id}/library`),
-                totalItems: publications.length,
-                items: publications.map(pub => pub.asRef()),
+                totalItems: reader.publications.length,
+                items: reader.publications.map(pub => pub.asRef()),
                 tags: reader.tags,
                 page: req.query.page,
                 pageSize: parseInt(req.query.limit)

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -82,7 +82,7 @@ const test = async () => {
 
     stack = stackActivityObject.object
     // assign mystack to publication B
-    await addPubToCollection(app, token, readerUrl, publicaiton.id, stack.id)
+    await addPubToCollection(app, token, readerUrl, publication.id, stack.id)
 
     // get library with filter for collection
     const res = await request(app)
@@ -94,7 +94,6 @@ const test = async () => {
       )
 
     await tap.equal(res.statusCode, 200)
-
     const body = res.body
     await tap.type(body, 'object')
     await tap.equal(body.totalItems, 1)
@@ -104,10 +103,10 @@ const test = async () => {
   })
 
   await tap.test('should work with pagination', async () => {
-    await createPublicationSimplified({ name: 'Publication 4' })
+    await createPublicationSimplified({ name: 'Publication 4 test' })
     await createPublicationSimplified({ name: 'Publication 5' })
     await createPublicationSimplified({ name: 'Publication 6' })
-    await createPublicationSimplified({ name: 'Publication 7' })
+    await createPublicationSimplified({ name: 'Publication 7 test' })
     await createPublicationSimplified({ name: 'Publication 8' })
     await createPublicationSimplified({ name: 'Publication 9' })
     await createPublicationSimplified({ name: 'Publication 10' })
@@ -128,7 +127,7 @@ const test = async () => {
     const pubId1 = library[0].id
     const pubId2 = library[1].id
     const pubId3 = library[2].id
-    const pubId4 = library[3].id // 5
+    const pubId4 = library[3].id
     const pubId5 = library[4].id
     const pubId6 = library[5].id
     // skipping 7
@@ -566,6 +565,20 @@ const test = async () => {
     const body = res.body
     await tap.equal(body.totalItems, 4)
     await tap.equal(body.items.length, 4)
+  })
+
+  await tap.test('filter by collection and title', async () => {
+    const res = await request(app)
+      .get(`${readerUrl}/library?stack=mystack&title=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    const body = res.body
+    await tap.equal(body.totalItems, 1)
+    await tap.equal(body.items.length, 1)
   })
 
   if (!process.env.POSTGRE_INSTANCE) {

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -200,6 +200,27 @@ const createActivity = async (app, token, readerUrl, object = {}) => {
     .send(JSON.stringify(activityObject))
 }
 
+const addPubToCollection = async (app, token, readerUrl, pubId, tagId) => {
+  return await request(app)
+    .post(`${readerUrl}/activity`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type(
+      'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+    )
+    .send(
+      JSON.stringify({
+        '@context': [
+          'https://www.w3.org/ns/activitystreams',
+          { reader: 'https://rebus.foundation/ns/reader' }
+        ],
+        type: 'Add',
+        object: { id: tagId, type: 'reader:Tag' },
+        target: { id: pubId, type: 'Publication' }
+      })
+    )
+}
+
 module.exports = {
   getToken,
   createUser,
@@ -207,5 +228,6 @@ module.exports = {
   getActivityFromUrl,
   createPublication,
   createNote,
-  createActivity
+  createActivity,
+  addPubToCollection
 }


### PR DESCRIPTION
This moves most of the filtering for library to after the database query. It is not ideal, but will eventually be fixed. 
For now, it means that filters work properly.

I also noticed that I was still filtering for collection and filtering out deleted publications after the database query, which would have caused problems with pagination. This fixes that. 
