### PR TITLE
Default modes

### DIFF
--- a/models/Reader.js
+++ b/models/Reader.js
@@ -5,6 +5,7 @@ const { Publication } = require('./Publication')
 const { Note } = require('./Note')
 const { ReadActivity } = require('./ReadActivity')
 const { Job } = require('./Job')
+const { Tag } = require('./Tag')
 const { Attribution } = require('./Attribution')
 const { urlToId } = require('../utils/utils')
 const urlparse = require('url').parse
@@ -410,13 +411,19 @@ class Reader extends BaseModel {
     const props = _.pick(person, attributes)
     props.id = translator.new()
     props.authId = authId
+    let newReader
     try {
-      return await Reader.query(Reader.knex())
+      newReader = await Reader.query(Reader.knex())
         .insert(props)
         .returning('*')
     } catch (err) {
       return err
     }
+
+    // create default Tags
+    // await Tag.createTag(newReader.id, {type: 'reader:Tag', tagType: 'mode', name: ''})
+
+    return newReader
   }
 
   static get tableName () /*: string */ {

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -421,7 +421,24 @@ class Reader extends BaseModel {
     }
 
     // create default Tags
-    // await Tag.createTag(newReader.id, {type: 'reader:Tag', tagType: 'mode', name: ''})
+    await Tag.createMultipleTags(newReader.id, [
+      {
+        name: 'Research',
+        tagType: 'mode'
+      },
+      {
+        name: 'Teaching',
+        tagType: 'mode'
+      },
+      {
+        name: 'Public Scholarships',
+        tagType: 'mode'
+      },
+      {
+        name: 'Personal',
+        tagType: 'mode'
+      }
+    ])
 
     return newReader
   }
@@ -462,7 +479,6 @@ class Reader extends BaseModel {
   static get relationMappings () /*: any */ {
     const { Document } = require('./Document')
     const { Activity } = require('./Activity.js')
-    const { Tag } = require('./Tag.js')
     return {
       publications: {
         relation: Model.HasManyRelation,

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -73,6 +73,25 @@ class Tag extends BaseModel {
     }
   }
 
+  static async createMultipleTags (
+    readerId /*: string */,
+    tags /*: Array<{type: string, name: string, tagType: string, json?: {}, readerId?: string}> */
+  ) /*: Promise<any> */ {
+    const tagArray = tags.map(tag => {
+      tag.readerId = readerId
+      tag.type = tag.tagType
+      tag = _.pick(tag, ['name', 'json', 'readerId', 'type'])
+      tag.id = `${urlToId(readerId)}-${crypto.randomBytes(5).toString('hex')}`
+      return tag
+    })
+
+    try {
+      return await Tag.query().insert(tagArray)
+    } catch (err) {
+      return err
+    }
+  }
+
   async delete () /*: Promise<number|Error> */ {
     const tagId = this.id
     // Delete all Publication_Tags associated with this tag

--- a/tests/integration/deprecated/tag-delete-old.test.js
+++ b/tests/integration/deprecated/tag-delete-old.test.js
@@ -147,7 +147,7 @@ const test = async app => {
     const noteWithTag = await Note.byId(urlToId(noteUrl))
     await tap.equal(noteWithTag.tags.length, 1)
     await tap.equal(noteWithTag.tags[0].name, libraryBefore.body.tags[0].name)
-    await tap.equal(libraryBefore.body.tags.length, 1)
+    await tap.equal(libraryBefore.body.tags.length, 5)
     await tap.equal(libraryBefore.body.tags[0].name, stack.name)
 
     // Delete the tag
@@ -186,7 +186,7 @@ const test = async app => {
     // Get the note after the modifications
     const noteWithoutTag = await Note.byId(urlToId(noteUrl))
 
-    await tap.equal(libraryAfter.body.tags.length, 0)
+    await tap.equal(libraryAfter.body.tags.length, 4)
     await tap.equal(libraryAfter.body.items[0].tags.length, 0)
     await tap.equal(noteWithoutTag.tags.length, 0)
   })

--- a/tests/integration/deprecated/tag-update.test.js
+++ b/tests/integration/deprecated/tag-update.test.js
@@ -149,8 +149,7 @@ const test = async app => {
     const noteWithTag = await Note.byId(urlToId(noteUrl))
     await tap.equal(noteWithTag.tags.length, 1)
     await tap.equal(noteWithTag.tags[0].name, libraryBefore.body.tags[0].name)
-    await tap.equal(libraryBefore.body.tags.length, 1)
-    await tap.equal(libraryBefore.body.tags[0].name, stack.name)
+    await tap.equal(libraryBefore.body.tags.length, 5)
 
     // Update the tag
     const res = await request(app)
@@ -188,8 +187,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 1)
-    await tap.equal(libraryAfter.body.tags[0].name, 'newName')
+    await tap.equal(libraryAfter.body.tags.length, 5)
     await tap.equal(noteWithNewTag.tags.length, 1)
     await tap.equal(noteWithNewTag.tags[0].name, 'newName')
   })
@@ -231,8 +229,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 1)
-    await tap.equal(libraryAfter.body.tags[0].json.property, 'value!!')
+    await tap.equal(libraryAfter.body.tags.length, 5)
     await tap.equal(noteWithNewTag.tags.length, 1)
     await tap.equal(noteWithNewTag.tags[0].json.property, 'value!!')
   })

--- a/tests/integration/reader-create.test.js
+++ b/tests/integration/reader-create.test.js
@@ -32,6 +32,18 @@ const test = async app => {
     readerUrl = res.get('Location')
   })
 
