### PR TITLE
Trying to fix totalItems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ repos:
   RebusFoundation/reader-api:
     endpoint: https://api.travis-ci.org/
 addons:
-  postgresql: '9.4'
+  postgresql: '9.6'
 services:
 - postgresql
 before_install:

--- a/doc.json
+++ b/doc.json
@@ -573,7 +573,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "the url of the document the note is associated with"
+            "description": "the url of the document the note is associated with. When this filter is used, will not paginate. Will return all results."
           },
           {
             "in": "query",
@@ -598,6 +598,14 @@
               "type": "string"
             },
             "description": "keyword to search for in the content of notes. Not case sensitive."
+          },
+          {
+            "in": "query",
+            "name": "stack",
+            "schema": {
+              "type": "string"
+            },
+            "description": "the collection (tag with type 'reader:Stack')"
           },
           {
             "in": "query",
@@ -1086,6 +1094,9 @@
             "$ref": "#/definitions/link"
           }
         },
+        "position": {
+          "type": "object"
+        },
         "json": {
           "type": "object"
         },
@@ -1146,6 +1157,15 @@
           "items": {
             "type": "string",
             "format": "url"
+          }
+        },
+        "json": {
+          "type": "object"
+        },
+        "resources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/link"
           }
         },
         "description": {
@@ -1237,6 +1257,80 @@
         }
       }
     },
+    "noteWithPub": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "url"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Note"
+          ]
+        },
+        "noteType": {
+          "type": "string"
+        },
+        "oa:hasSelector": {
+          "type": "object"
+        },
+        "content": {
+          "type": "string"
+        },
+        "@context": {
+          "type": "array"
+        },
+        "published": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "publication": {
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "url"
+            },
+            "author": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/annotation"
+              }
+            },
+            "editor": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/annotation"
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "datePublished": {
+              "type": "string",
+              "format": "timestamp"
+            }
+          }
+        },
+        "inReplyTo": {
+          "type": "string",
+          "format": "url",
+          "description": "The url of the document"
+        },
+        "context": {
+          "type": "string",
+          "format": "url",
+          "description": "The url of the publication"
+        },
+        "json": {
+          "type": "object"
+        }
+      }
+    },
     "notes": {
       "properties": {
         "id": {
@@ -1266,7 +1360,7 @@
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/note"
+            "$ref": "#/definitions/noteWithPub"
           }
         }
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1778,13 +1778,13 @@ fetch(<span class="hljs-string">'/activity-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
   },
   <span class="hljs-attr">"summaryMap"</span>: {
     <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
   },
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
 }
 </code></pre>
 <h3 id="get__activity-{id}-responses">Responses</h3>
@@ -2326,13 +2326,13 @@ fetch(<span class="hljs-string">'/reader-{id}/activity'</span>,
         <span class="hljs-attr">"profile"</span>: {},
         <span class="hljs-attr">"preferences"</span>: {},
         <span class="hljs-attr">"json"</span>: {},
-        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
       },
       <span class="hljs-attr">"summaryMap"</span>: {
         <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
       },
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
     }
   ]
 }
@@ -3006,6 +3006,18 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
       <span class="hljs-attr">"replies"</span>: [
         <span class="hljs-string">"string"</span>
       ],
+      <span class="hljs-attr">"json"</span>: {},
+      <span class="hljs-attr">"resources"</span>: [
+        {
+          <span class="hljs-attr">"href"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"mediaType"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"rel"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"hreflang"</span>: <span class="hljs-string">"string"</span>,
+          <span class="hljs-attr">"height"</span>: <span class="hljs-number">0</span>,
+          <span class="hljs-attr">"width"</span>: <span class="hljs-number">0</span>
+        }
+      ],
       <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"datePublished"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"readerId"</span>: <span class="hljs-string">"string"</span>,
@@ -3228,6 +3240,69 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <td>none</td>
 </tr>
 <tr>
