### PR TITLE
Rename routes and validate ownership

### DIFF
--- a/routes/publication-put-tag.js
+++ b/routes/publication-put-tag.js
@@ -12,18 +12,13 @@ const utils = require('../utils/utils')
 module.exports = function (app) {
   /**
    * @swagger
-   * /readers/{readerId}/publications/{pubId}/tags/{tagId}:
+   * /publications/{pubId}/tags/{tagId}:
    *   put:
    *     tags:
    *       - tags
    *       - publications
-   *     description: PUT /readers/:readerId/publications/:pubId/tags/:tagId
+   *     description: PUT /publications/:pubId/tags/:tagId
    *     parameters:
-   *       - in: path
-   *         name: readerId
-   *         schema:
-   *           type: string
-   *         required: true
    *       - in: path
    *         name: pubId
    *         schema:
@@ -42,30 +37,21 @@ module.exports = function (app) {
    *       400:
    *         description: Cannot assign the same tag twice
    *       404:
-   *         description: reader / publication or tag not found
+   *         description:  publication or tag not found
    *       403:
-   *         description: 'Access to reader {id} disallowed'
+   *         description: 'Access to tag or publication disallowed'
    */
   app.use('/', router)
   router
-    .route('/readers/:readerId/publications/:pubId/tags/:tagId')
+    .route('/publications/:pubId/tags/:tagId')
     .put(jwtAuth, function (req, res, next) {
-      const readerId = req.params.readerId
       const pubId = req.params.pubId
       const tagId = req.params.tagId
-      Reader.byId(readerId)
+      Reader.byAuthId(req.user)
         .then(reader => {
           if (!reader) {
             return next(
-              boom.notFound(`No reader with ID ${readerId}`, {
-                type: 'Reader',
-                id: readerId,
-                activity: 'Add Tag to Publication'
-              })
-            )
-          } else if (!utils.checkReader(req, reader)) {
-            return next(
-              boom.forbidden(`Access to reader ${readerId} disallowed`, {
+              boom.notFound(`No reader with this token`, {
                 type: 'Reader',
                 id: readerId,
                 activity: 'Add Tag to Publication'
@@ -111,7 +97,7 @@ module.exports = function (app) {
                   return next(err)
               }
             } else {
-              await libraryCacheUpdate(readerId)
+              await libraryCacheUpdate(reader.id)
               res.status(204).end()
             }
           })

--- a/routes/publication-put-tag.js
+++ b/routes/publication-put-tag.js
@@ -6,8 +6,7 @@ const jwtAuth = passport.authenticate('jwt', { session: false })
 const boom = require('@hapi/boom')
 const { libraryCacheUpdate } = require('../utils/cache')
 const { Publication_Tag } = require('../models/Publications_Tags')
-
-const utils = require('../utils/utils')
+const { checkOwnership } = require('../utils/utils')
 
 module.exports = function (app) {
   /**
@@ -54,6 +53,25 @@ module.exports = function (app) {
               boom.notFound(`No reader with this token`, {
                 type: 'Reader',
                 id: readerId,
+                activity: 'Add Tag to Publication'
+              })
+            )
+          }
+
+          if (!checkOwnership(reader.id, pubId)) {
+            return next(
+              boom.forbidden(`Access to Publication ${pubId} disallowed`, {
+                type: 'Publication',
+                id: pubId,
+                activity: 'Add Tag to Publication'
+              })
+            )
+          }
+          if (!checkOwnership(reader.id, tagId)) {
+            return next(
+              boom.forbidden(`Access to Tag ${tagId} disallowed`, {
+                type: 'Tag',
+                id: tagId,
                 activity: 'Add Tag to Publication'
               })
             )

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -380,7 +380,7 @@ const test = async app => {
 
     // post publication
     const res8 = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post('/publications')
       .set('Host', 'reader-api.test')
       .type('application/ld+json')
     await tap.equal(res8.statusCode, 401)

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -260,27 +260,6 @@ const test = async app => {
   )
 
   await tap.test(
-    'Try to remove tag from a publication for another user',
-    async () => {
-      const res = await request(app)
-        .delete(`/readers/${readerId}/publications/123/tags/123`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token2}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-
-      await tap.equal(res.statusCode, 403)
-      const error = JSON.parse(res.text)
-      await tap.equal(error.statusCode, 403)
-      await tap.equal(error.error, 'Forbidden')
-      await tap.equal(error.details.type, 'Reader')
-      await tap.type(error.details.id, 'string')
-      await tap.equal(error.details.activity, 'Remove Tag from Publication')
-    }
-  )
-
-  await tap.test(
     'Try to upload files to a folder belonging to another reader',
     async () => {
       const res = await request(app)
@@ -388,7 +367,7 @@ const test = async app => {
 
     // remove tag from publication
     const res12 = await request(app)
-      .delete(`/readers/123/publications/123/tags/123`)
+      .delete(`/publications/123/tags/123`)
       .set('Host', 'reader-api.test')
       .type('application/ld+json')
 

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -260,27 +260,6 @@ const test = async app => {
   )
 
   await tap.test(
-    'Try to add tag to a publication for another user',
-    async () => {
-      const res = await request(app)
-        .put(`/readers/${readerId}/publications/123/tags/123`)
-        .set('Host', 'reader-api.test')
-        .set('Authorization', `Bearer ${token2}`)
-        .type(
-          'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-        )
-
-      await tap.equal(res.statusCode, 403)
-      const error = JSON.parse(res.text)
-      await tap.equal(error.statusCode, 403)
-      await tap.equal(error.error, 'Forbidden')
-      await tap.equal(error.details.type, 'Reader')
-      await tap.type(error.details.id, 'string')
-      await tap.equal(error.details.activity, 'Add Tag to Publication')
-    }
-  )
-
-  await tap.test(
     'Try to remove tag from a publication for another user',
     async () => {
       const res = await request(app)
@@ -401,7 +380,7 @@ const test = async app => {
 
     // add tag to publication
     const res11 = await request(app)
-      .put(`/readers/${readerId}/publications/123/tags/123`)
+      .put(`/publications/123/tags/123`)
       .set('Host', 'reader-api.test')
       .type('application/ld+json')
 

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -7,7 +7,8 @@ const {
   destroyDB,
   getActivityFromUrl,
   createPublication,
-  createNote
+  createNote,
+  createTag
 } = require('../utils/utils')
 const { Reader } = require('../../models/Reader')
 const { urlToId } = require('../../utils/utils')
@@ -28,11 +29,23 @@ const test = async app => {
 
   // reader2
   const token2 = getToken()
-  await createUser(app, token2)
+  const readerCompleteUrl2 = await createUser(app, token2)
+  const readerUrl2 = urlparse(readerCompleteUrl2).path
+  const readerId2 = urlToId(readerCompleteUrl2)
 
-  // create publication and documents for reader 1
+  // create publication and tag for reader 1
   const publication = await createPublication(readerUrl)
   const publicationUrl = publication.id
+
+  const tag = await createTag(app, token, readerUrl)
+  const tagId = urlToId(tag.id)
+
+  // create publication and tag for reader 2
+  const publication2 = await createPublication(readerUrl2)
+  publicationId2 = urlToId(publication2.id)
+
+  const tag2 = await createTag(app, token2, readerUrl2)
+  const tagId2 = urlToId(tag2.id)
 
   // create Note for reader 1
   const noteActivity = await createNote(app, token, readerUrl)
@@ -197,30 +210,6 @@ const test = async app => {
     await tap.equal(error.details.activity, 'Create Activity')
   })
 
-  await tap.test('Try to create a publication for another user', async () => {
-    const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token2}`)
-      .type(
-        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-      )
-      .send(
-        JSON.stringify({
-          name: 'Publication 1',
-          type: 'Book'
-        })
-      )
-
-    await tap.equal(res.statusCode, 403)
-    const error = JSON.parse(res.text)
-    await tap.equal(error.statusCode, 403)
-    await tap.equal(error.error, 'Forbidden')
-    await tap.equal(error.details.type, 'Reader')
-    await tap.type(error.details.id, 'string')
-    await tap.equal(error.details.activity, 'Create Publication')
-  })
-
   await tap.test(
     'Try to delete a publication belonging to another user',
     async () => {
@@ -256,6 +245,82 @@ const test = async app => {
       await tap.equal(error.details.type, 'Publication')
       await tap.type(error.details.id, 'string')
       await tap.equal(error.details.activity, 'Update Publication')
+    }
+  )
+
+  await tap.test(
+    'Try to assign a tag to a publication belonging to another user',
+    async () => {
+      const res = await request(app)
+        .put(`/publications/${urlToId(publicationUrl)}/tags/${tagId2}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.details.type, 'Publication')
+      await tap.type(error.details.id, 'string')
+      await tap.equal(error.details.activity, 'Add Tag to Publication')
+    }
+  )
+
+  await tap.test(
+    'Try to assign a tag belonging to another user to a publication',
+    async () => {
+      const res = await request(app)
+        .put(`/publications/${publicationId2}/tags/${tagId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.details.type, 'Tag')
+      await tap.type(error.details.id, 'string')
+      await tap.equal(error.details.activity, 'Add Tag to Publication')
+    }
+  )
+
+  await tap.test(
+    'Try to remove a tag from a publication belonging to another user',
+    async () => {
+      const res = await request(app)
+        .delete(`/publications/${urlToId(publicationUrl)}/tags/${tagId2}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.details.type, 'Publication')
+      await tap.type(error.details.id, 'string')
+      await tap.equal(error.details.activity, 'Remove Tag from Publication')
+    }
+  )
+
+  await tap.test(
+    'Try to remove a tag belonging to another user from a publication',
+    async () => {
+      const res = await request(app)
+        .delete(`/publications/${publicationId2}/tags/${tagId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.details.type, 'Tag')
+      await tap.type(error.details.id, 'string')
+      await tap.equal(error.details.activity, 'Remove Tag from Publication')
     }
   )
 

--- a/tests/integration/publication-post.test.js
+++ b/tests/integration/publication-post.test.js
@@ -12,7 +12,6 @@ const test = async app => {
 
   const now = new Date().toISOString()
 
-  // TODO: add more properties when Pull Request is merged
   const publicationObject = {
     '@context': [
       'https://www.w3.org/ns/activitystreams',
@@ -79,7 +78,7 @@ const test = async app => {
 
   await tap.test('Create a Simple Publication', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post(`/publications`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -101,7 +100,7 @@ const test = async app => {
 
   await tap.test('Create a Publication', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post(`/publications`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -144,7 +143,7 @@ const test = async app => {
 
   await tap.test('invalid properties should be ignored', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post(`/publications`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -194,7 +193,7 @@ const test = async app => {
     'Create a Publication with link objects as strings',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -227,7 +226,7 @@ const test = async app => {
     'Link objects should only save recognized properties',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -321,7 +320,7 @@ const test = async app => {
     'Create a Publication with keywords as a single string',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -345,7 +344,7 @@ const test = async app => {
 
   await tap.test('trying to create a Publication without a name', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post(`/publications`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -374,7 +373,7 @@ const test = async app => {
 
   await tap.test('trying to create a Publication without a type', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post(`/publications`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -406,7 +405,7 @@ const test = async app => {
     'Try to create a Publication with an invalid json',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -436,7 +435,7 @@ const test = async app => {
     'Try to create a Publication with an invalid language code',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -463,7 +462,7 @@ const test = async app => {
     'Try to create a Publication with an invalid link object',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -485,7 +484,7 @@ const test = async app => {
       await tap.equal(error.details.activity, 'Create Publication')
 
       const res2 = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -507,7 +506,7 @@ const test = async app => {
       await tap.equal(error2.details.activity, 'Create Publication')
 
       const res3 = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -534,7 +533,7 @@ const test = async app => {
     'Try to create a Publication with an invalid type',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -555,7 +554,7 @@ const test = async app => {
       await tap.equal(error.details.activity, 'Create Publication')
 
       const res2 = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -581,7 +580,7 @@ const test = async app => {
     'Try to create a Publication with an invalid dateModified',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post(`/publications`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -608,7 +607,7 @@ const test = async app => {
     'Try to create a Publication with an invalid bookEdition',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -635,7 +634,7 @@ const test = async app => {
     'Try to create a Publication with an invalid book format',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -657,7 +656,7 @@ const test = async app => {
       await tap.equal(error.details.activity, 'Create Publication')
 
       const res2 = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -684,7 +683,7 @@ const test = async app => {
     'Try to create a Publication with an invalid isbn',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -711,7 +710,7 @@ const test = async app => {
     'Try to create a Publication with an invalid keywords',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -738,7 +737,7 @@ const test = async app => {
     'Try to create a Publication with an invalid genre',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -765,7 +764,7 @@ const test = async app => {
     'Try to create a Publication with an invalid url',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -792,7 +791,7 @@ const test = async app => {
     'Try to create a Publication with an invalid attribution',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -819,7 +818,7 @@ const test = async app => {
     'Try to create a Publication with an invalid attribution type',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -845,7 +844,7 @@ const test = async app => {
     'Try to create a Publication with an invalid attribution object',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -871,7 +870,7 @@ const test = async app => {
     'Try to create a Publication with an invalid inDirection value',
     async () => {
       const res = await request(app)
-        .post(`/readers/${readerId}/publications`)
+        .post('/publications')
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type(
@@ -896,7 +895,7 @@ const test = async app => {
 
   await tap.test('Try to create a Publication without a body', async () => {
     const res = await request(app)
-      .post(`/readers/${readerId}/publications`)
+      .post('/publications')
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(

--- a/tests/integration/publication-tag.test.js
+++ b/tests/integration/publication-tag.test.js
@@ -40,7 +40,7 @@ const test = async app => {
 
   await tap.test('Assign Publication to Tag', async () => {
     const res = await request(app)
-      .put(`/readers/${readerId}/publications/${publicationId}/tags/${tagId}`)
+      .put(`/publications/${publicationId}/tags/${tagId}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
@@ -66,7 +66,7 @@ const test = async app => {
     'Try to assign Publication to Tag with invalid Tag',
     async () => {
       const res = await request(app)
-        .put(`/readers/${readerId}/publications/${publicationId}/tags/123`)
+        .put(`/publications/${publicationId}/tags/123`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -83,7 +83,7 @@ const test = async app => {
     'Try to assign Publication to Tag with invalid Publication',
     async () => {
       const res = await request(app)
-        .put(`/readers/${readerId}/publications/123/tags/${tagId}`)
+        .put(`/publications/123/tags/${tagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -172,13 +172,13 @@ const test = async app => {
 
   await tap.test('Try to assign Publication to Tag twice', async () => {
     await request(app)
-      .put(`/readers/${readerId}/publications/${publicationId}/tags/${tagId}`)
+      .put(`/publications/${publicationId}/tags/${tagId}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
     const res = await request(app)
-      .put(`/readers/${readerId}/publications/${publicationId}/tags/${tagId}`)
+      .put(`/publications/${publicationId}/tags/${tagId}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')

--- a/tests/integration/publication-tag.test.js
+++ b/tests/integration/publication-tag.test.js
@@ -19,6 +19,9 @@ const test = async app => {
   const publication = await createPublication(readerUrl)
   const publicationId = urlToId(publication.id)
 
+  const invalidTagId = `${readerId}-123` // including readerId to avoid 403 error
+  const invalidPubId = `${readerId}-456`
+
   // create Tag
   await createTag(app, token, readerUrl, {
     type: 'reader:Tag',
@@ -66,7 +69,7 @@ const test = async app => {
     'Try to assign Publication to Tag with invalid Tag',
     async () => {
       const res = await request(app)
-        .put(`/publications/${publicationId}/tags/123`)
+        .put(`/publications/${publicationId}/tags/${invalidTagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -83,7 +86,7 @@ const test = async app => {
     'Try to assign Publication to Tag with invalid Publication',
     async () => {
       const res = await request(app)
-        .put(`/publications/123/tags/${tagId}`)
+        .put(`/publications/${invalidPubId}/tags/${tagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -138,7 +141,7 @@ const test = async app => {
     'Try to remove a Tag from a Publication with invalid Tag',
     async () => {
       const res = await request(app)
-        .delete(`/publications/${publicationId}/tags/123`)
+        .delete(`/publications/${publicationId}/tags/${invalidTagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -155,7 +158,7 @@ const test = async app => {
     'Try to remove a Tag from a Publication with invalid Publication',
     async () => {
       const res = await request(app)
-        .delete(`/publications/123/tags/${tagId}`)
+        .delete(`/publications/${invalidPubId}/tags/${tagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')

--- a/tests/integration/publication-tag.test.js
+++ b/tests/integration/publication-tag.test.js
@@ -112,9 +112,7 @@ const test = async app => {
     await tap.equal(bodybefore.tags.length, 1)
 
     const res = await request(app)
-      .delete(
-        `/readers/${readerId}/publications/${publicationId}/tags/${tagId}`
-      )
+      .delete(`/publications/${publicationId}/tags/${tagId}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
@@ -123,7 +121,7 @@ const test = async app => {
 
     // after:
     const pubres = await request(app)
-      .get(`/publications/${urlToId(publication.id)}`)
+      .get(`/publications/${publicationId}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type(
@@ -140,7 +138,7 @@ const test = async app => {
     'Try to remove a Tag from a Publication with invalid Tag',
     async () => {
       const res = await request(app)
-        .delete(`/readers/${readerId}/publications/${publicationId}/tags/123`)
+        .delete(`/publications/${publicationId}/tags/123`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -157,7 +155,7 @@ const test = async app => {
     'Try to remove a Tag from a Publication with invalid Publication',
     async () => {
       const res = await request(app)
-        .delete(`/readers/${readerId}/publications/123/tags/${tagId}`)
+        .delete(`/publications/123/tags/${tagId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')

--- a/tests/utils/utils.js
+++ b/tests/utils/utils.js
@@ -238,7 +238,7 @@ const addPubToCollection = async (app, token, readerId, pubId, tagId) => {
   }
   pubId = urlToId(pubId)
   const res = await request(app)
-    .put(`/readers/${readerId}/publications/${pubId}/tags/${tagId}`)
+    .put(`/publications/${pubId}/tags/${tagId}`)
     .set('Host', 'reader-api.test')
     .set('Authorization', `Bearer ${token}`)
     .type('application/ld+json')


### PR DESCRIPTION
This renames routes:
PUT and DELETE `/readers/:readerId/publications/:pubId/tags/:tagId` to `/publications/:pubId/tags/:tagId`
POST `/readers/:readerId/publications` to `/publications`

It also validates that the pubId and tagId belong to the reader, based on the token. 