### PR TITLE
loading reader notes now also includes publication information

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -83,7 +83,7 @@ class Note extends BaseModel {
           to: 'Document.id'
         }
       },
-      context: {
+      publication: {
         relation: Model.BelongsToOneRelation,
         modelClass: Publication,
         join: {

--- a/tests/integration/readerNotes-get.test.js
+++ b/tests/integration/readerNotes-get.test.js
@@ -93,6 +93,11 @@ const test = async app => {
     await tap.equal(body.items.length, 3)
     await tap.equal(body.items[0].type, 'Note')
     await tap.ok(body.items[0]['oa:hasSelector'])
+    // notes should include publication information
+    await tap.ok(body.items[0].publication)
+    await tap.type(body.items[0].publication.name, 'string')
+    await tap.ok(body.items[0].publication.author)
+    await tap.type(body.items[0].publication.author[0].name, 'string')
   })
 
   await tap.test(


### PR DESCRIPTION
changes for route /reader-:id/notes: each note will now have a .publication property which includes name, author, and other metadata. 