+<td>»» json</td>
+<td>object</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» resources</td>
+<td>[<a href="#schema#/definitions/link">#/definitions/link</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» href</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» mediaType</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» rel</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» name</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» hreflang</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» height</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» width</td>
+<td>integer</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
 <td>»» description</td>
 <td>string</td>
 <td>false</td>
@@ -3364,7 +3439,7 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
 <td>query</td>
 <td>string</td>
 <td>false</td>
-<td>the url of the document the note is associated with</td>
+<td>the url of the document the note is associated with. When this filter is used, will not paginate. Will return all results.</td>
 </tr>
 <tr>
 <td>publication</td>
@@ -3386,6 +3461,13 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
 <td>string</td>
 <td>false</td>
 <td>keyword to search for in the content of notes. Not case sensitive.</td>
+</tr>
+<tr>
+<td>stack</td>
+<td>query</td>
+<td>string</td>
+<td>false</td>
+<td>the collection (tag with type 'reader:Stack')</td>
 </tr>
 <tr>
 <td>orderBy</td>
@@ -3444,8 +3526,25 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
       <span class="hljs-attr">"oa:hasSelector"</span>: {},
       <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"@context"</span>: [],
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+      <span class="hljs-attr">"publication"</span>: {
+        <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
+        <span class="hljs-attr">"author"</span>: [
+          {
+            <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Person"</span>
+          }
+        ],
+        <span class="hljs-attr">"editor"</span>: [
+          {
+            <span class="hljs-attr">"name"</span>: <span class="hljs-string">"string"</span>,
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Person"</span>
+          }
+        ],
+        <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
+        <span class="hljs-attr">"datePublished"</span>: <span class="hljs-string">"string"</span>
+      },
       <span class="hljs-attr">"inReplyTo"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"context"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"json"</span>: {}
@@ -3541,7 +3640,7 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
 </tr>
 <tr>
 <td>» items</td>
-<td>[<a href="#schema#/definitions/note">#/definitions/note</a>]</td>
+<td>[<a href="#schema#/definitions/notewithpub">#/definitions/noteWithPub</a>]</td>
 <td>false</td>
 <td>none</td>
 <td>none</td>
@@ -3603,6 +3702,62 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
 <td>none</td>
 </tr>
 <tr>
+<td>»» publication</td>
+<td>object</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» id</td>
+<td>string(url)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» author</td>
+<td>[<a href="#schema#/definitions/annotation">#/definitions/annotation</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»»» name</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»»» type</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» editor</td>
+<td>[<a href="#schema#/definitions/annotation">#/definitions/annotation</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» description</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»»» datePublished</td>
+<td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
 <td>»» inReplyTo</td>
 <td>string(url)</td>
 <td>false</td>
@@ -3641,6 +3796,14 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
 <tr>
 <td>type</td>
 <td>Note</td>
+</tr>
+<tr>
+<td>type</td>
+<td>Person</td>
+</tr>
+<tr>
+<td>type</td>
+<td>Organization</td>
 </tr>
 </tbody>
 </table>
@@ -3715,8 +3878,8 @@ fetch(<span class="hljs-string">'/reader-{id}'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
 }
 </code></pre>
 <h3 id="get__reader-{id}-responses">Responses</h3>
@@ -4015,8 +4178,8 @@ fetch(<span class="hljs-string">'/whoami'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
 }
 </code></pre>
 <h3 id="get__whoami-responses">Responses</h3>
@@ -4231,8 +4394,8 @@ fetch(<span class="hljs-string">'/note-{id}'</span>,
   <span class="hljs-attr">"oa:hasSelector"</span>: {},
   <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"@context"</span>: [],
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
   <span class="hljs-attr">"inReplyTo"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"context"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"json"</span>: {}
@@ -4719,6 +4882,7 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
       <span class="hljs-attr">"width"</span>: <span class="hljs-number">0</span>
     }
   ],
+  <span class="hljs-attr">"position"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
   <span class="hljs-attr">"readerId"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"reader"</span>: {
@@ -4734,8 +4898,8 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-06-12T17:39:46Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-07-03T17:34:23Z"</span>
   },
   <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"string"</span>
@@ -4935,6 +5099,13 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
 <tr>
 <td>» links</td>
 <td>[<a href="#schema#/definitions/link">#/definitions/link</a>]</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>» position</td>
+<td>object</td>
 <td>false</td>
 <td>none</td>
 <td>none</td>

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -227,16 +227,7 @@ class Reader extends BaseModel {
   }
 
   static async getNotesCount (readerId, filters) {
-    const { Document } = require('./Document')
-    let doc
-    if (filters.document) {
-      // $FlowFixMe
-      const path = urlparse(filters.document).path.substr(45)
-      // $FlowFixMe
-      const pubId = urlparse(filters.document).path.substr(13, 32)
-      doc = await Document.byPath(pubId, path)
-      if (!doc) doc = { id: 'does not exist' } // to make sure it returns an empty array instead of failing
-    }
+    // note: not applied with filters.document
 
     let resultQuery = Note.query(Note.knex())
       .count()
@@ -249,9 +240,6 @@ class Reader extends BaseModel {
         '=',
         urlToId(filters.publication)
       )
-    }
-    if (filters.document) {
-      resultQuery = resultQuery.where('documentId', '=', urlToId(doc.id))
     }
     if (filters.type) {
       resultQuery = resultQuery.where('noteType', '=', filters.type)

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -358,6 +358,8 @@ class Reader extends BaseModel {
         // paginate
         if (!filters.document) {
           builder.limit(limit).offset(offset)
+        } else {
+          builder.limit(1000000).offset(0)
         }
       })
 

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -2,6 +2,7 @@ const { BaseModel } = require('./BaseModel.js')
 const { Model } = require('objection')
 const _ = require('lodash')
 const { Publication } = require('./Publication')
+const { Note } = require('./Note')
 const { ReadActivity } = require('./ReadActivity')
 const { Attribution } = require('./Attribution')
 const { urlToId } = require('../utils/utils')
@@ -51,6 +52,14 @@ class Reader extends BaseModel {
     const readers = await qb.eager(eager)
 
     return readers[0]
+  }
+
+  static async getLibraryCount (readerId) {
+    const result = await Publication.query(Publication.knex())
+      .count()
+      .whereNull('deleted')
+      .andWhere('readerId', '=', readerId)
+    return result[0].count
   }
 
   static async getLibrary (
@@ -165,6 +174,14 @@ class Reader extends BaseModel {
     return readers.length > 0
   }
 
+  static async getNotesCount (readerId) {
+    const result = await Note.query(Note.knex())
+      .count()
+      .whereNull('deleted')
+      .andWhere('readerId', '=', readerId)
+    return result[0].count
+  }
+
   static async getNotes (
     readerId /*: string */,
     limit /*: number */,
@@ -246,6 +263,7 @@ class Reader extends BaseModel {
         // paginate
         builder.limit(limit).offset(offset)
       })
+
     return readers[0]
   }
 

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -356,7 +356,9 @@ class Reader extends BaseModel {
         }
 
         // paginate
-        builder.limit(limit).offset(offset)
+        if (!filters.document) {
+          builder.limit(limit).offset(offset)
+        }
       })
 
     return readers[0]

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -415,8 +415,6 @@ class Reader extends BaseModel {
   }
   static get relationMappings () /*: any */ {
     const { Document } = require('./Document')
-
-    const { Note } = require('./Note.js')
     const { Activity } = require('./Activity.js')
     const { Tag } = require('./Tag.js')
     return {

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -297,7 +297,7 @@ class Reader extends BaseModel {
 
       // no pagination for filter by document
       offset = 0
-      limit = 1000000
+      limit = 100000
     }
 
     const readers = await qb

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -294,6 +294,10 @@ class Reader extends BaseModel {
       const pubId = urlparse(filters.document).path.substr(13, 32)
       doc = await Document.byPath(pubId, path)
       if (!doc) doc = { id: 'does not exist' } // to make sure it returns an empty array instead of failing
+
+      // no pagination for filter by document
+      offset = 0
+      limit = 1000000
     }
 
     const readers = await qb
@@ -356,11 +360,7 @@ class Reader extends BaseModel {
         }
 
         // paginate
-        if (!filters.document) {
-          builder.limit(limit).offset(offset)
-        } else {
-          builder.limit(1000000).offset(0)
-        }
+        builder.limit(limit).offset(offset)
       })
 
     return readers[0]

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -212,7 +212,14 @@ module.exports = app => {
             )
           } else {
             returnedReader = reader
-            return Reader.getLibraryCount(id)
+            // skip count query if we know we are at the last page
+            if (
+              reader.publications.length < req.query.limit &&
+              reader.publications.length > 0
+            ) {
+              return Promise.resolve(reader.publications.length + req.skip)
+            }
+            return Reader.getLibraryCount(id, filters)
           }
         })
         .then(count => {

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -190,6 +190,7 @@ module.exports = app => {
         reverse: req.query.reverse,
         collection: req.query.stack
       }
+      let returnedReader
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything
       Reader.getLibrary(id, req.query.limit, req.skip, filters)
         .then(reader => {
@@ -210,26 +211,31 @@ module.exports = app => {
               })
             )
           } else {
-            res.setHeader(
-              'Content-Type',
-              'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-            )
-            res.end(
-              JSON.stringify({
-                '@context': 'https://www.w3.org/ns/activitystreams',
-                summaryMap: {
-                  en: `Streams for reader with id ${id}`
-                },
-                type: 'Collection',
-                id: getId(`/reader-${id}/library`),
-                totalItems: reader.publications.length,
-                items: reader.publications,
-                tags: reader.tags,
-                page: req.query.page,
-                pageSize: parseInt(req.query.limit)
-              })
-            )
+            returnedReader = reader
+            return Reader.getLibraryCount(id)
           }
+        })
+        .then(count => {
+          let reader = returnedReader
+          res.setHeader(
+            'Content-Type',
+            'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+          )
+          res.end(
+            JSON.stringify({
+              '@context': 'https://www.w3.org/ns/activitystreams',
+              summaryMap: {
+                en: `Streams for reader with id ${id}`
+              },
+              type: 'Collection',
+              id: getId(`/reader-${id}/library`),
+              totalItems: parseInt(count),
+              items: reader.publications,
+              tags: reader.tags,
+              page: req.query.page,
+              pageSize: parseInt(req.query.limit)
+            })
+          )
         })
         .catch(err => {
           next(err)

--- a/routes/reader-notes.js
+++ b/routes/reader-notes.js
@@ -201,6 +201,9 @@ module.exports = app => {
           } else {
             returnedReader = reader
             const length = reader.replies.length
+            if (filters.document) {
+              return Promise.resolve(length)
+            }
             if (length < req.query.limit && length !== 0) {
               return Promise.resolve(length + req.skip)
             }

--- a/routes/reader-notes.js
+++ b/routes/reader-notes.js
@@ -115,7 +115,7 @@ module.exports = app => {
    *         name: document
    *         schema:
    *           type: string
-   *         description: the url of the document the note is associated with. Note: will return all results: no pagination
+   *         description: the url of the document the note is associated with. When this filter is used, will not paginate. Will return all results.
    *       - in: query
    *         name: publication
    *         schema:

--- a/routes/reader-notes.js
+++ b/routes/reader-notes.js
@@ -115,7 +115,7 @@ module.exports = app => {
    *         name: document
    *         schema:
    *           type: string
-   *         description: the url of the document the note is associated with
+   *         description: the url of the document the note is associated with. Note: will return all results: no pagination
    *       - in: query
    *         name: publication
    *         schema:

--- a/routes/reader-notes.js
+++ b/routes/reader-notes.js
@@ -200,7 +200,11 @@ module.exports = app => {
             )
           } else {
             returnedReader = reader
-            return Reader.getNotesCount(id)
+            const length = reader.replies.length
+            if (length < req.query.limit && length !== 0) {
+              return Promise.resolve(length + req.skip)
+            }
+            return Reader.getNotesCount(id, filters)
           }
         })
         .then(count => {
@@ -209,7 +213,7 @@ module.exports = app => {
             'Content-Type',
             'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
           )
-          let replies = reader.replies.filter(reply => !reply.deleted)
+          let replies = reader.replies
           res.end(
             JSON.stringify({
               '@context': 'https://www.w3.org/ns/activitystreams',

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -77,8 +77,9 @@ const test = async () => {
     await tap.equal(res.statusCode, 200)
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 1)
+    await tap.equal(body.totalItems, 3)
     await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 1)
     // documents should include:
     await tap.equal(body.items[0].name, 'Publication 2')
   })
@@ -141,7 +142,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 11)
+    await tap.equal(body.totalItems, 13)
     await tap.equal(body.items.length, 11)
   })
 
@@ -158,8 +159,9 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 0)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 0)
   })
 
   // ---------------------------------------- TITLE ------------------------------------
