### PR TITLE
new endpoint: Get tags

### DIFF
--- a/models/Tag.js
+++ b/models/Tag.js
@@ -113,6 +113,12 @@ class Tag extends BaseModel {
     }
   }
 
+  static async byReaderId (
+    readerId /*: string */
+  ) /*: Promise<Array<TagType>> */ {
+    return await Tag.query().where('readerId', '=', readerId)
+  }
+
   static async byId (id /*: string */) /*: Promise<TagType> */ {
     return await Tag.query().findById(id)
   }

--- a/routes/tags-get.js
+++ b/routes/tags-get.js
@@ -1,0 +1,61 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Tag } = require('../models/Tag')
+const { Reader } = require('../models/Reader')
+const { Publication } = require('../models/Publication')
+const debug = require('debug')('hobb:routes:publication')
+const utils = require('../utils/utils')
+const boom = require('@hapi/boom')
+const { urlToId } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /tags:
+   *   get:
+   *     tags:
+   *       - tags
+   *     description: GET /tags
+   *     security:
+   *       - Bearer: []
+   *     produces:
+   *       - application/json
+   *     responses:
+   *       200:
+   *         description: An array of tags for the reader (based on the validation token)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/definitions/tag'
+   *       404:
+   *         description: 'No Reader found'
+   */
+  app.use('/', router)
+  router.get(
+    '/tags',
+    passport.authenticate('jwt', { session: false }),
+    function (req, res, next) {
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                type: 'Reader',
+                activity: 'Get Tags'
+              })
+            )
+          }
+          let tags = await Tag.byReaderId(urlToId(reader.id))
+
+          tags = tags.filter(tag => !tag.deleted)
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.end(JSON.stringify(tags))
+        })
+        .catch(next)
+    }
+  )
+}

--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ const searchRoute = require('./routes/search')
 const getJobRoute = require('./routes/job-get')
 const fileUploadPubRoute = require('./routes/file-upload-pub')
 const libraryRouteOld = require('./routes/reader-library-old') // deprecated
-
+const getTagsRoute = require('./routes/tags-get')
 // new routes
 const publicationPostRoute = require('./routes/publication-post')
 const publicationPatchRoute = require('./routes/publication-patch')
@@ -196,7 +196,7 @@ searchRoute(app)
 getJobRoute(app)
 fileUploadPubRoute(app)
 libraryRouteOld(app) // deprecated
-
+getTagsRoute(app)
 // new routes
 readerLibraryRoute(app)
 publicationPostRoute(app)

--- a/tests/integration/auth-error.test.js
+++ b/tests/integration/auth-error.test.js
@@ -437,6 +437,14 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res12.statusCode, 401)
+
+    // get tags
+    const res13 = await request(app)
+      .get('/tags')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+
+    await tap.equal(res13.statusCode, 401)
   })
 
   await destroyDB(app)

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -47,6 +47,7 @@ const tagNoteTests = require('./tag-note.test')
 const tagDeleteTests = require('./tag-delete.test')
 const tagUpdateTests = require('./tag-update.test')
 const publicationAddTagTests = require('./publication-tag.test')
+const tagsGetTests = require('./tags-get.test')
 
 const jobGetTests = require('./job-get.test')
 
@@ -113,6 +114,7 @@ const allTests = async () => {
   }
 
   if (!test || test === 'tag') {
+    await tagsGetTests(app)
     await publicationAddTagTests(app)
     await tagCreateTests(app)
     await tagPublicationTests(app)

--- a/tests/integration/tags-get.test.js
+++ b/tests/integration/tags-get.test.js
@@ -10,6 +10,17 @@ const test = async app => {
   const readerUrl = urlparse(readerCompleteUrl).path
   const readerId = urlToId(readerCompleteUrl)
 
+  await tap.test('Get Tags for a reader with no tags', async () => {
+    const res = await request(app)
+      .get('/tags')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.length, 0)
+  })
+
   await createTag(app, token, readerUrl, { name: 'tag1' })
   await createTag(app, token, readerUrl, { name: 'tag2' })
 
@@ -21,7 +32,10 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    console.log(res.body)
+    const body = res.body
+    await tap.equal(res.body.length, 2)
+    await tap.equal(body[0].name, 'tag1')
+    await tap.equal(body[1].name, 'tag2')
   })
 
   await destroyDB(app)

--- a/tests/integration/tags-get.test.js
+++ b/tests/integration/tags-get.test.js
@@ -1,0 +1,30 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const { getToken, createUser, destroyDB, createTag } = require('../utils/utils')
+const { urlToId } = require('../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerCompleteUrl = await createUser(app, token)
+  const readerUrl = urlparse(readerCompleteUrl).path
+  const readerId = urlToId(readerCompleteUrl)
+
+  await createTag(app, token, readerUrl, { name: 'tag1' })
+  await createTag(app, token, readerUrl, { name: 'tag2' })
+
+  await tap.test('Get Tags', async () => {
+    const res = await request(app)
+      .get('/tags')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    console.log(res.body)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -77,11 +77,11 @@ const test = async app => {
       tagType: 'reader:Stack',
       name: 'tag2'
     })
-    let response = await Tag.byReaderId(urlToId(createdReader.id))
+    let responseGet = await Tag.byReaderId(urlToId(createdReader.id))
 
-    await tap.equal(response.length, 2)
-    await tap.ok(response[0] instanceof Tag)
-    await tap.ok(response[1] instanceof Tag)
+    await tap.equal(responseGet.length, 2)
+    await tap.ok(responseGet[0] instanceof Tag)
+    await tap.ok(responseGet[1] instanceof Tag)
   })
 
   await tap.test('Delete Publication_Tags of a Tag', async () => {

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -71,6 +71,19 @@ const test = async app => {
     await tap.ok(responseGet instanceof Tag)
   })
 
+  await tap.test('Get tags by readerId', async () => {
+    await Tag.createTag(createdReader.id, {
+      type: 'reader:Tag',
+      tagType: 'reader:Stack',
+      name: 'tag2'
+    })
+    let response = await Tag.byReaderId(urlToId(createdReader.id))
+
+    await tap.equal(response.length, 2)
+    await tap.ok(response[0] instanceof Tag)
+    await tap.ok(response[1] instanceof Tag)
+  })
+
   await tap.test('Delete Publication_Tags of a Tag', async () => {
     // Create 2 additional tags for testing purposes
     const createdTag2 = await Tag.createTag(urlToId(createdReader.id), {


### PR DESCRIPTION
This was surprisingly quick. 
So new endpoint: `/tags` 
returns the tags for a reader, based on the token. 

That's it.
I didn't write a ton of tests for it. Some things might change once I update the other tag endpoints and I might add more tests then. But there are not a lot of scenarios to test because this is so simple.