### PR TITLE
Added propreties to Publication database table

### DIFF
--- a/doc.json
+++ b/doc.json
@@ -414,68 +414,6 @@
         }
       }
     },
-    "/publication-{id}/file-upload": {
-      "post": {
-        "tags": [
-          "publications"
-        ],
-        "description": "POST /publication-:id/file-upload",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "description": "the id of the publication"
-          }
-        ],
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "type": "binary"
-                  },
-                  "documentPath": {
-                    "type": "string"
-                  },
-                  "mediaType": {
-                    "type": "string"
-                  },
-                  "json": {
-                    "type": "string",
-                    "description": "stringified json data"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "file created"
-          },
-          "400": {
-            "description": "No file was included with upload OR Error connecting to google bucket"
-          },
-          "403": {
-            "description": "Access to publication {id} disallowed"
-          },
-          "404": {
-            "description": "No publication with ID {id}"
-          }
-        }
-      }
-    },
     "/publication-{id}": {
       "get": {
         "tags": [
@@ -1251,10 +1189,7 @@
           "format": "url"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "Publication"
-          ]
+          "type": "string"
         },
         "summaryMap": {
           "type": "object",
@@ -1286,12 +1221,18 @@
             "format": "url"
           }
         },
-        "description": {
+        "abstract": {
           "type": "string"
         },
         "datePublished": {
           "type": "string",
           "format": "timestamp"
+        },
+        "numberOfPages": {
+          "type": "number"
+        },
+        "encodingFormat": {
+          "type": "string"
         },
         "readingOrder": {
           "type": "array",
@@ -1341,10 +1282,7 @@
           "format": "url"
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "Publication"
-          ]
+          "type": "string"
         },
         "summaryMap": {
           "type": "object",
@@ -1379,13 +1317,19 @@
         "json": {
           "type": "object"
         },
+        "numberOfPages": {
+          "type": "number"
+        },
+        "encodingFormat": {
+          "type": "string"
+        },
         "resources": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/link"
           }
         },
-        "description": {
+        "abstract": {
           "type": "string"
         },
         "datePublished": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1549,11 +1549,6 @@ var n=this.pipeline.run(e.tokenizer(t)),r=new e.Vector,i=[],o=this._fields.reduc
                   </li>
                 
                   <li>
-                    <a href="#post__publication--id-_file-upload" class="toc-h2 toc-link" data-title="post__publication-{id}_file-upload">post__publication-{id}_file-upload</a>
-                    
-                  </li>
-                
-                  <li>
                     <a href="#get__publication--id-" class="toc-h2 toc-link" data-title="get__publication-{id}">get__publication-{id}</a>
                     
                   </li>
@@ -1802,13 +1797,13 @@ fetch(<span class="hljs-string">'/activity-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
   },
   <span class="hljs-attr">"summaryMap"</span>: {
     <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
   },
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
 }
 </code></pre>
 <h3 id="get__activity-{id}-responses">Responses</h3>
@@ -2363,144 +2358,6 @@ fetch(<span class="hljs-string">'/publication-{id}/{path}'</span>,
 To perform this operation, you must be authenticated by means of one of the following methods:
 Bearer
 </aside>
-<h2 id="post__publication--id-_file-upload">post__publication-{id}_file-upload</h2>
-<blockquote>
-<p>Code samples</p>
-</blockquote>
-<pre class="highlight tab tab-javascript--nodejs"><code><span class="hljs-keyword">const</span> fetch = <span class="hljs-built_in">require</span>(<span class="hljs-string">'node-fetch'</span>);
-<span class="hljs-keyword">const</span> inputBody = <span class="hljs-string">'{
-  "file": null,
-  "documentPath": "string",
-  "mediaType": "string",
-  "json": "string"
-}'</span>;
-<span class="hljs-keyword">const</span> headers = {
-  <span class="hljs-string">'Content-Type'</span>:<span class="hljs-string">'multipart/form-data'</span>,
-  <span class="hljs-string">'Authorization'</span>:<span class="hljs-string">'Bearer {access-token}'</span>
-
-};
-
-fetch(<span class="hljs-string">'/publication-{id}/file-upload'</span>,
-{
-  <span class="hljs-attr">method</span>: <span class="hljs-string">'POST'</span>,
-  <span class="hljs-attr">body</span>: inputBody,
-  <span class="hljs-attr">headers</span>: headers
-})
-.then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">res</span>) </span>{
-    <span class="hljs-keyword">return</span> res.json();
-}).then(<span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">body</span>) </span>{
-    <span class="hljs-built_in">console</span>.log(body);
-});
-
-</code></pre>
-<p><code>POST /publication-{id}/file-upload</code></p>
-<p>POST /publication-:id/file-upload</p>
-<blockquote>
-<p>Body parameter</p>
-</blockquote>
-<pre class="highlight tab tab-yaml"><code><span class="hljs-attr">file:</span> <span class="hljs-literal">null</span>
-<span class="hljs-attr">documentPath:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">mediaType:</span> <span class="hljs-string">string</span>
-<span class="hljs-attr">json:</span> <span class="hljs-string">string</span>
-
-</code></pre>
-<h3 id="post__publication-{id}_file-upload-parameters">Parameters</h3>
-<table>
-<thead>
-<tr>
-<th>Name</th>
-<th>In</th>
-<th>Type</th>
-<th>Required</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>id</td>
-<td>path</td>
-<td>string</td>
-<td>true</td>
-<td>the id of the publication</td>
-</tr>
-<tr>
-<td>body</td>
-<td>body</td>
-<td>object</td>
-<td>false</td>
-<td>none</td>
-</tr>
-<tr>
-<td>» file</td>
-<td>body</td>
-<td>binary</td>
-<td>false</td>
-<td>none</td>
-</tr>
-<tr>
-<td>» documentPath</td>
-<td>body</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-</tr>
-<tr>
-<td>» mediaType</td>
-<td>body</td>
-<td>string</td>
-<td>false</td>
-<td>none</td>
-</tr>
-<tr>
-<td>» json</td>
-<td>body</td>
-<td>string</td>
-<td>false</td>
-<td>stringified json data</td>
-</tr>
-</tbody>
-</table>
-<h3 id="post__publication-{id}_file-upload-responses">Responses</h3>
-<table>
-<thead>
-<tr>
-<th>Status</th>
-<th>Meaning</th>
-<th>Description</th>
-<th>Schema</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>200</td>
-<td><a href="https://tools.ietf.org/html/rfc7231#section-6.3.1">OK</a></td>
-<td>file created</td>
-<td>None</td>
-</tr>
-<tr>
-<td>400</td>
-<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.1">Bad Request</a></td>
-<td>No file was included with upload OR Error connecting to google bucket</td>
-<td>None</td>
-</tr>
-<tr>
-<td>403</td>
-<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.3">Forbidden</a></td>
-<td>Access to publication {id} disallowed</td>
-<td>None</td>
-</tr>
-<tr>
-<td>404</td>
-<td><a href="https://tools.ietf.org/html/rfc7231#section-6.5.4">Not Found</a></td>
-<td>No publication with ID {id}</td>
-<td>None</td>
-</tr>
-</tbody>
-</table>
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-Bearer
-</aside>
 <h2 id="get__publication--id-">get__publication-{id}</h2>
 <blockquote>
 <p>Code samples</p>