@@ -178,8 +180,9 @@ const test = async () => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
-    await tap.equal(res.body.totalItems, 2)
+    await tap.equal(res.body.totalItems, 15)
     await tap.ok(res.body.items)
+    await tap.equal(res.body.items.length, 2)
     await tap.equal(res.body.items[0].name, 'Super great book!')
   })
 
@@ -192,7 +195,8 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res2.body.totalItems, 10)
+    await tap.equal(res2.body.totalItems, 15)
+    await tap.equal(res2.body.items.length, 10)
 
     const res3 = await request(app)
       .get(`${readerUrl}/library?title=publication&limit=11`)
@@ -202,7 +206,8 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res3.body.totalItems, 11)
+    await tap.equal(res3.body.totalItems, 15)
+    await tap.equal(res3.body.items.length, 11)
   })
 
   await tap.test('Filter Library by title using inexistant title', async () => {
@@ -214,7 +219,8 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res4.body.totalItems, 0)
+    await tap.equal(res4.body.totalItems, 15)
+    await tap.equal(res4.body.items.length, 0)
   })
 
   // ------------------------------------ ATTRIBUTION ------------------------------------
@@ -249,8 +255,9 @@ const test = async () => {
     await tap.type(body.id, 'string')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.totalItems, 18)
     await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 3)
     // documents should include:
     await tap.equal(body.items[0].type, 'Publication')
     await tap.type(body.items[0].id, 'string')
