### PR TITLE
cache library

### DIFF
--- a/models/Publication.js
+++ b/models/Publication.js
@@ -13,6 +13,8 @@ const { urlToId } = require('../utils/utils')
 
 const elasticsearchQueue = require('../processFiles/searchQueue')
 
+const { libraryCacheUpdate } = require('../utils/cache')
+
 /*::
 type PublicationType = {
   id: string,
@@ -187,6 +189,10 @@ class Publication extends BaseModel {
         }
       }
     }
+
+    // exceptionally, doing this instead of in the routes because of the complexity of
+    // the whole file upload thing.
+    await libraryCacheUpdate(reader.id)
 
     return createdPublication
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4607,6 +4607,11 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
     "driftless": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/driftless/-/driftless-2.0.3.tgz",
@@ -6969,6 +6974,11 @@
         "is-property": "^1.0.0"
       }
     },
+    "generic-pool": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.7.1.tgz",
+      "integrity": "sha512-ug6DAZoNgWm6q5KhPFA+hzXfBLFQu5sTXxPpv44DmE0A2g+CiHoq9LTVdkXpZMkYVMoGw83F6W+WT0h0MFMK/w=="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -8291,6 +8301,11 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha1-a+Fm0USCihMdaGiRuYPfYsOUkf8="
+    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -9469,6 +9484,11 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10379,6 +10399,27 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nocache/-/nocache-2.1.0.tgz",
       "integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
+    },
+    "node-cache-redis": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/node-cache-redis/-/node-cache-redis-2.14.0.tgz",
+      "integrity": "sha512-MTa49lXrEWL9W342m9snFQgvlWpmwHS1/0VC7dAI8AP1czBV8/ltQIDbAn2iwMkpYeQmpGWREJMMszeiJNjL4A==",
+      "requires": {
+        "debug": "^4.1.1",
+        "es6-promisify": "^6.0.1",
+        "generic-pool": "^3.7.1",
+        "is-json": "^2.0.1",
+        "lodash.pick": "^4.4.0",
+        "redis": "^2.8.0",
+        "retry-as-promised": "^2.2.0"
+      },
+      "dependencies": {
+        "es6-promisify": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.2.tgz",
+          "integrity": "sha512-eO6vFm0JvqGzjWIQA6QVKjxpmELfhWbDUWHm1rPfIbn55mhKPiAa5xpLmQWJrNa629ZIeQ8ZvMAi13kvrjK6Mg=="
+        }
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -13075,6 +13116,23 @@
         "strip-indent": "^2.0.0"
       }
     },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "redis-parser": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+          "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+        }
+      }
+    },
     "redis-commands": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.5.0.tgz",
@@ -13605,6 +13663,30 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "retry-as-promised": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-2.3.2.tgz",
+      "integrity": "sha1-zZdO5P2bX+A8vzGHHuSCIcB3N7c=",
+      "requires": {
+        "bluebird": "^3.4.6",
+        "debug": "^2.6.9"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "retry-request": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "passport-jwt": "^4.0.0",
     "path-match": "^1.2.4",
     "pg": "^7.4.3",
+    "redis": "^2.8.0",
     "request": "^2.88.0",
     "swagger-jsdoc": "^3.2.9"
   },

--- a/routes/activities/add.js
+++ b/routes/activities/add.js
@@ -4,6 +4,7 @@ const { Note_Tag } = require('../../models/Note_Tag')
 const { Activity } = require('../../models/Activity')
 // const { urlToId } = require('./utils')
 const boom = require('@hapi/boom')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 const handleAdd = async (req, res, next, reader) => {
   const body = req.body
@@ -53,6 +54,7 @@ const handleAdd = async (req, res, next, reader) => {
           body.target.id,
           body.object.id
         )
+        await libraryCacheUpdate(reader.id)
       } else if (body.target.type === 'Note') {
         resultStack = await Note_Tag.addTagToNote(
           body.target.id,

--- a/routes/activities/create.js
+++ b/routes/activities/create.js
@@ -6,6 +6,7 @@ const { Document } = require('../../models/Document')
 const { createActivityObject } = require('../../utils/utils')
 const boom = require('@hapi/boom')
 const { ValidationError } = require('objection')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 const handleCreate = async (req, res, next, reader) => {
   const body = req.body
@@ -113,6 +114,9 @@ const handleCreate = async (req, res, next, reader) => {
 
         return next(err)
       }
+
+      // update cache - TODO: make this conditional to the type of tag??
+      await libraryCacheUpdate(reader.id)
 
       const activityObjStack = createActivityObject(body, resultStack, reader)
 

--- a/routes/activities/delete.js
+++ b/routes/activities/delete.js
@@ -5,6 +5,7 @@ const { Note } = require('../../models/Note')
 const { Tag } = require('../../models/Tag')
 const { urlToId } = require('../../utils/utils')
 const boom = require('@hapi/boom')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 const handleDelete = async (req, res, next, reader) => {
   const body = req.body
@@ -46,6 +47,8 @@ const handleDelete = async (req, res, next, reader) => {
       }
       const activityObjPub = createActivityObject(body, returned, reader)
       const pubActivity = await Activity.createActivity(activityObjPub)
+
+      await libraryCacheUpdate(reader.id)
 
       res.status(204)
       res.set('Location', pubActivity.id)
@@ -101,6 +104,8 @@ const handleDelete = async (req, res, next, reader) => {
       }
       const activityObjTag = createActivityObject(body, body.object, reader)
       const tagActivity = await Activity.createActivity(activityObjTag)
+
+      await libraryCacheUpdate(reader.id)
 
       res.status(204)
       res.set('Location', tagActivity.id)

--- a/routes/activities/remove.js
+++ b/routes/activities/remove.js
@@ -3,6 +3,7 @@ const { Publication_Tag } = require('../../models/Publications_Tags')
 const { Activity } = require('../../models/Activity')
 const { Note_Tag } = require('../../models/Note_Tag')
 const boom = require('@hapi/boom')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 const handleRemove = async (req, res, next, reader) => {
   const body = req.body
@@ -60,6 +61,7 @@ const handleRemove = async (req, res, next, reader) => {
       body.target.id,
       body.object.id
     )
+    await libraryCacheUpdate(reader.id)
   } else if (body.target.type === 'Note') {
     resultStack = await Note_Tag.removeTagFromNote(
       body.target.id,

--- a/routes/activities/update.js
+++ b/routes/activities/update.js
@@ -5,6 +5,7 @@ const { Note } = require('../../models/Note')
 const { Tag } = require('../../models/Tag')
 const boom = require('@hapi/boom')
 const { ValidationError } = require('objection')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 const handleUpdate = async (req, res, next, reader) => {
   const body = req.body
@@ -85,6 +86,9 @@ const handleUpdate = async (req, res, next, reader) => {
 
       const activityObjPub = createActivityObject(body, resultPub, reader)
       const pubActivity = await Activity.createActivity(activityObjPub)
+
+      await libraryCacheUpdate(reader.id)
+
       res.status(201)
       res.set('Location', pubActivity.id)
       res.end()
@@ -114,6 +118,9 @@ const handleUpdate = async (req, res, next, reader) => {
 
       const activityObjTag = createActivityObject(body, resultTag, reader)
       const tagActivity = await Activity.createActivity(activityObjTag)
+
+      await libraryCacheUpdate(reader.id)
+
       res.status(201)
       res.set('Location', tagActivity.id)
       res.end()

--- a/server.js
+++ b/server.js
@@ -170,7 +170,9 @@ app.terminate = async () => {
     await epubQueue.empty()
     epubQueue.close()
   }
-  cache.quitCache()
+  if (cache) {
+    cache.quitCache()
+  }
   return await app.knex.destroy()
 }
 

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const helmet = require('helmet')
 const { Strategy, ExtractJwt } = require('passport-jwt')
 const elasticsearchQueue = require('./processFiles/searchQueue')
 const epubQueue = require('./processFiles/index')
+const cache = require('./utils/cache')
 
 const activityRoute = require('./routes/activity')
 const publicationRoute = require('./routes/publication')
@@ -169,6 +170,7 @@ app.terminate = async () => {
     await epubQueue.empty()
     epubQueue.close()
   }
+  cache.quitCache()
   return await app.knex.destroy()
 }
 

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -5,7 +5,9 @@ const {
   getToken,
   createUser,
   destroyDB,
-  createPublication
+  createPublication,
+  createTag,
+  addPubToCollection
 } = require('../utils/utils')
 const app = require('../../server').app
 
@@ -17,6 +19,8 @@ const test = async () => {
   const token = getToken()
   const readerCompleteUrl = await createUser(app, token)
   const readerUrl = urlparse(readerCompleteUrl).path
+
+  let time
 
   await tap.test('Get empty library', async () => {
     const res = await request(app)
@@ -103,6 +107,311 @@ const test = async () => {
       await tap.equal(error.details.type, 'Reader')
       await tap.type(error.details.id, 'string')
       await tap.equal(error.details.activity, 'Get Library')
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - not modified',
+    async () => {
+      time = new Date().getTime()
+      // with time at beginning - so it will be modified
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 304)
+      await tap.notOk(res.body)
+    }
+  )
+
+  let collectionId
+
+  await tap.test(
+    'Get Library with if-modified-since header - after collection created',
+    async () => {
+      await createTag(app, token, readerUrl)
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+      time = new Date().getTime()
+      collectionId = body.tags[0].id
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after collection updated',
+    async () => {
+      await request(app)
+        .post(`${readerUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Update',
+            object: {
+              type: 'reader:Tag',
+              id: collectionId,
+              name: 'new collection name'
+            }
+          })
+        )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+      time = new Date().getTime()
+    }
+  )
+
+  let publication
+
+  await tap.test(
+    'Get Library with if-modified-since header - after publication created',
+    async () => {
+      publication = await createPublication(readerUrl)
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+
+      time = new Date().getTime()
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after publication updated',
+    async () => {
+      await request(app)
+        .post(`${readerUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Update',
+            object: {
+              type: 'Publication',
+              id: publication.id,
+              description: 'new description!'
+            }
+          })
+        )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+      time = new Date().getTime()
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after publication added to collection',
+    async () => {
+      await addPubToCollection(
+        app,
+        token,
+        readerUrl,
+        publication.id,
+        collectionId
+      )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+
+      time = new Date().getTime()
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after publication removed from collection',
+    async () => {
+      const removeRes = await request(app)
+        .post(`${readerUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Remove',
+            object: { id: collectionId, type: 'reader:Tag' },
+            target: { id: publication.id, type: 'Publication' }
+          })
+        )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+
+      time = new Date().getTime()
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after publication deleted',
+    async () => {
+      await request(app)
+        .post(`${readerUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Delete',
+            object: {
+              type: 'Publication',
+              id: publication.id
+            }
+          })
+        )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+
+      time = new Date().getTime()
+    }
+  )
+
+  await tap.test(
+    'Get Library with if-modified-since header - after collection deleted',
+    async () => {
+      await request(app)
+        .post(`${readerUrl}/activity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+        .send(
+          JSON.stringify({
+            '@context': [
+              'https://www.w3.org/ns/activitystreams',
+              { reader: 'https://rebus.foundation/ns/reader' }
+            ],
+            type: 'Delete',
+            object: {
+              type: 'reader:Tag',
+              id: collectionId
+            }
+          })
+        )
+
+      const res = await request(app)
+        .get(`${readerUrl}/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .set('If-Modified-Since', time)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.statusCode, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.type, 'Collection')
+
+      time = new Date().getTime()
     }
   )
 

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,7 +1,9 @@
 const redis = require('redis')
 const { urlToId } = require('./utils')
 
-let libraryCacheGet, libraryCacheUpdate, quitCache
+let libraryCacheGet = () => undefined
+let libraryCacheUpdate = () => undefined
+let quitCache
 
 if (process.env.REDIS_PASSWORD) {
   const client = redis.createClient({

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,29 @@
+const redis = require('redis')
+const client = redis.createClient({
+  host: process.env.REDIS_HOST,
+  port: process.env.REDIS_PORT,
+  password: process.env.REDIS_PASSWORD
+})
+
+const { promisify } = require('util')
+const getAsync = promisify(client.get).bind(client)
+const setASync = promisify(client.set).bind(client)
+
+const { urlToId } = require('./utils')
+
+const libraryCacheUpdate = async readerId => {
+  readerId = urlToId(readerId)
+  return await setASync(`${readerId}-library`, new Date().getTime(), 'EX', 100)
+}
+
+const libraryCacheGet = async (readerId, check) => {
+  if (!check) return undefined // so we can skip when the 'if-modified-since' header is not used'
+  readerId = urlToId(readerId)
+  return await getAsync(`${readerId}-library`)
+}
+
+const quitCache = () => {
+  client.quit()
+}
+
+module.exports = { libraryCacheUpdate, libraryCacheGet, quitCache }

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,9 +1,12 @@
 const redis = require('redis')
-const client = redis.createClient({
-  host: process.env.REDIS_HOST,
-  port: process.env.REDIS_PORT,
-  password: process.env.REDIS_PASSWORD
-})
+let client
+if (process.env.REDIS_PASSWORD) {
+  client = redis.createClient({
+    host: process.env.REDIS_HOST,
+    port: process.env.REDIS_PORT,
+    password: process.env.REDIS_PASSWORD
+  })
+}
 
 const { promisify } = require('util')
 const getAsync = promisify(client.get).bind(client)
@@ -13,7 +16,7 @@ const { urlToId } = require('./utils')
 
 const libraryCacheUpdate = async readerId => {
   readerId = urlToId(readerId)
-  return await setASync(`${readerId}-library`, new Date().getTime(), 'EX', 100)
+  return await setASync(`${readerId}-library`, new Date().getTime(), 'EX', 3600)
 }
 
 const libraryCacheGet = async (readerId, check) => {

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,32 +1,38 @@
 const redis = require('redis')
-let client
+const { urlToId } = require('./utils')
+
+let libraryCacheGet, libraryCacheUpdate, quitCache
+
 if (process.env.REDIS_PASSWORD) {
-  client = redis.createClient({
+  const client = redis.createClient({
     host: process.env.REDIS_HOST,
     port: process.env.REDIS_PORT,
     password: process.env.REDIS_PASSWORD
   })
-}
 
-const { promisify } = require('util')
-const getAsync = promisify(client.get).bind(client)
-const setASync = promisify(client.set).bind(client)
+  const { promisify } = require('util')
+  const getAsync = promisify(client.get).bind(client)
+  const setASync = promisify(client.set).bind(client)
 
-const { urlToId } = require('./utils')
+  libraryCacheUpdate = async readerId => {
+    readerId = urlToId(readerId)
+    return await setASync(
+      `${readerId}-library`,
+      new Date().getTime(),
+      'EX',
+      3600
+    )
+  }
 
-const libraryCacheUpdate = async readerId => {
-  readerId = urlToId(readerId)
-  return await setASync(`${readerId}-library`, new Date().getTime(), 'EX', 3600)
-}
+  libraryCacheGet = async (readerId, check) => {
+    if (!check) return undefined // so we can skip when the 'if-modified-since' header is not used'
+    readerId = urlToId(readerId)
+    return await getAsync(`${readerId}-library`)
+  }
 
-const libraryCacheGet = async (readerId, check) => {
-  if (!check) return undefined // so we can skip when the 'if-modified-since' header is not used'
-  readerId = urlToId(readerId)
-  return await getAsync(`${readerId}-library`)
-}
-
-const quitCache = () => {
-  client.quit()
+  quitCache = () => {
+    client.quit()
+  }
 }
 
 module.exports = { libraryCacheUpdate, libraryCacheGet, quitCache }

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,9 +1,11 @@
 const redis = require('redis')
 const { urlToId } = require('./utils')
 
-let libraryCacheGet = () => undefined
+// this is to make sure that the tests work properly on pull requests:
+// the cache is not used in pull requests because travis does not have access to the redis password
+let libraryCacheGet = async () => Promise.resolve()
 let libraryCacheUpdate = () => undefined
-let quitCache
+let quitCache = () => undefined
 
 if (process.env.REDIS_PASSWORD) {
   const client = redis.createClient({


### PR DESCRIPTION
This implements the if-modified-since header for the library route.

If the library has not been modified, it returns a 304 status

The library is considered modified by these actions:
- create publication
- update publication
- delete publication
- create tag
- update tag
- delete tag
- assign publication to tag
- remove publication from tag

I have set the cache data to expire after 100 seconds. I now realise that is quite short. It was useful for testing... but I will change that. Maybe an hour? 
