### PR TITLE
patch publication endpoint working

### DIFF
--- a/routes/activities/update.js
+++ b/routes/activities/update.js
@@ -63,6 +63,7 @@ const handleUpdate = async (req, res, next, reader) => {
       res.end()
       break
 
+    // NOTE: deprecated
     case 'Publication':
       const resultPub = await Publication.update(body.object)
       if (resultPub === null) {

--- a/routes/publication-patch.js
+++ b/routes/publication-patch.js
@@ -7,6 +7,7 @@ const { Publication } = require('../models/Publication')
 const boom = require('@hapi/boom')
 const _ = require('lodash')
 const { ValidationError } = require('objection')
+const { libraryCacheUpdate } = require('../utils/cache')
 
 const utils = require('../utils/utils')
 
@@ -93,7 +94,7 @@ module.exports = function (app) {
             // update publication
             body.id = req.params.pubId
             Publication.update(body)
-              .then(updatedPub => {
+              .then(async updatedPub => {
                 if (updatedPub === null) {
                   return next(
                     boom.notFound(`no publication found with id ${body.id}`, {
@@ -125,6 +126,7 @@ module.exports = function (app) {
                     })
                   )
                 }
+                await libraryCacheUpdate(readerId)
 
                 res.setHeader('Content-Type', 'application/ld+json')
                 res.status(200).end(JSON.stringify(updatedPub.toJSON()))

--- a/server.js
+++ b/server.js
@@ -31,6 +31,7 @@ const fileUploadPubRoute = require('./routes/file-upload-pub')
 
 // new routes
 const publicationPostRoute = require('./routes/publication-post')
+const publicationPatchRoute = require('./routes/publication-patch')
 
 const errorHandling = require('./routes/middleware/error-handling')
 
@@ -193,6 +194,7 @@ fileUploadPubRoute(app)
 
 // new routes
 publicationPostRoute(app)
+publicationPatchRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -20,6 +20,7 @@ const publicationGetTests = require('./publication-get.test')
 const publicationUpdateTests = require('./publication-update.test')
 const publicationDeleteTests = require('./publication-delete.test')
 const publicationPostTests = require('./publication-post.test')
+const publicationPatchTests = require('./publication-patch.test')
 
 const readerCreateTests = require('./reader-create.test')
 const readerGetTests = require('./reader-get.test')
@@ -68,9 +69,10 @@ const allTests = async () => {
 
   if (!test || test === 'publication') {
     await publicationGetTests(app)
-    await publicationUpdateTests(app)
+    await publicationUpdateTests(app) // deprecated
     await publicationDeleteTests(app)
     await publicationPostTests(app)
+    await publicationPatchTests(app)
   }
 
   if (!test || test === 'reader') {

--- a/tests/integration/publication-patch.test.js
+++ b/tests/integration/publication-patch.test.js
@@ -1,0 +1,242 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication
+} = require('../utils/utils')
+const { urlToId } = require('../../utils/utils')
+const { Attribution } = require('../../models/Attribution')
+
+const test = async app => {
+  const token = getToken()
+  const readerCompleteUrl = await createUser(app, token)
+  const readerId = urlToId(readerCompleteUrl)
+
+  const readerUrl = urlparse(readerCompleteUrl).path
+
+  const now = new Date().toISOString()
+
+  const publicationObject = {
+    type: 'Book',
+    name: 'Publication A',
+    author: ['John Smith'],
+    editor: 'Jané S. Doe',
+    contributor: ['Sample Contributor'],
+    creator: ['Sample Creator'],
+    illustrator: ['Sample Illustrator'],
+    publisher: ['Sample Publisher'],
+    translator: ['Sample Translator'],
+    abstract: 'this is a description!!',
+    inLanguage: ['en'],
+    url: 'http://www.something.com',
+    dateModified: now,
+    bookEdition: 'third',
+    bookFormat: 'EBook',
+    keywords: ['one', 'two'],
+    isbn: '1234',
+    copyrightYear: 1977,
+    genre: 'vampire romance',
+    license: 'http://www.mylicense.com',
+    numberOfPages: 333,
+    encodingFormat: 'epub',
+    datePublished: now,
+    links: [
+      {
+        url: 'http://example.org/abc',
+        encodingFormat: 'text/html',
+        name: 'An example link'
+      }
+    ],
+    readingOrder: [
+      {
+        url: 'http://example.org/abc',
+        encodingFormat: 'text/html',
+        name: 'An example reading order object1'
+      },
+      {
+        url: 'http://example.org/abc',
+        encodingFormat: 'text/html',
+        name: 'An example reading order object2'
+      },
+      {
+        url: 'http://example.org/abc',
+        encodingFormat: 'text/html',
+        name: 'An example reading order object3'
+      }
+    ],
+    resources: [
+      {
+        url: 'http://example.org/abc',
+        encodingFormat: 'text/html',
+        name: 'An example resource'
+      }
+    ],
+    json: { property: 'value' }
+  }
+
+  const resCreatePub = await createPublication(readerUrl, publicationObject)
+  const publicationUrl = resCreatePub.id
+  const publicationId = urlToId(publicationUrl)
+
+  await tap.test('Update a Publication', async () => {
+    // const timestamp = new Date(2018, 01, 30).toISOString()
+    const res = await request(app)
+      .patch(`/readers/${readerId}/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          type: 'Article',
+          name: 'New name for pub A',
+          // datePublished: timestamp,
+          abstract: 'New description for Publication',
+          numberOfPages: 444,
+          encodingFormat: 'new',
+          json: { property: 'New value for json property' },
+          inLanguage: ['en', 'fr'],
+          url: 'http://www.something2.com',
+          dateModified: new Date(2012, 3, 22).toISOString(),
+          bookEdition: 'fourth',
+          bookFormat: 'Paperback',
+          isbn: '12345',
+          copyrightYear: 1978,
+          genre: 'elf romance',
+          license: 'http://www.mylicense2.com',
+          keywords: ['newKeyWord1', 'newKeyWord2'],
+          author: [
+            { type: 'Person', name: 'New Sample Author' },
+            { type: 'Organization', name: 'New Org inc.' }
+          ],
+          editor: [{ type: 'Person', name: 'New Sample Editor' }],
+          contributor: ['Sample Contributor2'],
+          creator: ['Sample Creator2'],
+          illustrator: ['Sample Illustrator2'],
+          publisher: ['Sample Publisher2'],
+          translator: ['Sample Translator2']
+        })
+      )
+    await tap.equal(res.status, 200)
+
+    const body = res.body
+    await tap.equal(body.name, 'New name for pub A')
+    await tap.equal(body.abstract, 'New description for Publication')
+    // await tap.equal(body.datePublished, timestamp)
+    await tap.equal(body.json.property, 'New value for json property')
+    await tap.equal(body.numberOfPages, 444)
+    await tap.equal(body.encodingFormat, 'new')
+    await tap.equal(body.url, 'http://www.something2.com')
+    await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
+    await tap.equal(body.bookEdition, 'fourth')
+    await tap.equal(body.isbn, '12345')
+    await tap.equal(body.copyrightYear, 1978)
+    await tap.equal(body.genre, 'elf romance')
+    await tap.equal(body.license, 'http://www.mylicense2.com')
+    await tap.equal(body.inLanguage[0], 'en')
+    await tap.equal(body.inLanguage[1], 'fr')
+    await tap.equal(body.keywords[0], 'newKeyWord1')
+    await tap.equal(body.keywords[1], 'newKeyWord2')
+    await tap.ok(
+      body.author[0].name === 'New Org inc.' ||
+        body.author[0].name === 'New Sample Author'
+    )
+    await tap.ok(
+      body.author[1].name === 'New Org inc.' ||
+        body.author[1].name === 'New Sample Author'
+    )
+    await tap.equal(body.editor[0].name, 'New Sample Editor')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+    await tap.equal(body.creator[0].name, 'Sample Creator2')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+    await tap.equal(body.translator[0].name, 'Sample Translator2')
+  })
+
+  await tap.test(
+    'Try to update a Publication to an invalid value',
+    async () => {
+      const res = await request(app)
+        .patch(`/readers/${readerId}/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 1234
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(error.details.type, 'Publication')
+      await tap.equal(error.details.activity, 'Update Publication')
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(error.details.validation.name[0].keyword, 'type')
+      await tap.equal(error.details.validation.name[0].params.type, 'string')
+    }
+  )
+
+  await tap.test(
+    'Try to update a Publication to an invalid metadata value',
+    async () => {
+      const res = await request(app)
+        .patch(`/readers/${readerId}/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            genre: 123
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(error.details.type, 'Publication')
+      await tap.equal(error.details.activity, 'Update Publication')
+    }
+  )
+
+  await tap.test(
+    'Try to update a Publication that does not exist',
+    async () => {
+      const res = await request(app)
+        .patch(`/readers/${readerId}/publications/${publicationId}1`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'New name for pub A',
+            abstract: 'New description for Publication',
+            json: { property: 'New value for json property' },
+            inLanguage: ['en', 'fr'],
+            keywords: ['newKeyWord1', 'newKeyWord2'],
+            author: [
+              { type: 'Person', name: 'New Sample Author' },
+              { type: 'Organization', name: 'New Org inc.' }
+            ],
+            editor: [{ type: 'Person', name: 'New Sample Editor' }]
+          })
+        )
+
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(error.details.type, 'Publication')
+      await tap.type(error.details.id, 'string')
+      await tap.equal(error.details.activity, 'Update Publication')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test


### PR DESCRIPTION
PATCH /readers/:readerId/publications/:pubId

Only needs the properties to be updated in the body of the request.
Returns the updated publication object.

