### PR TITLE
Database queries fixed!

### DIFF
--- a/models/Publication.js
+++ b/models/Publication.js
@@ -130,11 +130,6 @@ class Publication extends BaseModel {
     }
   }
 
-  asRef () /*: any */ {
-    const pub = this.toJSON()
-    return _.omit(pub, ['resources', 'readingOrder', 'links', 'json'])
-  }
-
   static async createPublication (
     reader /*: any */,
     publication /*: any */

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -72,7 +72,20 @@ class Reader extends BaseModel {
       .skipUndefined()
       .eager('[tags, publications]')
       .modifyEager('publications', builder => {
-        builder.select('Publication.*').from('Publication')
+        builder
+          .select(
+            'Publication.id',
+            'Publication.description',
+            'Publication.metadata',
+            'Publication.name',
+            'Publication.datePublished',
+            'Publication.json',
+            'Publication.readerId',
+            'Publication.published',
+            'Publication.updated',
+            'Publication.deleted'
+          )
+          .from('Publication')
         builder.distinct('Publication.id')
         builder.whereNull('Publication.deleted')
         if (filter.title) {

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -175,6 +175,7 @@ class Reader extends BaseModel {
       .modifyEager('replies', builder => {
         // load details of parent publication for each note
         builder.modifyEager('publication', pubBuilder => {
+          pubBuilder.whereNull('Publication.deleted')
           pubBuilder.select(
             'id',
             'name',
@@ -183,6 +184,7 @@ class Reader extends BaseModel {
             'metadata'
           )
         })
+        builder.whereNull('Note.deleted')
 
         // filters
         if (filters.publication) {
@@ -199,6 +201,15 @@ class Reader extends BaseModel {
             'LOWER(content) LIKE ?',
             '%' + filters.search.toLowerCase() + '%'
           )
+        }
+
+        builder.leftJoin('note_tag', 'note_tag.noteId', '=', 'Note.id')
+        builder.leftJoin('Tag', 'note_tag.tagId', '=', 'Tag.id')
+        builder.whereNull('Tag.deleted')
+        if (filters.collection) {
+          builder
+            .where('Tag.name', '=', filters.collection)
+            .andWhere('Tag.type', '=', 'reader:Stack')
         }
 
         // orderBy

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -92,6 +92,7 @@ class Reader extends BaseModel {
           'Publication.id'
         )
         builder.leftJoin('Tag', 'publication_tag.tagId', '=', 'Tag.id')
+        builder.whereNull('Tag.deleted')
         if (filter.author) {
           builder
             .where('Attribution.normalizedName', '=', author)

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -62,193 +62,215 @@ class Reader extends BaseModel {
     offset = !offset ? 0 : offset
     const qb = Reader.query(Reader.knex()).where('Reader.id', '=', readerId)
 
-    if (!filter.author && !filter.attribution && !filter.collection) {
-      const readers = await qb
-        .eager('[tags, publications.[tags, attributions]]')
-        .modifyEager('publications', builder => {
-          builder.whereNull('deleted')
-          if (filter.title) {
-            builder.whereRaw(
-              'LOWER(name) LIKE ?',
-              '%' + filter.title.toLowerCase() + '%'
-            )
-          }
-          if (filter.orderBy === 'title') {
-            if (filter.reverse) {
-              builder.orderBy('name', 'desc')
-            } else {
-              builder.orderBy('name')
-            }
-          } else if (filter.orderBy === 'datePublished') {
-            if (filter.reverse) {
-              builder.orderByRaw('"datePublished" NULLS FIRST')
-            } else {
-              builder.orderByRaw('"datePublished" DESC NULLS LAST')
-            }
-          } else {
-            if (filter.reverse) {
-              builder.orderBy('updated')
-            } else {
-              builder.orderBy('updated', 'desc')
-            }
-          }
-          builder.limit(limit).offset(offset)
-        })
-      return readers[0]
-    }
-
-    // temporary fix. TODO: make this into a SQL query
-    const readers = await qb.eager('[tags, publications.[tags, attributions]]')
-    if (!readers[0]) return null
-    let publications = readers[0].publications
-    publications = publications.filter(pub => !pub.deleted)
-    if (filter.author) {
-      const author = Attribution.normalizeName(filter.author)
-      publications = publications.filter(pub => {
-        return !!_.find(pub.attributions, {
-          normalizedName: author,
-          role: 'author'
-        })
-      })
-    }
-    if (filter.attribution && filter.role) {
-      const attribution = Attribution.normalizeName(filter.attribution)
-      publications = publications.filter(pub => {
-        return !!_.find(pub.attributions, attr => {
-          return (
-            attr.normalizedName.includes(attribution) &&
-            attr.role === filter.role
-          )
-        })
-      })
-    } else if (filter.attribution) {
-      const attribution = Attribution.normalizeName(filter.attribution)
-      publications = publications.filter(pub => {
-        return !!_.find(pub.attributions, attr => {
-          return attr.normalizedName.includes(attribution)
-        })
-      })
-    }
-
-    // other filters
-    if (filter.title) {
-      publications = publications.filter(pub => {
-        return pub.name.toLowerCase().includes(filter.title.toLowerCase())
-      })
-    }
-
-    if (filter.collection) {
-      publications = publications.filter(pub => {
-        return !!_.find(pub.tags, {
-          name: filter.collection,
-          type: 'reader:Stack'
-        })
-      })
-    }
-
-    // order
-    if (filter.orderBy === 'title') {
-      if (filter.reverse) {
-        publications = _.orderBy(
-          publications,
-          pub => {
-            return pub.name.toLowerCase()
-          },
-          ['desc']
-        )
-      } else {
-        publications = _.orderBy(
-          publications,
-          pub => {
-            return pub.name.toLowerCase()
-          },
-          ['asc']
-        )
-      }
-    } else if (filter.orderBy === 'datePublished') {
-      if (filter.reverse) {
-        publications = _.orderBy(
-          publications,
-          [
-            o => {
-              return o.datePublished === null ? -1 : 1
-            },
-            'datePublished'
-          ],
-          ['asc']
-        )
-      } else {
-        publications = _.orderBy(
-          publications,
-          [o => o.datePublished || ''],
-          ['desc']
-        )
-      }
-    } else {
-      if (filter.reverse) {
-        publications = _.orderBy(publications, ['updated'], ['asc'])
-      } else {
-        publications = _.orderBy(publications, ['updated'], ['desc'])
-      }
-    }
-
-    // paginate
-    publications = _.take(_.drop(publications, offset), limit)
-
-    readers[0].publications = publications
-
-    return readers[0]
+    //  if (!filter.author && !filter.attribution && !filter.collection) {
+    // const readers = await qb
+    //   .eager('[tags, publications.[tags, attributions]]')
+    //   .modifyEager('publications', builder => {
+    //     builder.whereNull('deleted')
+    //     builder.joinRelation('attributions')
+    //     if (filter.title) {
+    //       builder.whereRaw(
+    //         'LOWER(name) LIKE ?',
+    //         '%' + filter.title.toLowerCase() + '%'
+    //       )
+    //     }
+    //     if (filter.orderBy === 'title') {
+    //       if (filter.reverse) {
+    //         builder.orderBy('name', 'desc')
+    //       } else {
+    //         builder.orderBy('name')
+    //       }
+    //     } else if (filter.orderBy === 'datePublished') {
+    //       if (filter.reverse) {
+    //         builder.orderByRaw('"datePublished" NULLS FIRST')
+    //       } else {
+    //         builder.orderByRaw('"datePublished" DESC NULLS LAST')
+    //       }
+    //     } else {
+    //       if (filter.reverse) {
+    //         builder.orderBy('updated')
+    //       } else {
+    //         builder.orderBy('updated', 'desc')
+    //       }
+    //     }
+    //     builder.limit(limit).offset(offset)
+    //   })
+    // return readers[0]
+    //  }
 
     // This was almost working. Almost.
-    // if (filter.author || filter.attribution || filter.collection) {
-    //   let author, attribution
-    //   if (filter.author) author = Attribution.normalizeName(filter.author)
-    //   if (filter.attribution) {
-    //     attribution = Attribution.normalizeName(filter.attribution)
-    //   }
+    //   if (filter.author || filter.attribution || filter.collection) {
+    let author, attribution
+    if (filter.author) author = Attribution.normalizeName(filter.author)
+    if (filter.attribution) {
+      attribution = Attribution.normalizeName(filter.attribution)
+    }
 
-    //   const readers = await qb
-    //     .skipUndefined()
-    //     .eager('[tags, publications]')
-    //     .modifyEager('publications', builder => {
-    //       if (filter.title) {
-    //         const title = filter.title.toLowerCase()
-    //         builder.where('Publication.name', 'like', `%${title}%`)
-    //       }
-    //       builder.leftJoin(
-    //         'Attribution',
-    //         'Attribution.publicationId',
-    //         '=',
-    //         'Publication.id'
-    //       )
-    //       if (filter.author) {
-    //         builder
-    //           .where('Attribution.normalizedName', '=', author)
-    //           .andWhere('Attribution.role', '=', 'author')
-    //       }
-    //       if (filter.attribution) {
-    //         builder.where(
-    //           'Attribution.normalizedName',
-    //           'like',
-    //           `%${attribution}%`
-    //         )
-    //         if (filter.role) {
-    //           builder.andWhere('Attribution.role', '=', filter.role)
-    //         }
-    //       }
-    //       builder.eager('[tags, attributions]')
-    //       if (filter.collection) {
-    //         builder
-    //           .where('Tag.name', '=', filter.collection)
-    //           .andWhere('Tag.type', '=', 'reader:Stack')
-    //       }
-    //       orderBuilder(builder)
-    //       builder.limit(limit)
-    //       builder.offset(offset)
-    //     })
+    const readers = await qb
+      .skipUndefined()
+      .eager('[tags, publications]')
+      .modifyEager('publications', builder => {
+        builder.select('Publication.*').from('Publication')
+        builder.distinct('Publication.id')
+        if (filter.title) {
+          const title = filter.title.toLowerCase()
+          builder.where('Publication.name', 'ilike', `%${title}%`)
+        }
+        builder.leftJoin(
+          'Attribution',
+          'Attribution.publicationId',
+          '=',
+          'Publication.id'
+        )
+        // builder.joinRelation('tags')
+        if (filter.author) {
+          builder
+            .where('Attribution.normalizedName', '=', author)
+            .andWhere('Attribution.role', '=', 'author')
+        }
+        if (filter.attribution) {
+          builder.where(
+            'Attribution.normalizedName',
+            'like',
+            `%${attribution}%`
+          )
+          if (filter.role) {
+            builder.andWhere('Attribution.role', '=', filter.role)
+          }
+        }
+        builder.eager('[tags, attributions]')
+        // if (filter.collection) {
+        //   builder
+        //     .where('Tag.name', '=', filter.collection)
+        //     .andWhere('Tag.type', '=', 'reader:Stack')
+        // }
+        if (filter.orderBy === 'title') {
+          if (filter.reverse) {
+            builder.orderBy('name', 'desc')
+          } else {
+            builder.orderBy('name')
+          }
+        } else if (filter.orderBy === 'datePublished') {
+          if (filter.reverse) {
+            builder.orderByRaw('"datePublished" NULLS FIRST')
+          } else {
+            builder.orderByRaw('"datePublished" DESC NULLS LAST')
+          }
+        } else {
+          if (filter.reverse) {
+            builder.orderBy('updated')
+          } else {
+            builder.orderBy('updated', 'desc')
+          }
+        }
+        builder.limit(limit)
+        builder.offset(offset)
+      })
 
-    //   return readers[0]
+    return readers[0]
     // }
+
+    // temporary fix. TODO: make this into a SQL query
+    // const readers = await qb.eager('[tags, publications.[tags, attributions]]')
+    // if (!readers[0]) return null
+    // let publications = readers[0].publications
+    // publications = publications.filter(pub => !pub.deleted)
+    // if (filter.author) {
+    //   const author = Attribution.normalizeName(filter.author)
+    //   publications = publications.filter(pub => {
+    //     return !!_.find(pub.attributions, {
+    //       normalizedName: author,
+    //       role: 'author'
+    //     })
+    //   })
+    // }
+    // if (filter.attribution && filter.role) {
+    //   const attribution = Attribution.normalizeName(filter.attribution)
+    //   publications = publications.filter(pub => {
+    //     return !!_.find(pub.attributions, attr => {
+    //       return (
+    //         attr.normalizedName.includes(attribution) &&
+    //         attr.role === filter.role
+    //       )
+    //     })
+    //   })
+    // } else if (filter.attribution) {
+    //   const attribution = Attribution.normalizeName(filter.attribution)
+    //   publications = publications.filter(pub => {
+    //     return !!_.find(pub.attributions, attr => {
+    //       return attr.normalizedName.includes(attribution)
+    //     })
+    //   })
+    // }
+
+    // // other filters
+    // if (filter.title) {
+    //   publications = publications.filter(pub => {
+    //     return pub.name.toLowerCase().includes(filter.title.toLowerCase())
+    //   })
+    // }
+
+    // if (filter.collection) {
+    //   publications = publications.filter(pub => {
+    //     return !!_.find(pub.tags, {
+    //       name: filter.collection,
+    //       type: 'reader:Stack'
+    //     })
+    //   })
+    // }
+
+    // // order
+    // if (filter.orderBy === 'title') {
+    //   if (filter.reverse) {
+    //     publications = _.orderBy(
+    //       publications,
+    //       pub => {
+    //         return pub.name.toLowerCase()
+    //       },
+    //       ['desc']
+    //     )
+    //   } else {
+    //     publications = _.orderBy(
+    //       publications,
+    //       pub => {
+    //         return pub.name.toLowerCase()
+    //       },
+    //       ['asc']
+    //     )
+    //   }
+    // } else if (filter.orderBy === 'datePublished') {
+    //   if (filter.reverse) {
+    //     publications = _.orderBy(
+    //       publications,
+    //       [
+    //         o => {
+    //           return o.datePublished === null ? -1 : 1
+    //         },
+    //         'datePublished'
+    //       ],
+    //       ['asc']
+    //     )
+    //   } else {
+    //     publications = _.orderBy(
+    //       publications,
+    //       [o => o.datePublished || ''],
+    //       ['desc']
+    //     )
+    //   }
+    // } else {
+    //   if (filter.reverse) {
+    //     publications = _.orderBy(publications, ['updated'], ['asc'])
+    //   } else {
+    //     publications = _.orderBy(publications, ['updated'], ['desc'])
+    //   }
+    // }
+
+    // // paginate
+    // publications = _.take(_.drop(publications, offset), limit)
+
+    // readers[0].publications = publications
+
+    // return readers[0]
   }
 
   static async checkIfExistsByAuthId (

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -83,7 +83,8 @@ class Reader extends BaseModel {
             'Publication.readerId',
             'Publication.published',
             'Publication.updated',
-            'Publication.deleted'
+            'Publication.deleted',
+            'Publication.resources'
           )
           .from('Publication')
         builder.distinct('Publication.id')

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -40,6 +40,10 @@ const boom = require('@hapi/boom')
  *           format: url
  *       json:
  *         type: object
+ *       resources:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/link'
  *       description:
  *         type: string
  *       datePublished:

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -38,6 +38,8 @@ const boom = require('@hapi/boom')
  *         items:
  *           type: string
  *           format: url
+ *       json:
+ *         type: object
  *       description:
  *         type: string
  *       datePublished:
@@ -217,7 +219,7 @@ module.exports = app => {
                 type: 'Collection',
                 id: getId(`/reader-${id}/library`),
                 totalItems: reader.publications.length,
-                items: reader.publications.map(pub => pub.asRef()),
+                items: reader.publications,
                 tags: reader.tags,
                 page: req.query.page,
                 pageSize: parseInt(req.query.limit)

--- a/routes/reader-notes.js
+++ b/routes/reader-notes.js
@@ -132,6 +132,11 @@ module.exports = app => {
    *           type: string
    *         description: keyword to search for in the content of notes. Not case sensitive.
    *       - in: query
+   *         name: stack
+   *         schema:
+   *           type: string
+   *         description: the collection (tag with type 'reader:Stack')
+   *       - in: query
    *         name: orderBy
    *         schema:
    *           type: string
@@ -171,7 +176,8 @@ module.exports = app => {
         type: req.query.type,
         search: req.query.search,
         orderBy: req.query.orderBy,
-        reverse: req.query.reverse
+        reverse: req.query.reverse,
+        collection: req.query.stack
       }
       Reader.getNotes(id, req.query.limit, req.skip, filters)
         .then(reader => {

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -26,6 +26,7 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
+    console.log(res.error)
     await tap.equal(res.status, 200)
 
     const body = res.body
@@ -69,6 +70,7 @@ const test = async () => {
     await tap.type(body['@context'], 'string')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
+    console.log(body.items)
     await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     // documents should include:

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -80,8 +80,8 @@ const test = async () => {
     await tap.equal(body.items[0].editor[0].name, 'Jane Doe')
     await tap.equal(body.items[0].keywords, 'one, two')
     await tap.ok(body.items[0].json)
+    await tap.ok(body.items[0].resources)
     // documents should NOT include:
-    await tap.notOk(body.items[0].resources)
     await tap.notOk(body.items[0].readingOrder)
     await tap.notOk(body.items[0].links)
   })

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -26,7 +26,6 @@ const test = async () => {
       .type(
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
-    console.log(res.error)
     await tap.equal(res.status, 200)
 
     const body = res.body
@@ -70,7 +69,6 @@ const test = async () => {
     await tap.type(body['@context'], 'string')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    console.log(body.items)
     await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     // documents should include:

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -79,11 +79,11 @@ const test = async () => {
     await tap.equal(body.items[0].author[0].name, 'John Smith')
     await tap.equal(body.items[0].editor[0].name, 'Jane Doe')
     await tap.equal(body.items[0].keywords, 'one, two')
+    await tap.ok(body.items[0].json)
     // documents should NOT include:
     await tap.notOk(body.items[0].resources)
     await tap.notOk(body.items[0].readingOrder)
     await tap.notOk(body.items[0].links)
-    await tap.notOk(body.items[0].json)
   })
 
   await tap.test(

--- a/tests/integration/readerNotes-filter.test.js
+++ b/tests/integration/readerNotes-filter.test.js
@@ -8,7 +8,9 @@ const {
   getActivityFromUrl,
   createPublication,
   createNote,
-  createDocument
+  createDocument,
+  createTag,
+  addNoteToCollection
 } = require('../utils/utils')
 const { urlToId } = require('../../utils/utils')
 
@@ -91,6 +93,8 @@ const test = async app => {
     inReplyTo: documentUrl2
   })
 
+  let noteId1, noteId2, noteId3
+
   // --------------------------------------------- PUBLICATION -----------------------------------
 
   await tap.test('Filter Notes by Publication', async () => {
@@ -108,6 +112,8 @@ const test = async app => {
     await tap.equal(body.totalItems, 2)
     await tap.equal(body.items.length, 2)
     await tap.equal(body.items[0].type, 'Note')
+
+    noteId1 = body.items[0].id
   })
 
   await createNoteSimplified({
@@ -167,6 +173,9 @@ const test = async app => {
     await tap.equal(res2.status, 200)
     await tap.equal(res2.body.totalItems, 10)
     await tap.equal(res2.body.items.length, 10)
+
+    noteId2 = res2.body.items[3].id
+    noteId3 = res2.body.items[5].id
 
     const res3 = await request(app)
       .get(`${readerUrl}/notes?page=2&publication=${urlToId(publicationUrl2)}`)
@@ -344,9 +353,9 @@ const test = async app => {
   const tagId = tagActivityObject.object.id
 
   // add 3 notes to this collection
-  await addNoteToCollection(app, token, readerUrl, noteId1, tagId)
-  await addNoteToCollection(app, token, readerUrl, noteId2, tagId)
-  await addNoteToCollection(app, token, readerUrl, noteId3, tagId)
+  await addNoteToCollection(app, token, readerUrl, urlToId(noteId1), tagId)
+  await addNoteToCollection(app, token, readerUrl, urlToId(noteId2), tagId)
+  await addNoteToCollection(app, token, readerUrl, urlToId(noteId3), tagId)
 
   await tap.test('Get Notes by Collection', async () => {
     const res = await request(app)

--- a/tests/integration/readerNotes-filter.test.js
+++ b/tests/integration/readerNotes-filter.test.js
@@ -331,6 +331,37 @@ const test = async app => {
     await tap.equal(res.body.items.length, 4)
   })
 
+  // --------------------------------------------- COLLECTION ---------------------------------------
+
+  const tagCreateRes = await createTag(app, token, readerUrl, {
+    name: 'testCollection'
+  })
+  const tagActivityObject = await getActivityFromUrl(
+    app,
+    tagCreateRes.get('Location'),
+    token
+  )
+  const tagId = tagActivityObject.object.id
+
+  // add 3 notes to this collection
+  await addNoteToCollection(app, token, readerUrl, noteId1, tagId)
+  await addNoteToCollection(app, token, readerUrl, noteId2, tagId)
+  await addNoteToCollection(app, token, readerUrl, noteId3, tagId)
+
+  await tap.test('Get Notes by Collection', async () => {
+    const res = await request(app)
+      .get(`${readerUrl}/notes?stack=testCollection`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.items.length, 3)
+  })
+
   // ----------------------------------- COMBINING FILTERS -----------------------------------
 
   await tap.test('Filter Notes by noteType and PubId', async () => {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -158,10 +158,6 @@ const test = async app => {
     await tap.ok(publication.reader instanceof Reader)
   })
 
-  await tap.test('Publication asRef', async () => {
-    // asRef is broken. Will fix the test and the code in another PR
-  })
-
   await tap.test('Publication addTag', async () => {
     const res = await Publication_Tag.addTagToPub(
       urlToId(publication.id),


### PR DESCRIPTION
Finally managed to fix those database queries. :tada: 
From a user's perspective it shouldn't make much of a difference, except by possibly being more efficient.

What I changed:
all queries for the library are handled in a single database query. No more fetching everything and filtering after the fact.
I also made it so that it wont return deleted publications. (before the filtering out of deleted publication was done after the database query, which could mess up pagination)

the readerNotes route now has a 'stack' filter, just like the library. 
`/reader:-{id}/notes?stack=mycollection`

I have removed the publication.asRef method. It was only used for the library, so I changed the database query to only get the fields we want. The only change there that would be visible to the user is that I have now left the json property. So publications in the library are publication objects without links, readingOrder and resources. Everything else is there. 

the readerNotes route still sends the entire notes objects. That can change if some properties are not needed. 
