### PR TITLE
renamed the file to be uploaded

### DIFF
--- a/routes/file-upload-pub.js
+++ b/routes/file-upload-pub.js
@@ -92,7 +92,7 @@ module.exports = app => {
         const randomName = `${crypto
           .randomBytes(15)
           .toString('hex')}.${extension}`
-        file.name = `job-${job.id}/reader-${req.params.id}/${randomName}`
+        file.name = `reader-${req.params.id}/job-${job.id}/${randomName}`
 
         // upload
         const blob = bucket.file(file.name)

--- a/routes/file-upload-pub.js
+++ b/routes/file-upload-pub.js
@@ -70,10 +70,6 @@ module.exports = app => {
       } else {
         // check extension
         const extension = file.originalname.split('.').pop()
-        const randomName = `${crypto
-          .randomBytes(15)
-          .toString('hex')}.${extension}`
-        file.name = `reader-${req.params.id}/${randomName}`
 
         // for now, only accept epub
         if (extension !== 'epub') {
@@ -85,6 +81,18 @@ module.exports = app => {
             })
           )
         }
+
+        // create job
+        const job = await Job.createJob({
+          type: 'epub',
+          readerId: req.params.id
+        })
+
+        // file name: `job-{jobId}/reader-{readerId}/${randomfilename}.epub
+        const randomName = `${crypto
+          .randomBytes(15)
+          .toString('hex')}.${extension}`
+        file.name = `job-${job.id}/reader-${req.params.id}/${randomName}`
 
         // upload
         const blob = bucket.file(file.name)
@@ -108,27 +116,6 @@ module.exports = app => {
           blob
             .makePublic()
             .then(() => {
-              return Job.createJob({
-                type: 'epub',
-                readerId: req.params.id
-              })
-            })
-            .then(job => {
-              // TODO: figure out what to do with elasticsearch
-              // if (
-              //   (document.mediaType === 'text/html' ||
-              //     document.mediaType === 'application/xhtml+xml') &&
-              //   elasticsearchQueue
-              // ) {
-              //   elasticsearchQueue.add({
-              //     type: 'add',
-              //     fileName: file.name,
-              //     bucketName: bucketName,
-              //     document: doc,
-              //     pubId: id
-              //   })
-              // }
-
               res.setHeader('Content-Type', 'application/json;')
               res.end(JSON.stringify(job))
             })

--- a/tests/getToken.js
+++ b/tests/getToken.js
@@ -1,4 +1,6 @@
 const jwt = require('jsonwebtoken')
+require('dotenv').config()
+const crypto = require('crypto')
 
 const options = {
   subject: `foo${Date.now()}`,
@@ -7,3 +9,19 @@ const options = {
 }
 
 console.log(jwt.sign({}, 'kick-opossum-snowiness', options))
+
+// dev server
+const optionsDev = {
+  algorithm: 'HS256',
+  audience: 'REBUS_API',
+  subject: `foo${Date.now()}`,
+  expiresIn: '24h',
+  issuer: 'REBUS_READER'
+}
+console.log(
+  jwt.sign(
+    { id: crypto.randomBytes(16).toString('hex') },
+    process.env.SECRETORKEY,
+    optionsDev
+  )
+)

--- a/tests/google-integration/index.js
+++ b/tests/google-integration/index.js
@@ -16,10 +16,10 @@ const allTests = async () => {
     }
   }
 
-  await searchTests(app)
+  //  await searchTests(app)
   await fileUploadPubTests(app)
   await fileUploadTests(app)
-  await publicationFileUploadTests(app)
+  // await publicationFileUploadTests(app)
 
   if (process.env.POSTGRE_INSTANCE) {
     await app.knex.migrate.rollback()


### PR DESCRIPTION
actually what I was missing was the jobId. So now the name of the file uploaded will be:
reader-{readerId)/job-{jobId}/filename.epub
that way I can extract the readerId and jobId. The publicationId will be created by the google function. It will be in the job object once the job is done. 

makes sense?

(I know that right now I inverted the readerId and jobId... will push changes in a few minutes to fix that)