@@ -456,8 +463,9 @@ const test = async () => {
     await tap.type(body, 'object')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    await tap.equal(body.totalItems, 2)
+    await tap.equal(body.totalItems, 30)
     await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 2)
     // documents should include:
     await tap.equal(body.items[0].type, 'Publication')
     await tap.type(body.items[0].id, 'string')
@@ -514,7 +522,7 @@ const test = async () => {
       const body = res.body
       await tap.type(body, 'object')
       await tap.equal(body.type, 'Collection')
-      await tap.equal(body.totalItems, 0)
+      await tap.equal(body.items.length, 0)
     }
   )
 
@@ -530,7 +538,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.totalItems, 30)
     await tap.equal(body.items.length, 3)
   })
 
@@ -544,7 +552,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 4)
+    await tap.equal(body.totalItems, 30)
     await tap.equal(body.items.length, 4)
   })
 
@@ -558,7 +566,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 1)
+    await tap.equal(body.totalItems, 30)
     await tap.equal(body.items.length, 1)
   })
 

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -77,7 +77,7 @@ const test = async () => {
     await tap.equal(res.statusCode, 200)
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 1)
     // documents should include:
@@ -131,7 +131,7 @@ const test = async () => {
 
     // get library with filter for collection with pagination
     const res = await request(app)
-      .get(`${readerUrl}/library?stack=mystack&limit=11`)
+      .get(`${readerUrl}/library?stack=mystack&limit=10`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -142,8 +142,8 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 13)
-    await tap.equal(body.items.length, 11)
+    await tap.equal(body.totalItems, 11)
+    await tap.equal(body.items.length, 10)
   })
 
   await tap.test('Filter Library with a non-existing collection', async () => {
@@ -159,7 +159,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 13)
+    await tap.equal(body.totalItems, 0)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 0)
   })