@@ -2557,7 +2414,7 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
 </blockquote>
 <pre class="highlight tab tab-json"><code>{
   <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Publication"</span>,
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"summaryMap"</span>: {
     <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
   },
@@ -2577,8 +2434,10 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
   <span class="hljs-attr">"replies"</span>: [
     <span class="hljs-string">"string"</span>
   ],
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
+  <span class="hljs-attr">"abstract"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"datePublished"</span>: <span class="hljs-string">"string"</span>,
+  <span class="hljs-attr">"numberOfPages"</span>: <span class="hljs-number">0</span>,
+  <span class="hljs-attr">"encodingFormat"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"readingOrder"</span>: [
     {
       <span class="hljs-attr">"href"</span>: <span class="hljs-string">"string"</span>,
@@ -2628,8 +2487,8 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
     <span class="hljs-attr">"profile"</span>: {},
     <span class="hljs-attr">"preferences"</span>: {},
     <span class="hljs-attr">"json"</span>: {},
-    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+    <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+    <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
   },
   <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"string"</span>
@@ -2750,7 +2609,7 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
 <td>none</td>
 </tr>
 <tr>
-<td>» description</td>
+<td>» abstract</td>
 <td>string</td>
 <td>false</td>
 <td>none</td>
@@ -2759,6 +2618,20 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
 <tr>
 <td>» datePublished</td>
 <td>string(timestamp)</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>» numberOfPages</td>
+<td>number</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>» encodingFormat</td>
+<td>string</td>
 <td>false</td>
 <td>none</td>
 <td>none</td>
@@ -2977,10 +2850,6 @@ fetch(<span class="hljs-string">'/publication-{id}'</span>,
 </tr>
 </thead>
 <tbody>
-<tr>
-<td>type</td>
-<td>Publication</td>
-</tr>
 <tr>
 <td>type</td>
 <td>Person</td>
@@ -3208,13 +3077,13 @@ fetch(<span class="hljs-string">'/reader-{id}/activity'</span>,
         <span class="hljs-attr">"profile"</span>: {},
         <span class="hljs-attr">"preferences"</span>: {},
         <span class="hljs-attr">"json"</span>: {},
-        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+        <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+        <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
       },
       <span class="hljs-attr">"summaryMap"</span>: {
         <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
       },
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
     }
   ]
 }