+  await tap.test('Created Reader should have default modes', async () => {
+    const res = await request(app)
+      .get('/tags')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+
+    await tap.equal(res.body.length, 4)
+  })
+
   await tap.test('Create Simple Reader', async () => {
     const res = await request(app)
       .post('/readers')

--- a/tests/integration/tag/tag-delete.test.js
+++ b/tests/integration/tag/tag-delete.test.js
@@ -101,8 +101,7 @@ const test = async app => {
     const noteWithTag = await Note.byId(urlToId(noteUrl))
     await tap.equal(noteWithTag.tags.length, 1)
     await tap.equal(noteWithTag.tags[0].name, libraryBefore.body.tags[0].name)
-    await tap.equal(libraryBefore.body.tags.length, 1)
-    await tap.equal(libraryBefore.body.tags[0].name, stack.name)
+    await tap.equal(libraryBefore.body.tags.length, 5) // 4 default modes + tag created
 
     // Delete the tag
     const res = await request(app)
@@ -123,7 +122,7 @@ const test = async app => {
     // Get the note after the modifications
     const noteWithoutTag = await Note.byId(urlToId(noteUrl))
 
-    await tap.equal(libraryAfter.body.tags.length, 0)
+    await tap.equal(libraryAfter.body.tags.length, 4)
     await tap.equal(libraryAfter.body.items[0].tags.length, 0)
     await tap.equal(noteWithoutTag.tags.length, 0)
   })

--- a/tests/integration/tag/tag-patch.test.js
+++ b/tests/integration/tag/tag-patch.test.js
@@ -86,7 +86,7 @@ const test = async app => {
     const noteWithTag = await Note.byId(urlToId(noteUrl))
     await tap.equal(noteWithTag.tags.length, 1)
     await tap.equal(noteWithTag.tags[0].name, libraryBefore.body.tags[0].name)
-    await tap.equal(libraryBefore.body.tags.length, 1)
+    await tap.equal(libraryBefore.body.tags.length, 5)
     await tap.equal(libraryBefore.body.tags[0].name, stack.name)
 
     // Update the tag
@@ -114,7 +114,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 1)
+    await tap.equal(libraryAfter.body.tags.length, 5)
     await tap.equal(libraryAfter.body.tags[0].name, 'newName')
     await tap.equal(noteWithNewTag.tags.length, 1)
     await tap.equal(noteWithNewTag.tags[0].name, 'newName')
@@ -146,7 +146,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 1)
+    await tap.equal(libraryAfter.body.tags.length, 5)
     await tap.equal(libraryAfter.body.tags[0].json.property, 'value!!')
     await tap.equal(noteWithNewTag.tags.length, 1)
     await tap.equal(noteWithNewTag.tags[0].json.property, 'value!!')

--- a/tests/integration/tag/tags-get.test.js
+++ b/tests/integration/tag/tags-get.test.js
@@ -23,7 +23,7 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.length, 0)
+    await tap.equal(res.body.length, 4) // 4 default modes
   })
 
   await createTag(app, token, readerUrl, { name: 'tag1' })
@@ -38,9 +38,7 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     const body = res.body
-    await tap.equal(res.body.length, 2)
-    await tap.equal(body[0].name, 'tag1')
-    await tap.equal(body[1].name, 'tag2')
+    await tap.equal(res.body.length, 6) // 4 default modes + 2 created tags
   })
 
   await destroyDB(app)

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -64,6 +64,28 @@ const test = async app => {
     tagId = responseCreate.id
   })
 
+  await tap.test('Create Multiple Tags', async () => {
+    let responseCreate = await Tag.createMultipleTags(createdReader.id, [
+      {
+        name: 'tag1',
+        tagType: 'something'
+      },
+      {
+        name: 'tag2',
+        tagType: 'something'
+      }
+    ])
+
+    await tap.ok(responseCreate)
+    await tap.ok(Array.isArray(responseCreate))
+    await tap.equal(responseCreate.length, 2)
+    await tap.ok(responseCreate[0] instanceof Tag)
+    await tap.equal(responseCreate[0].readerId, createdReader.id)
+    await tap.equal(responseCreate[0].name, 'tag1')
+    await tap.type(responseCreate[0].id, 'string')
+    await tap.ok(responseCreate[0].published)
+  })
+
   await tap.test('Get tag by id', async () => {
     let responseGet = await Tag.byId(tagId)
     await tap.ok(responseGet)
@@ -78,9 +100,11 @@ const test = async app => {
     })
     let responseGet = await Tag.byReaderId(urlToId(createdReader.id))
 
-    await tap.equal(responseGet.length, 2)
+    await tap.equal(responseGet.length, 4)
     await tap.ok(responseGet[0] instanceof Tag)
     await tap.ok(responseGet[1] instanceof Tag)
+    await tap.ok(responseGet[2] instanceof Tag)
+    await tap.ok(responseGet[3] instanceof Tag)
   })
 
   await tap.test('Delete Publication_Tags of a Tag', async () => {

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -100,7 +100,7 @@ const test = async app => {
     })
     let responseGet = await Tag.byReaderId(urlToId(createdReader.id))
 
-    await tap.equal(responseGet.length, 4)
+    await tap.equal(responseGet.length, 8) // 4 default modes and 4 tags we created
     await tap.ok(responseGet[0] instanceof Tag)
     await tap.ok(responseGet[1] instanceof Tag)
     await tap.ok(responseGet[2] instanceof Tag)


### PR DESCRIPTION
So I fixed it so that whenever a new Reader is created, we also create 4 tags for that reader for the 4 default 'modes'. 
Those tags are not returned with the Reader object when it is created, since the tags are not included there, but they will show up in the library tags and in the GET /tags endpoint.