@@ -180,7 +180,7 @@ const test = async () => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
-    await tap.equal(res.body.totalItems, 15)
+    await tap.equal(res.body.totalItems, 2)
     await tap.ok(res.body.items)
     await tap.equal(res.body.items.length, 2)
     await tap.equal(res.body.items[0].name, 'Super great book!')
@@ -195,7 +195,7 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res2.body.totalItems, 15)
+    await tap.equal(res2.body.totalItems, 13)
     await tap.equal(res2.body.items.length, 10)
 
     const res3 = await request(app)
@@ -206,7 +206,7 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res3.body.totalItems, 15)
+    await tap.equal(res3.body.totalItems, 13)
     await tap.equal(res3.body.items.length, 11)
   })
 
@@ -219,7 +219,7 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res4.body.totalItems, 15)
+    await tap.equal(res4.body.totalItems, 0)
     await tap.equal(res4.body.items.length, 0)
   })
 
@@ -255,7 +255,7 @@ const test = async () => {
     await tap.type(body.id, 'string')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    await tap.equal(body.totalItems, 18)
+    await tap.equal(body.totalItems, 3)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 3)
     // documents should include:
@@ -463,7 +463,7 @@ const test = async () => {
     await tap.type(body, 'object')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    await tap.equal(body.totalItems, 30)
+    await tap.equal(body.totalItems, 2)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 2)
     // documents should include:
@@ -538,7 +538,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 30)
+    await tap.equal(body.totalItems, 3)
     await tap.equal(body.items.length, 3)
   })
 
@@ -552,7 +552,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 30)
+    await tap.equal(body.totalItems, 4)
     await tap.equal(body.items.length, 4)
   })
 
@@ -566,7 +566,7 @@ const test = async () => {
       )
 
     const body = res.body
-    await tap.equal(body.totalItems, 30)
+    await tap.equal(body.totalItems, 1)
     await tap.equal(body.items.length, 1)
   })
 

--- a/tests/integration/library-paginate.test.js
+++ b/tests/integration/library-paginate.test.js
@@ -49,7 +49,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 10)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
     await tap.equal(body.items.length, 10)
@@ -72,7 +72,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 11)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
     await tap.equal(body.items.length, 11)
@@ -95,7 +95,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
     await tap.equal(body.items.length, 3)
@@ -118,7 +118,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 2)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
     await tap.equal(body.items.length, 2)
@@ -167,7 +167,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 0)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 0)
     await tap.equal(body.page, 3)
@@ -189,7 +189,7 @@ const test = async () => {
 
       const body = res.body
       await tap.type(body, 'object')
-      await tap.equal(body.totalItems, 10)
+      await tap.equal(body.totalItems, 13)
       await tap.ok(Array.isArray(body.items))
       await tap.equal(body.items.length, 10)
       await tap.equal(body.page, 1)
@@ -210,7 +210,7 @@ const test = async () => {
 
     const body = res.body
     await tap.type(body, 'object')
-    await tap.equal(body.totalItems, 10)
+    await tap.equal(body.totalItems, 13)
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 10)
     await tap.equal(body.page, 1)
@@ -341,7 +341,7 @@ const test = async () => {
 
       const body = res.body
       await tap.type(body, 'object')
-      await tap.equal(body.totalItems, 100)
+      await tap.equal(body.totalItems, 110)
       await tap.ok(Array.isArray(body.items))
       await tap.equal(body.items.length, 100)
       await tap.equal(body.page, 1)
@@ -364,7 +364,7 @@ const test = async () => {
 
       const body = res.body
       await tap.type(body, 'object')
-      await tap.equal(body.totalItems, 10)
+      await tap.equal(body.totalItems, 110)
       await tap.ok(Array.isArray(body.items))
       await tap.equal(body.items.length, 10)
       await tap.equal(body.page, 1)
@@ -387,7 +387,7 @@ const test = async () => {
 
       const body = res.body
       await tap.type(body, 'object')
-      await tap.equal(body.totalItems, 10)
+      await tap.equal(body.totalItems, 110)
       await tap.ok(Array.isArray(body.items))
       await tap.equal(body.items.length, 10)
       await tap.equal(body.page, 1)

--- a/tests/integration/readerNotes-filter.test.js
+++ b/tests/integration/readerNotes-filter.test.js
@@ -109,7 +109,7 @@ const test = async app => {
     await tap.equal(res.status, 200)
     const body = res.body
 
-    await tap.equal(body.totalItems, 15)
+    await tap.equal(body.totalItems, 2)
     await tap.equal(body.items.length, 2)
     await tap.equal(body.items[0].type, 'Note')
 
@@ -213,7 +213,7 @@ const test = async app => {
     await tap.equal(res.status, 200)
     const body = res.body
 
-    await tap.equal(body.totalItems, 13)
+    await tap.equal(body.totalItems, 0)
     await tap.equal(body.items.length, 0)
   })
 
@@ -230,6 +230,7 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 13)
     await tap.equal(res.body.items.length, 10)
   })
 
@@ -244,6 +245,7 @@ const test = async app => {
 
     await tap.equal(res2.status, 200)
     await tap.ok(res2.body)
+    await tap.equal(res2.body.totalItems, 13)
     await tap.equal(res2.body.items.length, 3)
   })
 
