### PR TITLE
Add metadata and attributions

### DIFF
--- a/models/Publication.js
+++ b/models/Publication.js
@@ -6,14 +6,23 @@ const _ = require('lodash')
 const { Attribution } = require('./Attribution')
 const { ReadActivity } = require('./ReadActivity')
 const { Note } = require('./Note')
-
-const metadataProps = ['inLanguage', 'keywords']
-const attributionTypes = ['author', 'editor']
 const { urlToId } = require('../utils/utils')
-
 const elasticsearchQueue = require('../processFiles/searchQueue')
-
 const { libraryCacheUpdate } = require('../utils/cache')
+
+const metadataProps = [
+  'inLanguage',
+  'keywords',
+  'url',
+  'dateModified',
+  'bookEdition',
+  'bookFormat',
+  'isbn',
+  'copyrightYear',
+  'genre',
+  'license'
+]
+const attributionTypes = ['author', 'editor']
 
 /*::
 type PublicationType = {
@@ -67,6 +76,14 @@ class Publication extends BaseModel {
         datePublished: { type: 'string', format: 'date-time' },
         inLanguage: { type: 'array' },
         keywords: { type: 'array' },
+        url: { type: 'string', format: 'url' },
+        dateModified: { type: 'string', format: 'date-time' },
+        bookEdition: { type: 'string' },
+        bookFormat: { type: 'string ' },
+        isbn: { type: 'string' },
+        copyrightYear: { type: 'integer' },
+        genre: { type: 'romance' },
+        license: { type: 'string' },
         numberOfPages: { type: 'integer' },
         encodingFormat: { type: 'string' },
         readingOrder: { type: 'object' },

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -22,7 +22,15 @@ const metadataProps = [
   'genre',
   'license'
 ]
-const attributionTypes = ['author', 'editor']
+const attributionTypes = [
+  'author',
+  'editor',
+  'contributor',
+  'creator',
+  'illustrator',
+  'publisher',
+  'translator'
+]
 
 /*::
 type PublicationType = {

--- a/routes/publication.js
+++ b/routes/publication.js
@@ -54,6 +54,26 @@ const boom = require('@hapi/boom')
  *         type: array
  *         items:
  *           $ref: '#/definitions/annotation'
+ *       creator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       contributor:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       illustrator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       publisher:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       translator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
  *       replies:
  *         type: array
  *         items:
@@ -67,6 +87,21 @@ const boom = require('@hapi/boom')
  *       numberOfPages:
  *         type: number
  *       encodingFormat:
+ *         type: string
+ *       url:
+ *         type: string
+ *       dateModified:
+ *         type: string
+ *         format: timestamp
+ *       bookEdition:
+ *         type: string
+ *       isbn:
+ *         type: string
+ *       copyrightYear:
+ *         type: number
+ *       genre:
+ *         type: string
+ *       license:
  *         type: string
  *       readingOrder:
  *         type: array

--- a/routes/reader-library.js
+++ b/routes/reader-library.js
@@ -34,6 +34,26 @@ const { libraryCacheGet } = require('../utils/cache')
  *         type: array
  *         items:
  *           $ref: '#/definitions/annotation'
+ *       creator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       contributor:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       illustrator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       publisher:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
+ *       translator:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/annotation'
  *       replies:
  *         type: array
  *         items:
@@ -44,6 +64,21 @@ const { libraryCacheGet } = require('../utils/cache')
  *       numberOfPages:
  *         type: number
  *       encodingFormat:
+ *         type: string
+ *       url:
+ *         type: string
+ *       dateModified:
+ *         type: string
+ *         format: timestamp
+ *       bookEdition:
+ *         type: string
+ *       isbn:
+ *         type: string
+ *       copyrightYear:
+ *         type: number
+ *       genre:
+ *         type: string
+ *       license:
  *         type: string
  *       resources:
  *         type: array
@@ -145,7 +180,7 @@ module.exports = app => {
    *         name: role
    *         schema:
    *           type: string
-   *           enum: ['author', 'editor']
+   *           enum: ['author', 'editor', 'contributor', 'creator', 'illustrator', 'publisher', 'translator']
    *         description: a modifier for attribution to specify the type of attribution
    *       - in: query
    *         name: author

--- a/tests/integration/library-filter.test.js
+++ b/tests/integration/library-filter.test.js
@@ -229,6 +229,28 @@ const test = async () => {
     editor: 'John doe'
   })
 
+  // adding for other attribution types
+  await createPublicationSimplified({
+    name: 'new book 3b',
+    contributor: 'John Doe'
+  })
+  await createPublicationSimplified({
+    name: 'new book 3c',
+    creator: 'John Doe'
+  })
+  await createPublicationSimplified({
+    name: 'new book 3d',
+    illustrator: 'John Doe'
+  })
+  await createPublicationSimplified({
+    name: 'new book 3e',
+    publisher: 'John Doe'
+  })
+  await createPublicationSimplified({
+    name: 'new book 3f',
+    translator: 'John Doe'
+  })
+
   await tap.test('Filter Library by attribution', async () => {
     const res = await request(app)
       .get(`${readerUrl}/library?attribution=John%20Doe`)
@@ -245,15 +267,20 @@ const test = async () => {
     await tap.type(body.id, 'string')
     await tap.equal(body.type, 'Collection')
     await tap.type(body.totalItems, 'number')
-    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.totalItems, 8)
     await tap.ok(Array.isArray(body.items))
-    await tap.equal(body.items.length, 3)
+    await tap.equal(body.items.length, 8)
     // documents should include:
-    await tap.equal(body.items[0].type, 'Book')
-    await tap.type(body.items[0].id, 'string')
-    await tap.type(body.items[0].name, 'string')
-    await tap.equal(body.items[0].name, 'new book 3')
-    await tap.equal(body.items[0].author[0].name, 'John Smith')
+    await tap.equal(body.items[0].name, 'new book 3f')
+    await tap.equal(body.items[1].name, 'new book 3e')
+    await tap.equal(body.items[2].name, 'new book 3d')
+    await tap.equal(body.items[3].name, 'new book 3c')
+    await tap.equal(body.items[4].name, 'new book 3b')
+    await tap.equal(body.items[5].type, 'Book')
+    await tap.type(body.items[5].id, 'string')
+    await tap.type(body.items[5].name, 'string')
+    await tap.equal(body.items[5].name, 'new book 3')
+    await tap.equal(body.items[5].author[0].name, 'John Smith')
   })
 
   await tap.test(
@@ -267,7 +294,7 @@ const test = async () => {
           'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
         )
 
-      await tap.equal(res1.body.items.length, 3)
+      await tap.equal(res1.body.items.length, 8)
     }
   )
 
@@ -361,7 +388,7 @@ const test = async () => {
         'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
       )
 
-    await tap.equal(res4.body.items.length, 4)
+    await tap.equal(res4.body.items.length, 9)
   })
 
   await tap.test(
@@ -382,18 +409,122 @@ const test = async () => {
 
   // ---------------------------------------- ATTRIBUTION + ROLE -----------------------------------
 
-  await tap.test('Filter Library by attribution and role', async () => {
-    const res = await request(app)
-      .get(`${readerUrl}/library?attribution=John%20D&role=author`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
-    await tap.equal(res.status, 200)
-    await tap.ok(res.body)
-    await tap.equal(res.body.items.length, 2)
-  })
+  await tap.test(
+    'Filter Library by attribution and role - author',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=author`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 2)
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - editor',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=editor`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 10)
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - contributor',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=contributor`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 1)
+      await tap.equal(res.body.items[0].name, 'new book 3b')
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - creator',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=creator`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 1)
+      await tap.equal(res.body.items[0].name, 'new book 3c')
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - illustrator',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=illustrator`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 1)
+      await tap.equal(res.body.items[0].name, 'new book 3d')
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - publisher',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=publisher`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 1)
+      await tap.equal(res.body.items[0].name, 'new book 3e')
+    }
+  )
+
+  await tap.test(
+    'Filter Library by attribution and role - translator',
+    async () => {
+      const res = await request(app)
+        .get(`${readerUrl}/library?attribution=John%20D&role=translator`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type(
+          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+        )
+      await tap.equal(res.status, 200)
+      await tap.ok(res.body)
+      await tap.equal(res.body.items.length, 1)
+      await tap.equal(res.body.items[0].name, 'new book 3f')
+    }
+  )
 
   await tap.test(
     'Filter Library by attribution and role with pagination',

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -49,6 +49,14 @@ const test = async () => {
       numberOfPages: 99,
       encodingFormat: 'epub',
       keywords: 'one, two',
+      url: 'http://www.something.com',
+      dateModified: new Date(2020, 11, 11).toISOString(),
+      bookEdition: 'third',
+      bookFormat: 'EBook',
+      isbn: '1234',
+      copyrightYear: 1977,
+      genre: 'vampire romance',
+      license: 'http://www.mylicense.com',
       links: [{ property: 'value' }],
       readingOrder: [{ name: 'one' }, { name: 'two' }, { name: 'three' }],
       resources: [{ property: 'value' }],
@@ -74,21 +82,30 @@ const test = async () => {
     await tap.equal(body.totalItems, 1)
     await tap.ok(Array.isArray(body.items))
     // documents should include:
-    await tap.equal(body.items[0].type, 'Book')
-    await tap.type(body.items[0].id, 'string')
-    await tap.type(body.items[0].name, 'string')
-    await tap.equal(body.items[0].name, 'Publication A')
-    await tap.equal(body.items[0].author[0].name, 'John Smith')
-    await tap.equal(body.items[0].editor[0].name, 'Jane Doe')
-    await tap.equal(body.items[0].keywords, 'one, two')
-    await tap.ok(body.items[0].json)
-    await tap.ok(body.items[0].resources)
-    await tap.equal(body.items[0].abstract, 'this is a description!!')
-    await tap.equal(body.items[0].numberOfPages, 99)
-    await tap.equal(body.items[0].encodingFormat, 'epub')
+    const pub = body.items[0]
+    await tap.equal(pub.type, 'Book')
+    await tap.type(pub.id, 'string')
+    await tap.type(pub.name, 'string')
+    await tap.equal(pub.name, 'Publication A')
+    await tap.equal(pub.author[0].name, 'John Smith')
+    await tap.equal(pub.editor[0].name, 'Jane Doe')
+    await tap.equal(pub.keywords, 'one, two')
+    await tap.ok(pub.json)
+    await tap.ok(pub.resources)
+    await tap.equal(pub.abstract, 'this is a description!!')
+    await tap.equal(pub.numberOfPages, 99)
+    await tap.equal(pub.encodingFormat, 'epub')
+    await tap.equal(pub.url, 'http://www.something.com')
+    await tap.ok(pub.dateModified)
+    await tap.equal(pub.bookEdition, 'third')
+    await tap.equal(pub.bookFormat, 'EBook')
+    await tap.equal(pub.isbn, '1234')
+    await tap.equal(pub.copyrightYear, 1977)
+    await tap.equal(pub.genre, 'vampire romance')
+    await tap.equal(pub.license, 'http://www.mylicense.com')
     // documents should NOT include:
-    await tap.notOk(body.items[0].readingOrder)
-    await tap.notOk(body.items[0].links)
+    await tap.notOk(pub.readingOrder)
+    await tap.notOk(pub.links)
   })
 
   await tap.test(

--- a/tests/integration/library-get.test.js
+++ b/tests/integration/library-get.test.js
@@ -45,6 +45,11 @@ const test = async () => {
       name: 'Publication A',
       author: ['John Smith'],
       editor: 'Jane Doe',
+      contributor: ['Sample Contributor'],
+      creator: ['Sample Creator'],
+      illustrator: ['Sample Illustrator'],
+      publisher: ['Sample Publisher'],
+      translator: ['Sample Translator'],
       abstract: 'this is a description!!',
       numberOfPages: 99,
       encodingFormat: 'epub',
@@ -89,6 +94,11 @@ const test = async () => {
     await tap.equal(pub.name, 'Publication A')
     await tap.equal(pub.author[0].name, 'John Smith')
     await tap.equal(pub.editor[0].name, 'Jane Doe')
+    await tap.equal(pub.contributor[0].name, 'Sample Contributor')
+    await tap.equal(pub.creator[0].name, 'Sample Creator')
+    await tap.equal(pub.illustrator[0].name, 'Sample Illustrator')
+    await tap.equal(pub.publisher[0].name, 'Sample Publisher')
+    await tap.equal(pub.translator[0].name, 'Sample Translator')
     await tap.equal(pub.keywords, 'one, two')
     await tap.ok(pub.json)
     await tap.ok(pub.resources)

--- a/tests/integration/publication-get.test.js
+++ b/tests/integration/publication-get.test.js
@@ -25,6 +25,14 @@ const test = async app => {
     numberOfPages: 250,
     encodingFormat: 'epub',
     inLanguage: 'English',
+    url: 'http://www.something.com',
+    dateModified: now,
+    bookEdition: 'third',
+    bookFormat: 'EBook',
+    isbn: '1234',
+    copyrightYear: 1977,
+    genre: 'vampire romance',
+    license: 'http://www.mylicense.com',
     datePublished: now,
     links: [
       {
@@ -108,6 +116,14 @@ const test = async app => {
     await tap.equal(body.inLanguage, 'English')
     await tap.equal(body.numberOfPages, 250)
     await tap.equal(body.encodingFormat, 'epub')
+    await tap.equal(body.url, 'http://www.something.com')
+    await tap.ok(body.dateModified)
+    await tap.equal(body.bookEdition, 'third')
+    await tap.equal(body.bookFormat, 'EBook')
+    await tap.equal(body.isbn, '1234')
+    await tap.equal(body.copyrightYear, 1977)
+    await tap.equal(body.genre, 'vampire romance')
+    await tap.equal(body.license, 'http://www.mylicense.com')
     // should not have a position
     await tap.notOk(body.position)
   })

--- a/tests/integration/publication-get.test.js
+++ b/tests/integration/publication-get.test.js
@@ -21,6 +21,11 @@ const test = async app => {
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
+    contributor: ['Sample Contributor'],
+    creator: ['Sample Creator'],
+    illustrator: ['Sample Illustrator'],
+    publisher: ['Sample Publisher'],
+    translator: ['Sample Translator'],
     abstract: 'this is a description!!',
     numberOfPages: 250,
     encodingFormat: 'epub',
@@ -101,6 +106,11 @@ const test = async app => {
     await tap.ok(_.isArray(body.author))
     await tap.equal(body.author[0].name, 'John Smith')
     await tap.equal(body.editor[0].name, 'Jané S. Doe')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor')
+    await tap.equal(body.creator[0].name, 'Sample Creator')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher')
+    await tap.equal(body.translator[0].name, 'Sample Translator')
     await tap.equal(body.abstract, 'this is a description!!')
     await tap.ok(body.datePublished)
     await tap.equal(body.links[0].name, 'An example link')

--- a/tests/integration/publication-update.test.js
+++ b/tests/integration/publication-update.test.js
@@ -23,6 +23,11 @@ const test = async app => {
     name: 'Publication A',
     author: ['John Smith'],
     editor: 'Jané S. Doe',
+    contributor: ['Sample Contributor'],
+    creator: ['Sample Creator'],
+    illustrator: ['Sample Illustrator'],
+    publisher: ['Sample Publisher'],
+    translator: ['Sample Translator'],
     abstract: 'this is a description!!',
     inLanguage: 'English',
     url: 'http://www.something.com',
@@ -122,7 +127,12 @@ const test = async app => {
               { type: 'Person', name: 'New Sample Author' },
               { type: 'Organization', name: 'New Org inc.' }
             ],
-            editor: [{ type: 'Person', name: 'New Sample Editor' }]
+            editor: [{ type: 'Person', name: 'New Sample Editor' }],
+            contributor: ['Sample Contributor2'],
+            creator: ['Sample Creator2'],
+            illustrator: ['Sample Illustrator2'],
+            publisher: ['Sample Publisher2'],
+            translator: ['Sample Translator2']
           }
         })
       )
@@ -181,14 +191,14 @@ const test = async app => {
         body.author[1].name === 'New Sample Author'
     )
     await tap.equal(body.editor[0].name, 'New Sample Editor')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+    await tap.equal(body.creator[0].name, 'Sample Creator2')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+    await tap.equal(body.translator[0].name, 'Sample Translator2')
     await tap.ok(attributions)
     await tap.ok(attributions[0] instanceof Attribution)
-    await tap.equal(attributions.length, 3)
-    await tap.ok(
-      attributions[0].name === 'New Sample Author' ||
-        attributions[0].name === 'New Org inc.' ||
-        attributions[0].name === 'New Sample Editor'
-    )
+    await tap.equal(attributions.length, 8)
   })
 
   await tap.test(

--- a/tests/integration/publication-update.test.js
+++ b/tests/integration/publication-update.test.js
@@ -172,7 +172,7 @@ const test = async app => {
     await tap.equal(body.numberOfPages, 444)
     await tap.equal(body.encodingFormat, 'new')
     await tap.equal(body.url, 'http://www.something2.com')
-    await tap.equal(body.dateModified, new Date(2012, 03, 22).toISOString())
+    await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
     await tap.equal(body.bookEdition, 'fourth')
     await tap.equal(body.isbn, '12345')
     await tap.equal(body.copyrightYear, 1978)

--- a/tests/integration/publication-update.test.js
+++ b/tests/integration/publication-update.test.js
@@ -25,6 +25,14 @@ const test = async app => {
     editor: 'Jané S. Doe',
     abstract: 'this is a description!!',
     inLanguage: 'English',
+    url: 'http://www.something.com',
+    dateModified: now,
+    bookEdition: 'third',
+    bookFormat: 'EBook',
+    isbn: '1234',
+    copyrightYear: 1977,
+    genre: 'vampire romance',
+    license: 'http://www.mylicense.com',
     numberOfPages: 333,
     encodingFormat: 'epub',
     datePublished: now,
@@ -101,6 +109,14 @@ const test = async app => {
             encodingFormat: 'new',
             json: { property: 'New value for json property' },
             inLanguage: ['Swahili', 'French'],
+            url: 'http://www.something2.com',
+            dateModified: new Date(2012, 3, 22).toISOString(),
+            bookEdition: 'fourth',
+            bookFormat: 'Paperback',
+            isbn: '12345',
+            copyrightYear: 1978,
+            genre: 'elf romance',
+            license: 'http://www.mylicense2.com',
             keywords: ['newKeyWord1', 'newKeyWord2'],
             author: [
               { type: 'Person', name: 'New Sample Author' },
@@ -145,6 +161,13 @@ const test = async app => {
     await tap.equal(body.json.property, 'New value for json property')
     await tap.equal(body.numberOfPages, 444)
     await tap.equal(body.encodingFormat, 'new')
+    await tap.equal(body.url, 'http://www.something2.com')
+    await tap.equal(body.dateModified, new Date(2012, 03, 22).toISOString())
+    await tap.equal(body.bookEdition, 'fourth')
+    await tap.equal(body.isbn, '12345')
+    await tap.equal(body.copyrightYear, 1978)
+    await tap.equal(body.genre, 'elf romance')
+    await tap.equal(body.license, 'http://www.mylicense2.com')
     await tap.equal(body.inLanguage[0], 'Swahili')
     await tap.equal(body.inLanguage[1], 'French')
     await tap.equal(body.keywords[0], 'newKeyWord1')

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -33,6 +33,14 @@ const test = async app => {
     numberOfPages: 666,
     encodingFormat: 'epub',
     datePublished: new Date(2011, 3, 20).toISOString(),
+    url: 'http://www.something.com',
+    dateModified: new Date(2012, 4, 25).toISOString(),
+    bookEdition: 'second edition',
+    bookFormat: 'EBook',
+    isbn: '1234',
+    copyrightYear: 1923,
+    genre: 'romance',
+    license: 'http://www.mylicense.com',
     json: {
       property1: 'value1'
     },
@@ -162,6 +170,17 @@ const test = async app => {
       await tap.equal(publication.readingOrder.length, 2)
       await tap.equal(publication.links.length, 2)
       await tap.equal(publication.resources.length, 2)
+
+      // metadata
+      const metadata = publication.metadata
+      await tap.equal(metadata.url, 'http://www.something.com')
+      await tap.ok(metadata.dateModified)
+      await tap.equal(metadata.bookEdition, 'second edition')
+      await tap.equal(metadata.bookFormat, 'EBook')
+      await tap.equal(metadata.isbn, '1234')
+      await tap.equal(metadata.copyrightYear, 1923)
+      await tap.equal(metadata.genre, 'romance')
+      await tap.equal(metadata.license, 'http://www.mylicense.com')
     }
   )
 

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -28,6 +28,11 @@ const test = async app => {
       { type: 'Organization', name: 'Org inc.' }
     ],
     editor: ['Sample editor'],
+    contributor: ['Sample Contributor'],
+    creator: ['Sample Creator'],
+    illustrator: ['Sample Illustrator'],
+    publisher: ['Sample Publisher'],
+    translator: ['Sample Translator'],
     inLanguage: ['English'],
     keywords: ['key', 'words'],
     numberOfPages: 666,
@@ -162,8 +167,6 @@ const test = async app => {
       await tap.equal(publication.abstract, 'description of publication A')
       await tap.ok(publication.datePublished)
       await tap.equal(publication.name, 'Publication A')
-      // does not extract attributions yet.
-      await tap.ok(publication.attributions)
       await tap.equal(publication.numberOfPages, 666)
       await tap.equal(publication.encodingFormat, 'epub')
       await tap.equal(publication.json.property1, 'value1')
@@ -171,6 +174,10 @@ const test = async app => {
       await tap.equal(publication.links.length, 2)
       await tap.equal(publication.resources.length, 2)
 
+      // attributions
+      const attributions = publication.attributions
+      await tap.ok(attributions)
+      await tap.equal(attributions.length, 8)
       // metadata
       const metadata = publication.metadata
       await tap.equal(metadata.url, 'http://www.something.com')
@@ -468,7 +475,7 @@ const test = async app => {
     )
     await tap.equal(newPub.editor[0].name, 'New Sample Editor')
     await tap.ok(attributions[0] instanceof Attribution)
-    await tap.equal(attributions.length, 3)
+    await tap.equal(attributions.length, 8)
     await tap.ok(newAuthor1Exists)
     await tap.ok(newAuthor2Exists)
     await tap.ok(newEditorExists)
@@ -478,7 +485,12 @@ const test = async app => {
     const newPubObj = {
       id: publication.id,
       author: ['Sample String Author1', 'Sample String Author2'],
-      editor: ['Sample String Editor1', 'Sample String Editor2']
+      editor: ['Sample String Editor1', 'Sample String Editor2'],
+      contributor: ['New Sample Contributor'],
+      creator: ['New Sample Creator'],
+      illustrator: ['New Sample Illustrator'],
+      publisher: ['New Sample Publisher'],
+      translator: ['New Sample Translator']
     }
 
     const newPub = await Publication.update(newPubObj)
@@ -490,6 +502,11 @@ const test = async app => {
     let author2Exists = false
     let editor1Exists = false
     let editor2Exists = false
+    let contributorExists = false
+    let creatorExists = false
+    let illustratorExists = false
+    let publisherExists = false
+    let translatorExists = false
 
     for (let i = 0; i < attributions.length; i++) {
       if (
@@ -519,16 +536,51 @@ const test = async app => {
       ) {
         editor2Exists = true
       }
+      if (
+        attributions[i].role === 'contributor' &&
+        attributions[i].name === 'New Sample Contributor'
+      ) {
+        contributorExists = true
+      }
+      if (
+        attributions[i].role === 'creator' &&
+        attributions[i].name === 'New Sample Creator'
+      ) {
+        creatorExists = true
+      }
+      if (
+        attributions[i].role === 'illustrator' &&
+        attributions[i].name === 'New Sample Illustrator'
+      ) {
+        illustratorExists = true
+      }
+      if (
+        attributions[i].role === 'publisher' &&
+        attributions[i].name === 'New Sample Publisher'
+      ) {
+        publisherExists = true
+      }
+      if (
+        attributions[i].role === 'translator' &&
+        attributions[i].name === 'New Sample Translator'
+      ) {
+        translatorExists = true
+      }
     }
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
     await tap.ok(attributions[0] instanceof Attribution)
-    await tap.equal(attributions.length, 4)
+    await tap.equal(attributions.length, 9)
     await tap.ok(author1Exists)
     await tap.ok(author2Exists)
     await tap.ok(editor1Exists)
     await tap.ok(editor2Exists)
+    await tap.ok(contributorExists)
+    await tap.ok(creatorExists)
+    await tap.ok(illustratorExists)
+    await tap.ok(publisherExists)
+    await tap.ok(translatorExists)
   })
 
   await tap.test(


### PR DESCRIPTION
This adds these properties to the metadata field:

- url
- dateModified
- bookEdition
- bookFormat
- isbn
- copyrightYear
- genre
- license

It also adds these attribution roles:
- contributor
- creator
- illustrator
- publisher
- translator
Those roles can also be used for filtering the library. For example:
GET /library?attribution=Smith&role=illustrator