@@ -3868,7 +3737,7 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
   <span class="hljs-attr">"items"</span>: [
     {
       <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"Publication"</span>,
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"summaryMap"</span>: {
         <span class="hljs-attr">"en"</span>: <span class="hljs-string">"string"</span>
       },
@@ -3889,6 +3758,8 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
         <span class="hljs-string">"string"</span>
       ],
       <span class="hljs-attr">"json"</span>: {},
+      <span class="hljs-attr">"numberOfPages"</span>: <span class="hljs-number">0</span>,
+      <span class="hljs-attr">"encodingFormat"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"resources"</span>: [
         {
           <span class="hljs-attr">"href"</span>: <span class="hljs-string">"string"</span>,
@@ -3900,7 +3771,7 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
           <span class="hljs-attr">"width"</span>: <span class="hljs-number">0</span>
         }
       ],
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"abstract"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"datePublished"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"readerId"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"published"</span>: <span class="hljs-string">"string"</span>,
@@ -4129,6 +4000,20 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <td>none</td>
 </tr>
 <tr>
+<td>»» numberOfPages</td>
+<td>number</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
+<td>»» encodingFormat</td>
+<td>string</td>
+<td>false</td>
+<td>none</td>
+<td>none</td>
+</tr>
+<tr>
 <td>»» resources</td>
 <td>[<a href="#schema#/definitions/link">#/definitions/link</a>]</td>
 <td>false</td>
@@ -4185,7 +4070,7 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <td>none</td>
 </tr>
 <tr>
-<td>»» description</td>
+<td>»» abstract</td>
 <td>string</td>
 <td>false</td>
 <td>none</td>
@@ -4237,10 +4122,6 @@ fetch(<span class="hljs-string">'/reader-{id}/library'</span>,
 <tr>
 <td>type</td>
 <td>reader:Tag</td>
-</tr>
-<tr>
-<td>type</td>
-<td>Publication</td>
 </tr>
 <tr>
 <td>type</td>
@@ -4408,8 +4289,8 @@ fetch(<span class="hljs-string">'/reader-{id}/notes'</span>,
       <span class="hljs-attr">"oa:hasSelector"</span>: {},
       <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"@context"</span>: [],
-      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
+      <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+      <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
       <span class="hljs-attr">"publication"</span>: {
         <span class="hljs-attr">"id"</span>: <span class="hljs-string">"string"</span>,
         <span class="hljs-attr">"author"</span>: [
@@ -4760,8 +4641,8 @@ fetch(<span class="hljs-string">'/reader-{id}'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
 }
 </code></pre>
 <h3 id="get__reader-{id}-responses">Responses</h3>
@@ -5267,8 +5148,8 @@ fetch(<span class="hljs-string">'/whoami'</span>,
   <span class="hljs-attr">"profile"</span>: {},
   <span class="hljs-attr">"preferences"</span>: {},
   <span class="hljs-attr">"json"</span>: {},
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>
 }
 </code></pre>
 <h3 id="get__whoami-responses">Responses</h3>
@@ -5479,8 +5360,8 @@ fetch(<span class="hljs-string">'/job-{id}'</span>,
 <pre class="highlight tab tab-json"><code>{
   <span class="hljs-attr">"id"</span>: <span class="hljs-number">0</span>,
   <span class="hljs-attr">"type"</span>: <span class="hljs-string">"epub"</span>,
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-  <span class="hljs-attr">"finished"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+  <span class="hljs-attr">"finished"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
   <span class="hljs-attr">"error"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"publicationId"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"status"</span>: <span class="hljs-number">302</span>
@@ -5668,8 +5549,8 @@ fetch(<span class="hljs-string">'/note-{id}'</span>,
   <span class="hljs-attr">"oa:hasSelector"</span>: {},
   <span class="hljs-attr">"content"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"@context"</span>: [],
-  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
-  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-10-21T15:52:18Z"</span>,
+  <span class="hljs-attr">"published"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
+  <span class="hljs-attr">"updated"</span>: <span class="hljs-string">"2019-11-20T15:46:58Z"</span>,
   <span class="hljs-attr">"inReplyTo"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"context"</span>: <span class="hljs-string">"string"</span>,
   <span class="hljs-attr">"json"</span>: {}

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,9 +1,10 @@
 // Update with your config settings.
+require('dotenv').config()
 
 const path = require('path')
 module.exports = {
   postgresql: {
-    client: 'postgresql',
+    client: 'pg',
     connection: {
       host: process.env.POSTGRE_INSTANCE,
       database: process.env.POSTGRE_DB,

--- a/migrations/20190409155848_publication.js
+++ b/migrations/20190409155848_publication.js
@@ -8,7 +8,7 @@ exports.up = function (knex, Promise) {
     table.integer('numberOfPages')
     table.string('encodingFormat')
     table.jsonb('metadata')
-    table.jsonb('readingOrder').notNullable()
+    table.jsonb('readingOrder')
     table.jsonb('resources')
     table.jsonb('links')
     table.jsonb('json')

--- a/migrations/20190409155848_publication.js
+++ b/migrations/20190409155848_publication.js
@@ -1,9 +1,12 @@
 exports.up = function (knex, Promise) {
   return knex.schema.createTable('Publication', function (table) {
     table.string('id').primary()
-    table.text('description')
+    table.text('abstract')
     table.string('name').notNullable()
+    table.string('type').notNullable()
     table.timestamp('datePublished')
+    table.integer('numberOfPages')
+    table.string('encodingFormat')
     table.jsonb('metadata')
     table.jsonb('readingOrder').notNullable()
     table.jsonb('resources')

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -165,6 +165,10 @@ class Publication extends BaseModel {
     props.readerId = reader.id
     props.metadata = metadata
 
+    if (!props.type) {
+      return Error('no type')
+    }
+
     if (props.readingOrder) props.readingOrder = { data: props.readingOrder }
     if (props.links) props.links = { data: props.links }
     if (props.resources) props.resources = { data: props.resources }

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -18,11 +18,14 @@ const { libraryCacheUpdate } = require('../utils/cache')
 /*::
 type PublicationType = {
   id: string,
-  description?: string,
+  abstract?: string,
   name: string,
+  type: string,
   datePublished?: Date,
+  numberOfPages: number,
+  encodingFormat: string,
   metadata?: Object,
-  readingOrder: Object,
+  readingOrder?: Object,
   resources?: Object,
   links?: Object,
   json?: Object,
@@ -57,12 +60,15 @@ class Publication extends BaseModel {
         id: { type: 'string' },
         readerId: { type: 'string' },
         name: { type: 'string' },
+        type: { type: 'string' },
         author: { type: 'array' },
-        description: { type: 'string' },
+        abstract: { type: 'string' },
         editor: { type: 'array' },
         datePublished: { type: 'string', format: 'date-time' },
         inLanguage: { type: 'array' },
         keywords: { type: 'array' },
+        numberOfPages: { type: 'integer' },
+        encodingFormat: { type: 'string' },
         readingOrder: { type: 'object' },
         resources: { type: 'object' },
         links: { type: 'object' },
@@ -71,7 +77,7 @@ class Publication extends BaseModel {
         published: { type: 'string', format: 'date-time' },
         deleted: { type: 'string', format: 'date-time' }
       },
-      required: ['name', 'readerId', 'readingOrder']
+      required: ['name', 'readerId', 'type']
     }
   }
   static get relationMappings () /*: any */ {
@@ -146,7 +152,10 @@ class Publication extends BaseModel {
     const props = _.pick(publication, [
       'id',
       'name',
-      'description',
+      'type',
+      'numberOfPages',
+      'encodingFormat',
+      'abstract',
       'datePublished',
       'json',
       'readingOrder',
@@ -155,10 +164,7 @@ class Publication extends BaseModel {
     ])
     props.readerId = reader.id
     props.metadata = metadata
-    // since this is stored under data:, the validation does not kick in if it is missing.
-    if (!props.readingOrder || props.readingOrder.length === 0) {
-      return Error('no readingOrder')
-    }
+
     props.readingOrder = { data: props.readingOrder }
     if (props.links) props.links = { data: props.links }
     if (props.resources) props.resources = { data: props.resources }
@@ -262,7 +268,8 @@ class Publication extends BaseModel {
 
     const modifications = _.pick(newPubObj, [
       'name',
-      'description',
+      'abstract',
+      'type',
       'datePublished',
       'json',
       'readingOrder',
@@ -326,7 +333,6 @@ class Publication extends BaseModel {
   $formatJson (json /*: any */) /*: any */ {
     json = super.$formatJson(json)
     json.id = json.id + '/'
-    json.type = 'Publication'
     if (json.attributions) {
       attributionTypes.forEach(type => {
         json[type] = json.attributions.filter(

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -165,7 +165,7 @@ class Publication extends BaseModel {
     props.readerId = reader.id
     props.metadata = metadata
 
-    props.readingOrder = { data: props.readingOrder }
+    if (props.readingOrder) props.readingOrder = { data: props.readingOrder }
     if (props.links) props.links = { data: props.links }
     if (props.resources) props.resources = { data: props.resources }
 
@@ -214,7 +214,7 @@ class Publication extends BaseModel {
     if (latestReadActivity && latestReadActivity.selector) {
       pub.position = latestReadActivity.selector
     }
-    pub.readingOrder = pub.readingOrder.data
+    if (pub.readingOrder) pub.readingOrder = pub.readingOrder.data
     if (pub.links) pub.links = pub.links.data
     if (pub.resources) pub.resources = pub.resources.data
 
@@ -274,7 +274,9 @@ class Publication extends BaseModel {
       'json',
       'readingOrder',
       'resources',
-      'links'
+      'links',
+      'numberOfPages',
+      'encodingFormat'
     ])
 
     if (metadata) {

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -142,10 +142,13 @@ class Reader extends BaseModel {
         builder
           .select(
             'Publication.id',
-            'Publication.description',
+            'Publication.abstract',
             'Publication.metadata',
             'Publication.name',
             'Publication.datePublished',
+            'Publication.type',
+            'Publication.numberOfPages',
+            'Publication.encodingFormat',
             'Publication.json',
             'Publication.readerId',
             'Publication.published',
@@ -301,9 +304,10 @@ class Reader extends BaseModel {
           pubBuilder.select(
             'id',
             'name',
-            'description',
+            'abstract',
             'datePublished',
-            'metadata'
+            'metadata',
+            'type'
           )
         })
         builder.whereNull('Note.deleted')

--- a/processFiles/saveFiles.js
+++ b/processFiles/saveFiles.js
@@ -1,8 +1,7 @@
-const { updateJob } = require('./updateJob')
 const { Document } = require('../models/Document')
 const elasticsearchQueue = require('./searchQueue')
 
-exports.saveFiles = async (book, media, zip, storage, file, jobId) => {
+exports.saveFiles = async (book, media, zip, storage, file) => {
   const bucketName = 'publication-file-storage-test'
   const bucket = storage.bucket(bucketName)
 

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -39,7 +39,6 @@ const boom = require('@hapi/boom')
  *         format: url
  *       type:
  *         type: string
- *         enum: ['Publication']
  *       summaryMap:
  *         type: object
  *         properties:
@@ -60,11 +59,15 @@ const boom = require('@hapi/boom')
  *         items:
  *           type: string
  *           format: url
- *       description:
+ *       abstract:
  *         type: string
  *       datePublished:
  *         type: string
  *         format: timestamp
+ *       numberOfPages:
+ *         type: number
+ *       encodingFormat:
+ *         type: string
  *       readingOrder:
  *         type: array
  *         items:

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -19,7 +19,6 @@ const { libraryCacheGet } = require('../utils/cache')
  *         format: url
  *       type:
  *         type: string
- *         enum: ['Publication']
  *       summaryMap:
  *         type: object
  *         properties:
@@ -42,11 +41,15 @@ const { libraryCacheGet } = require('../utils/cache')
  *           format: url
  *       json:
  *         type: object
+ *       numberOfPages:
+ *         type: number
+ *       encodingFormat:
+ *         type: string
  *       resources:
  *         type: array
  *         items:
  *           $ref: '#/definitions/link'
- *       description:
+ *       abstract:
  *         type: string
  *       datePublished:
  *         type: string

--- a/tests/google-integration/search.test.js
+++ b/tests/google-integration/search.test.js
@@ -10,8 +10,6 @@ const {
   addPubToCollection
 } = require('../utils/utils')
 
-const { urlToId } = require('../../utils/utils')
-
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -249,7 +249,7 @@ const test = async () => {
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 3)
     // documents should include:
-    await tap.equal(body.items[0].type, 'book')
+    await tap.equal(body.items[0].type, 'Book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'new book 3')
@@ -457,7 +457,7 @@ const test = async () => {
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 2)
     // documents should include:
-    await tap.equal(body.items[0].type, 'book')
+    await tap.equal(body.items[0].type, 'Book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'new book 2 - the sequel')

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -249,7 +249,7 @@ const test = async () => {
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 3)
     // documents should include:
-    await tap.equal(body.items[0].type, 'Publication')
+    await tap.equal(body.items[0].type, 'book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'new book 3')
@@ -457,7 +457,7 @@ const test = async () => {
     await tap.ok(Array.isArray(body.items))
     await tap.equal(body.items.length, 2)
     // documents should include:
-    await tap.equal(body.items[0].type, 'Publication')
+    await tap.equal(body.items[0].type, 'book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'new book 2 - the sequel')

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -41,11 +41,13 @@ const test = async () => {
 
   await tap.test('Get Library containing a publication', async () => {
     await createPublication(readerUrl, {
-      type: 'Publication',
+      type: 'book',
       name: 'Publication A',
       author: ['John Smith'],
       editor: 'Jane Doe',
-      description: 'this is a description!!',
+      abstract: 'this is a description!!',
+      numberOfPages: 99,
+      encodingFormat: 'epub',
       keywords: 'one, two',
       links: [{ property: 'value' }],
       readingOrder: [{ name: 'one' }, { name: 'two' }, { name: 'three' }],
@@ -72,7 +74,7 @@ const test = async () => {
     await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
-    await tap.equal(body.items[0].type, 'Publication')
+    await tap.equal(body.items[0].type, 'book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'Publication A')
@@ -81,6 +83,9 @@ const test = async () => {
     await tap.equal(body.items[0].keywords, 'one, two')
     await tap.ok(body.items[0].json)
     await tap.ok(body.items[0].resources)
+    await tap.equal(body.items[0].abstract, 'this is a description!!')
+    await tap.equal(body.items[0].numberOfPages, 99)
+    await tap.equal(body.items[0].encodingFormat, 'epub')
     // documents should NOT include:
     await tap.notOk(body.items[0].readingOrder)
     await tap.notOk(body.items[0].links)
@@ -237,7 +242,7 @@ const test = async () => {
               object: {
                 type: 'Publication',
                 id: publication.id,
-                description: 'new description!'
+                abstract: 'new description!'
               }
             })
           )

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -41,7 +41,7 @@ const test = async () => {
 
   await tap.test('Get Library containing a publication', async () => {
     await createPublication(readerUrl, {
-      type: 'book',
+      type: 'Book',
       name: 'Publication A',
       author: ['John Smith'],
       editor: 'Jane Doe',
@@ -74,7 +74,7 @@ const test = async () => {
     await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
-    await tap.equal(body.items[0].type, 'book')
+    await tap.equal(body.items[0].type, 'Book')
     await tap.type(body.items[0].id, 'string')
     await tap.type(body.items[0].name, 'string')
     await tap.equal(body.items[0].name, 'Publication A')

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -296,7 +296,7 @@ const test = async () => {
     await tap.test(
       'Get Library with if-modified-since header - after publication removed from collection',
       async () => {
-        const removeRes = await request(app)
+        await request(app)
           .post(`${readerUrl}/activity`)
           .set('Host', 'reader-api.test')
           .set('Authorization', `Bearer ${token}`)

--- a/tests/integration/note-create.test.js
+++ b/tests/integration/note-create.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createDocument
 } = require('../utils/utils')

--- a/tests/integration/publication-delete.test.js
+++ b/tests/integration/publication-delete.test.js
@@ -34,7 +34,7 @@ const test = async app => {
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
-    description: 'this is a description!!',
+    abstract: 'this is a description!!',
     inLanguage: 'English',
     datePublished: now,
     links: [

--- a/tests/integration/publication-delete.test.js
+++ b/tests/integration/publication-delete.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createDocument
 } = require('../utils/utils')

--- a/tests/integration/publication-get.test.js
+++ b/tests/integration/publication-get.test.js
@@ -18,11 +18,13 @@ const test = async app => {
   const now = new Date().toISOString()
 
   const publicationObject = {
-    type: 'Publication',
+    type: 'book',
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
-    description: 'this is a description!!',
+    abstract: 'this is a description!!',
+    numberOfPages: 250,
+    encodingFormat: 'epub',
     inLanguage: 'English',
     datePublished: now,
     links: [
@@ -87,12 +89,12 @@ const test = async app => {
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
     await tap.ok(body.id.endsWith('/'))
-    await tap.equal(body.type, 'Publication')
+    await tap.equal(body.type, 'book')
     await tap.equal(body.name, 'Publication A')
     await tap.ok(_.isArray(body.author))
     await tap.equal(body.author[0].name, 'John Smith')
     await tap.equal(body.editor[0].name, 'Jané S. Doe')
-    await tap.equal(body.description, 'this is a description!!')
+    await tap.equal(body.abstract, 'this is a description!!')
     await tap.ok(body.datePublished)
     await tap.equal(body.links[0].name, 'An example link')
     await tap.equal(
@@ -105,6 +107,8 @@ const test = async app => {
     await tap.ok(body.published)
     await tap.ok(body.updated)
     await tap.equal(body.inLanguage, 'English')
+    await tap.equal(body.numberOfPages, 250)
+    await tap.equal(body.encodingFormat, 'epub')
     // should not have a position
     await tap.notOk(body.position)
   })
@@ -171,7 +175,7 @@ const test = async app => {
 
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
-    await tap.equal(body.type, 'Publication')
+    await tap.equal(body.type, 'book')
     await tap.equal(body.name, 'Publication A')
     await tap.type(body.position, 'object')
     await tap.equal(body.position.property, 'last')

--- a/tests/integration/publication-get.test.js
+++ b/tests/integration/publication-get.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication
 } = require('../utils/utils')
 const _ = require('lodash')

--- a/tests/integration/publication-get.test.js
+++ b/tests/integration/publication-get.test.js
@@ -17,7 +17,7 @@ const test = async app => {
   const now = new Date().toISOString()
 
   const publicationObject = {
-    type: 'book',
+    type: 'Book',
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
@@ -88,7 +88,7 @@ const test = async app => {
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
     await tap.ok(body.id.endsWith('/'))
-    await tap.equal(body.type, 'book')
+    await tap.equal(body.type, 'Book')
     await tap.equal(body.name, 'Publication A')
     await tap.ok(_.isArray(body.author))
     await tap.equal(body.author[0].name, 'John Smith')
@@ -174,7 +174,7 @@ const test = async app => {
 
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
-    await tap.equal(body.type, 'book')
+    await tap.equal(body.type, 'Book')
     await tap.equal(body.name, 'Publication A')
     await tap.type(body.position, 'object')
     await tap.equal(body.position.property, 'last')

--- a/tests/integration/publication-update.test.js
+++ b/tests/integration/publication-update.test.js
@@ -19,12 +19,14 @@ const test = async app => {
   const now = new Date().toISOString()
 
   const publicationObject = {
-    type: 'Publication',
+    type: 'book',
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
-    description: 'this is a description!!',
+    abstract: 'this is a description!!',
     inLanguage: 'English',
+    numberOfPages: 333,
+    encodingFormat: 'epub',
     datePublished: now,
     links: [
       {
@@ -94,7 +96,9 @@ const test = async app => {
             id: publicationUrl,
             name: 'New name for pub A',
             // datePublished: timestamp,
-            description: 'New description for Publication',
+            abstract: 'New description for Publication',
+            numberOfPages: 444,
+            encodingFormat: 'new',
             json: { property: 'New value for json property' },
             inLanguage: ['Swahili', 'French'],
             keywords: ['newKeyWord1', 'newKeyWord2'],
@@ -136,9 +140,11 @@ const test = async app => {
     )
 
     await tap.equal(body.name, 'New name for pub A')
-    await tap.equal(body.description, 'New description for Publication')
+    await tap.equal(body.abstract, 'New description for Publication')
     // await tap.equal(body.datePublished, timestamp)
     await tap.equal(body.json.property, 'New value for json property')
+    await tap.equal(body.numberOfPages, 444)
+    await tap.equal(body.encodingFormat, 'new')
     await tap.equal(body.inLanguage[0], 'Swahili')
     await tap.equal(body.inLanguage[1], 'French')
     await tap.equal(body.keywords[0], 'newKeyWord1')
@@ -221,7 +227,7 @@ const test = async app => {
               id: publicationUrl + 'abc',
               name: 'New name for pub A',
               // datePublished: timestamp,
-              description: 'New description for Publication',
+              abstract: 'New description for Publication',
               json: { property: 'New value for json property' },
               inLanguage: ['Swahili', 'French'],
               keywords: ['newKeyWord1', 'newKeyWord2'],

--- a/tests/integration/publication-update.test.js
+++ b/tests/integration/publication-update.test.js
@@ -19,7 +19,7 @@ const test = async app => {
   const now = new Date().toISOString()
 
   const publicationObject = {
-    type: 'book',
+    type: 'Book',
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',

--- a/tests/integration/readActivity-create.test.js
+++ b/tests/integration/readActivity-create.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication
 } = require('../utils/utils')
 const { Reader } = require('../../models/Reader')

--- a/tests/integration/readerNotes-get.test.js
+++ b/tests/integration/readerNotes-get.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createNote,
   createDocument

--- a/tests/integration/readerNotes-orderBy.test.js
+++ b/tests/integration/readerNotes-orderBy.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createNote,
   createDocument

--- a/tests/integration/readerNotes-paginate.test.js
+++ b/tests/integration/readerNotes-paginate.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createNote,
   createDocument

--- a/tests/integration/tag-publication.test.js
+++ b/tests/integration/tag-publication.test.js
@@ -5,7 +5,6 @@ const {
   getToken,
   createUser,
   destroyDB,
-  getActivityFromUrl,
   createPublication,
   createTag
 } = require('../utils/utils')

--- a/tests/models/Attribution.test.js
+++ b/tests/models/Attribution.test.js
@@ -15,7 +15,7 @@ const test = async app => {
   const createdReader = await Reader.createReader(`auth0|foo${random}`, reader)
 
   const simplePublication = {
-    type: 'book',
+    type: 'Book',
     name: 'Publication A',
     readingOrder: [
       {

--- a/tests/models/Attribution.test.js
+++ b/tests/models/Attribution.test.js
@@ -15,7 +15,7 @@ const test = async app => {
   const createdReader = await Reader.createReader(`auth0|foo${random}`, reader)
 
   const simplePublication = {
-    type: 'Publication',
+    type: 'book',
     name: 'Publication A',
     readingOrder: [
       {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -30,6 +30,9 @@ const test = async app => {
     editor: ['Sample editor'],
     inLanguage: ['English'],
     keywords: ['key', 'words'],
+    numberOfPages: 666,
+    encodingFormat: 'epub',
+    datePublished: new Date(2011, 3, 20).toISOString(),
     json: {
       property1: 'value1'
     },
@@ -91,25 +94,7 @@ const test = async app => {
 
   const simplePublication = {
     name: 'Publication A',
-    type: 'book',
-    readingOrder: [
-      {
-        '@context': 'https://www.w3.org/ns/activitystreams',
-        type: 'Link',
-        href: 'http://example.org/abc',
-        hreflang: 'en',
-        mediaType: 'text/html',
-        name: 'An example link'
-      },
-      {
-        '@context': 'https://www.w3.org/ns/activitystreams',
-        type: 'Link',
-        href: 'http://example.org/abc2',
-        hreflang: 'en',
-        mediaType: 'text/html',
-        name: 'An example link2'
-      }
-    ]
+    type: 'book'
   }
 
   const createdTag = await Tag.createTag(urlToId(createdReader.id), {
@@ -157,6 +142,28 @@ const test = async app => {
     await tap.type(publication.reader, 'object')
     await tap.ok(publication.reader instanceof Reader)
   })
+
+  await tap.test(
+    'Get publication by id should return all metadata',
+    async () => {
+      publication = await Publication.byId(urlToId(publicationId2))
+      await tap.type(publication, 'object')
+      await tap.ok(publication instanceof Publication)
+      await tap.equal(publication.readerId, createdReader.id)
+      await tap.equal(publication.type, 'book')
+      await tap.equal(publication.abstract, 'description of publication A')
+      await tap.ok(publication.datePublished)
+      await tap.equal(publication.name, 'Publication A')
+      // does not extract attributions yet.
+      await tap.ok(publication.attributions)
+      await tap.equal(publication.numberOfPages, 666)
+      await tap.equal(publication.encodingFormat, 'epub')
+      await tap.equal(publication.json.property1, 'value1')
+      await tap.equal(publication.readingOrder.length, 2)
+      await tap.equal(publication.links.length, 2)
+      await tap.equal(publication.resources.length, 2)
+    }
+  )
 
   await tap.test('Publication addTag', async () => {
     const res = await Publication_Tag.addTagToPub(
@@ -236,10 +243,6 @@ const test = async app => {
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
     await tap.equal(newPub.name, pubRetrieved.name)
-    await tap.equal(
-      newPub.readingOrder.data[0].name,
-      pubRetrieved.readingOrder[0].name
-    )
   })
 
   await tap.test(
@@ -257,41 +260,41 @@ const test = async app => {
     }
   )
 
-  // await tap.test('Update publication datePublished', async () => {
-  //   const timestamp = new Date(2018, 01, 30).toISOString()
-  //   const newPubObj = {
-  //     id: publication.id,
-  //     datePublished: timestamp
-  //   }
+  await tap.test('Update publication datePublished', async () => {
+    const timestamp = new Date(2018, 01, 30).toISOString()
+    const newPubObj = {
+      id: publication.id,
+      datePublished: timestamp
+    }
 
-  //   const newPub = await Publication.update(newPubObj)
+    const newPub = await Publication.update(newPubObj)
 
-  //   // Retrieve the Publication that has just been updated
-  //   const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+    // Retrieve the Publication that has just been updated
+    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
 
-  //   await tap.ok(newPub)
-  //   await tap.ok(newPub instanceof Publication)
-  //   await tap.equal(
-  //     newPub.datePublished.toString(),
-  //     pubRetrieved.datePublished.toString()
-  //   )
-  // })
+    await tap.ok(newPub)
+    await tap.ok(newPub instanceof Publication)
+    await tap.equal(
+      newPub.datePublished.toString(),
+      pubRetrieved.datePublished.toString()
+    )
+  })
 
-  // await tap.test('Update publication abstract', async () => {
-  //   const newPubObj = {
-  //     id: publication.id,
-  //     abstract: 'New description for Publication'
-  //   }
+  await tap.test('Update publication abstract', async () => {
+    const newPubObj = {
+      id: publication.id,
+      abstract: 'New description for Publication'
+    }
 
-  //   const newPub = await Publication.update(newPubObj)
+    const newPub = await Publication.update(newPubObj)
 
-  //   // Retrieve the Publication that has just been updated
-  //   const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+    // Retrieve the Publication that has just been updated
+    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
 
-  //   await tap.ok(newPub)
-  //   await tap.ok(newPub instanceof Publication)
-  //   await tap.equal(newPub.abstract, pubRetrieved.abstract)
-  // })
+    await tap.ok(newPub)
+    await tap.ok(newPub instanceof Publication)
+    await tap.equal(newPub.abstract, pubRetrieved.abstract)
+  })
 
   await tap.test('Update publication json object', async () => {
     const newPubObj = {
@@ -307,6 +310,54 @@ const test = async app => {
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
     await tap.equal(newPub.json.property, pubRetrieved.json.property)
+  })
+
+  await tap.test('Update publication numberOfPages', async () => {
+    const newPubObj = {
+      id: publication.id,
+      numberOfPages: 555
+    }
+
+    const newPub = await Publication.update(newPubObj)
+
+    // Retrieve the Publication that has just been updated
+    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+
+    await tap.ok(newPub)
+    await tap.ok(newPub instanceof Publication)
+    await tap.equal(pubRetrieved.numberOfPages, 555)
+  })
+
+  await tap.test('Update publication encodingFormat', async () => {
+    const newPubObj = {
+      id: publication.id,
+      encodingFormat: 'pdf'
+    }
+
+    const newPub = await Publication.update(newPubObj)
+
+    // Retrieve the Publication that has just been updated
+    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+
+    await tap.ok(newPub)
+    await tap.ok(newPub instanceof Publication)
+    await tap.equal(pubRetrieved.encodingFormat, 'pdf')
+  })
+
+  await tap.test('Update publication type', async () => {
+    const newPubObj = {
+      id: publication.id,
+      type: 'article'
+    }
+
+    const newPub = await Publication.update(newPubObj)
+
+    // Retrieve the Publication that has just been updated
+    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+
+    await tap.ok(newPub)
+    await tap.ok(newPub instanceof Publication)
+    await tap.equal(pubRetrieved.type, 'article')
   })
 
   await tap.test('Update publication metadata', async () => {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -261,7 +261,7 @@ const test = async app => {
   )
 
   await tap.test('Update publication datePublished', async () => {
-    const timestamp = new Date(2018, 01, 30).toISOString()
+    const timestamp = new Date(2018, 1, 30).toISOString()
     const newPubObj = {
       id: publication.id,
       datePublished: timestamp

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -21,7 +21,8 @@ const test = async app => {
 
   const createPublicationObj = {
     name: 'Publication A',
-    description: 'description of publication A',
+    abstract: 'description of publication A',
+    type: 'book',
     author: [
       { type: 'Person', name: 'Sample Author' },
       { type: 'Organization', name: 'Org inc.' }
@@ -90,6 +91,7 @@ const test = async app => {
 
   const simplePublication = {
     name: 'Publication A',
+    type: 'book',
     readingOrder: [
       {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -275,21 +277,21 @@ const test = async app => {
   //   )
   // })
 
-  await tap.test('Update publication description', async () => {
-    const newPubObj = {
-      id: publication.id,
-      description: 'New description for Publication'
-    }
+  // await tap.test('Update publication abstract', async () => {
+  //   const newPubObj = {
+  //     id: publication.id,
+  //     abstract: 'New description for Publication'
+  //   }
 
-    const newPub = await Publication.update(newPubObj)
+  //   const newPub = await Publication.update(newPubObj)
 
-    // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(newPub.id))
+  //   // Retrieve the Publication that has just been updated
+  //   const pubRetrieved = await Publication.byId(urlToId(newPub.id))
 
-    await tap.ok(newPub)
-    await tap.ok(newPub instanceof Publication)
-    await tap.equal(newPub.description, pubRetrieved.description)
-  })
+  //   await tap.ok(newPub)
+  //   await tap.ok(newPub instanceof Publication)
+  //   await tap.equal(newPub.abstract, pubRetrieved.abstract)
+  // })
 
   await tap.test('Update publication json object', async () => {
     const newPubObj = {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -22,7 +22,7 @@ const test = async app => {
   const createPublicationObj = {
     name: 'Publication A',
     abstract: 'description of publication A',
-    type: 'book',
+    type: 'Book',
     author: [
       { type: 'Person', name: 'Sample Author' },
       { type: 'Organization', name: 'Org inc.' }
@@ -94,7 +94,7 @@ const test = async app => {
 
   const simplePublication = {
     name: 'Publication A',
-    type: 'book'
+    type: 'Book'
   }
 
   const createdTag = await Tag.createTag(urlToId(createdReader.id), {
@@ -150,7 +150,7 @@ const test = async app => {
       await tap.type(publication, 'object')
       await tap.ok(publication instanceof Publication)
       await tap.equal(publication.readerId, createdReader.id)
-      await tap.equal(publication.type, 'book')
+      await tap.equal(publication.type, 'Book')
       await tap.equal(publication.abstract, 'description of publication A')
       await tap.ok(publication.datePublished)
       await tap.equal(publication.name, 'Publication A')

--- a/tests/models/ReadActivity.test.js
+++ b/tests/models/ReadActivity.test.js
@@ -15,7 +15,7 @@ const test = async app => {
   const createdReader = await Reader.createReader(`auth0|foo${random}`, reader)
 
   const simplePublication = {
-    type: 'book',
+    type: 'Book',
     name: 'Publication A',
     readingOrder: [
       {

--- a/tests/models/ReadActivity.test.js
+++ b/tests/models/ReadActivity.test.js
@@ -15,7 +15,7 @@ const test = async app => {
   const createdReader = await Reader.createReader(`auth0|foo${random}`, reader)
 
   const simplePublication = {
-    type: 'Publication',
+    type: 'book',
     name: 'Publication A',
     readingOrder: [
       {

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -25,7 +25,7 @@ const test = async app => {
 
   const simplePublication = {
     name: 'Publication A',
-    type: 'book',
+    type: 'Book',
     readingOrder: [
       {
         '@context': 'https://www.w3.org/ns/activitystreams',

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -25,6 +25,7 @@ const test = async app => {
 
   const simplePublication = {
     name: 'Publication A',
+    type: 'book',
     readingOrder: [
       {
         '@context': 'https://www.w3.org/ns/activitystreams',

--- a/tests/performance/utils/createPublication.js
+++ b/tests/performance/utils/createPublication.js
@@ -24,11 +24,11 @@ const createPublication = async (token, readerUrl, number = 1) => {
           ],
           type: 'Create',
           object: {
-            type: 'Publication',
+            type: 'Book',
             name: 'Publication ' + i,
             author: ['John Smith'],
             editor: 'Jané S. Doe',
-            description: 'this is a description!!',
+            abstract: 'this is a description!!',
             inLanguage: 'English',
             links: [
               {

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -70,11 +70,13 @@ const createPublication = async (readerUrl, object = {}) => {
   const publicationDate = new Date(2002, 12, 25).toISOString()
   const pubObject = Object.assign(
     {
-      type: 'Book',
+      type: 'book',
       name: 'publication name',
       author: 'generic author',
       editor: 'generic editor',
       abstract: 'this is a description!!',
+      numberOfPages: 100,
+      encodingFormat: 'epub',
       keywords: 'one, two',
       datePublished: publicationDate,
       readingOrder: [

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -70,11 +70,11 @@ const createPublication = async (readerUrl, object = {}) => {
   const publicationDate = new Date(2002, 12, 25).toISOString()
   const pubObject = Object.assign(
     {
-      type: 'Publication',
+      type: 'Book',
       name: 'publication name',
       author: 'generic author',
       editor: 'generic editor',
-      description: 'this is a description!!',
+      abstract: 'this is a description!!',
       keywords: 'one, two',
       datePublished: publicationDate,
       readingOrder: [

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -70,7 +70,7 @@ const createPublication = async (readerUrl, object = {}) => {
   const publicationDate = new Date(2002, 12, 25).toISOString()
   const pubObject = Object.assign(
     {
-      type: 'book',
+      type: 'Book',
       name: 'publication name',
       author: 'generic author',
       editor: 'generic editor',


### PR DESCRIPTION
So those are the new properties that have their own database column:
- abstract (replaces description)
- type 
- numberOfPages
- encodingFormat

I also made readingOrder optional. 'type' is now required. Which reminds me that I should add tests to make sure we handle missing type errors correctly. 

Aside from that I updated the tests, and I made sure that getting the publication and getting the library will also return the new properties. 