@@ -287,6 +289,7 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 3)
     await tap.equal(res.body.items.length, 3)
   })
 
@@ -336,6 +339,7 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 4)
     await tap.equal(res.body.items.length, 4)
   })
 
@@ -367,6 +371,7 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 3)
     await tap.equal(res.body.items.length, 3)
   })
 
@@ -383,6 +388,7 @@ const test = async app => {
 
     await tap.equal(res2.status, 200)
     await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 2)
     await tap.equal(res2.body.items.length, 2)
   })
 
@@ -397,6 +403,7 @@ const test = async app => {
 
     await tap.equal(res2.status, 200)
     await tap.ok(res2.body)
+    await tap.equal(res2.body.totalItems, 1)
     await tap.equal(res2.body.items.length, 1)
   })
 
@@ -411,6 +418,7 @@ const test = async app => {
 
     await tap.equal(res3.status, 200)
     await tap.ok(res3.body)
+    await tap.ok(res3.body.totalItems, 3)
     await tap.equal(res3.body.items.length, 3)
   })
 

--- a/tests/integration/readerNotes-filter.test.js
+++ b/tests/integration/readerNotes-filter.test.js
@@ -231,23 +231,26 @@ const test = async app => {
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
     await tap.equal(res.body.totalItems, 13)
-    await tap.equal(res.body.items.length, 10)
+    await tap.equal(res.body.items.length, 13) // no pagination with documentUrl filter
   })
 
-  await tap.test('Filter Notes by documentUrl with pagination', async () => {
-    const res2 = await request(app)
-      .get(`${readerUrl}/notes?document=${documentUrl2}&page=2`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
+  await tap.test(
+    'Filter Notes by documentUrl should not work with pagination',
+    async () => {
+      const res2 = await request(app)
+        .get(`${readerUrl}/notes?document=${documentUrl2}&page=2`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
 
-    await tap.equal(res2.status, 200)
-    await tap.ok(res2.body)
-    await tap.equal(res2.body.totalItems, 13)
-    await tap.equal(res2.body.items.length, 3)
-  })
+      await tap.equal(res2.status, 200)
+      await tap.ok(res2.body)
+      await tap.equal(res2.body.totalItems, 13)
+      await tap.equal(res2.body.items.length, 13)
+    }
+  )
 
   await tap.test('Filter Notes by a nonexistant documentUrl', async () => {
     const res = await request(app)

--- a/tests/integration/readerNotes-filter.test.js
+++ b/tests/integration/readerNotes-filter.test.js
@@ -109,7 +109,7 @@ const test = async app => {
     await tap.equal(res.status, 200)
     const body = res.body
 
-    await tap.equal(body.totalItems, 2)
+    await tap.equal(body.totalItems, 15)
     await tap.equal(body.items.length, 2)
     await tap.equal(body.items[0].type, 'Note')
 
@@ -171,7 +171,6 @@ const test = async app => {
       )
 
     await tap.equal(res2.status, 200)
-    await tap.equal(res2.body.totalItems, 10)
     await tap.equal(res2.body.items.length, 10)
 
     noteId2 = res2.body.items[3].id
@@ -186,7 +185,7 @@ const test = async app => {
       )
 
     await tap.equal(res3.status, 200)
-    await tap.equal(res3.body.totalItems, 3)
+    await tap.equal(res3.body.totalItems, 13)
     await tap.equal(res3.body.items.length, 3)
 
     const res4 = await request(app)
@@ -198,7 +197,7 @@ const test = async app => {
       )
 
     await tap.equal(res4.status, 200)
-    await tap.equal(res4.body.totalItems, 2)
+    await tap.equal(res4.body.totalItems, 13)
     await tap.equal(res4.body.items.length, 2)
   })
 
@@ -214,7 +213,7 @@ const test = async app => {
     await tap.equal(res.status, 200)
     const body = res.body
 
-    await tap.equal(body.totalItems, 0)
+    await tap.equal(body.totalItems, 13)
     await tap.equal(body.items.length, 0)
   })
 

--- a/tests/integration/readerNotes-paginate.test.js
+++ b/tests/integration/readerNotes-paginate.test.js
@@ -64,7 +64,7 @@ const test = async app => {
       )
 
     await tap.equal(res2.status, 200)
-    await tap.equal(res2.body.totalItems, 10)
+    await tap.equal(res2.body.totalItems, 13)
     await tap.equal(res2.body.items.length, 10)
   })
 
@@ -78,7 +78,7 @@ const test = async app => {
       )
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.totalItems, 12)
+    await tap.equal(res.body.totalItems, 13)
     await tap.equal(res.body.items.length, 12)
   })
 
@@ -92,7 +92,7 @@ const test = async app => {
       )
 
     await tap.equal(res3.status, 200)
-    await tap.equal(res3.body.totalItems, 3)
+    await tap.equal(res3.body.totalItems, 13)
     await tap.equal(res3.body.items.length, 3)
   })
 
@@ -106,7 +106,7 @@ const test = async app => {
       )
 
     await tap.equal(res4.status, 200)
-    await tap.equal(res4.body.totalItems, 2)
+    await tap.equal(res4.body.totalItems, 13)
     await tap.equal(res4.body.items.length, 2)
   })
 
@@ -122,7 +122,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 200)
-      await tap.equal(res.body.totalItems, 0)
+      await tap.equal(res.body.totalItems, 13)
       await tap.equal(res.body.items.length, 0)
     }
   )
@@ -156,7 +156,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 200)
-      await tap.equal(res.body.totalItems, 10)
+      await tap.equal(res.body.totalItems, 13)
       await tap.equal(res.body.items.length, 10)
     }
   )
@@ -171,7 +171,7 @@ const test = async app => {
       )
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.totalItems, 10)
+    await tap.equal(res.body.totalItems, 13)
     await tap.equal(res.body.items.length, 10)
   })
 


### PR DESCRIPTION
This is still a work in progress. It works for the library. I can do the same for the readerNotes, and eventually the activities.

But before I do, I want to make sure that this is something that is worth it. And that there isn't any obvious easier way that I didn't think of.

I tried using the knex-paginator package but that did not work, because the count / pagination I am doing is in a sub-query. What I am querying is the Reader table and then doing a whole mess of eager loading and joins with other tables. 

The solution I am doing right now is not ideal. There is a lot of repetition and any change to the filters will mean changes in two different complex queries. 

I did make it so that we don't have to call the query whenever we are on the last page (if the page limit is 10 and there are 9 publications, no need to do a count query!)