### PR TITLE
Put note endpoint

### DIFF
--- a/routes/note-put.js
+++ b/routes/note-put.js
@@ -1,0 +1,107 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Publication } = require('../models/Publication')
+const boom = require('@hapi/boom')
+const { checkOwnership } = require('../utils/utils')
+const { libraryCacheUpdate } = require('../utils/cache')
+const { Note } = require('../models/Note')
+const { urlToId } = require('../utils/utils')
+const { ValidationError } = require('objection')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /notes/{noteId}:
+   *   put:
+   *     tags:
+   *       - notes
+   *     description: PUT /notes/:noteId
+   *     parameters:
+   *       - in: path
+   *         name: noteId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     responses:
+   *       200:
+   *         description: Successfully updated Note
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/note'
+   *       404:
+   *         description: Note not found
+   *       403:
+   *         description: 'Access to publication {noteId} disallowed'
+   */
+  app.use('/', router)
+  router.route('/notes/:noteId').put(jwtAuth, function (req, res, next) {
+    const noteId = req.params.noteId
+
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader || !checkOwnership(reader.id, noteId)) {
+          return next(
+            boom.forbidden(`Access to Note ${noteId} disallowed`, {
+              type: 'Note',
+              id: noteId,
+              activity: 'Update Note'
+            })
+          )
+        }
+
+        const note = Object.assign(req.body, { id: urlToId(noteId) })
+
+        const result = await Note.update(note)
+
+        if (result === null) {
+          return next(
+            boom.notFound(`no note found with id ${noteId}`, {
+              type: 'Note',
+              id: noteId,
+              activity: 'Update Note'
+            })
+          )
+        }
+
+        if (result instanceof ValidationError) {
+          return next(
+            boom.badRequest('Validation Error on Update Note: ', {
+              activity: 'Update Note',
+              type: 'Note',
+              validation: result.data
+            })
+          )
+        }
+        if (result instanceof Error) {
+          if (result.message === 'no body') {
+            return next(
+              boom.badRequest('body is a required property', {
+                activity: 'Update Note',
+                type: 'Note'
+              })
+            )
+          }
+
+          return next(
+            boom.badRequest(result.message, {
+              activity: 'Update Note',
+              type: 'Note'
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(200).end(JSON.stringify(result.toJSON()))
+      })
+
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/server.js
+++ b/server.js
@@ -49,6 +49,7 @@ const noteDeleteTagRoute = require('./routes/note-delete-tag')
 const readActivityPostRoute = require('./routes/readActivity-post')
 const notePostRoute = require('./routes/note-post')
 const noteDeleteRoute = require('./routes/note-delete')
+const notePutRoute = require('./routes/note-put')
 
 const errorHandling = require('./routes/middleware/error-handling')
 
@@ -230,6 +231,7 @@ notePutTagRoute(app)
 noteDeleteTagRoute(app)
 notePostRoute(app)
 noteDeleteRoute(app)
+notePutRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -220,6 +220,22 @@ const test = async app => {
     await tap.equal(error.details.activity, 'Delete Note')
   })
 
+  await tap.test('Try to update a note belonging to another user', async () => {
+    const res = await request(app)
+      .put(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 403)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 403)
+    await tap.equal(error.error, 'Forbidden')
+    await tap.equal(error.details.type, 'Note')
+    await tap.type(error.details.id, 'string')
+    await tap.equal(error.details.activity, 'Update Note')
+  })
+
   await tap.test('Try to delete a tag belonging to another user', async () => {
     const res = await request(app)
       .delete(`/tags/${tagId}`)

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -197,6 +197,13 @@ const test = async app => {
       .set('Host', 'reader-api.test')
       .type('application/ld+json')
     await tap.equal(res23.statusCode, 401)
+
+    // update note
+    const res24 = await request(app)
+      .put('/notes/note123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res24.statusCode, 401)
   })
 
   await destroyDB(app)

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -137,7 +137,7 @@ const allTests = async () => {
 
   if (!test || test === 'note') {
     // await noteCreateTests(app)
-    // await noteGetTests(app) // route not deprecated, but model is. needs fixing.
+    await noteGetTests(app) // route not deprecated, but model is. needs fixing.
     // await noteUpdateTests(app)
     // await noteGetOldTests(app) // deprecated
     await notePostTests(app)

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -30,6 +30,7 @@ const noteUpdateTests = require('./note-update.test')
 const noteDeleteTestsOld = require('./note-delete.test') // deprecated
 const notePostTests = require('./note/note-post.test')
 const noteDeleteTests = require('./note/note-delete.test')
+const notePutTests = require('./note/note-put.test')
 
 const outboxGetTests = require('./deprecated/outbox-get.test')
 
@@ -141,6 +142,7 @@ const allTests = async () => {
     // await noteGetOldTests(app) // deprecated
     await notePostTests(app)
     await noteDeleteTests(app)
+    await notePutTests(app)
   }
 
   if (!test || test === 'tag') {

--- a/tests/integration/note/note-put.test.js
+++ b/tests/integration/note/note-put.test.js
@@ -1,0 +1,142 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createNote,
+  createDocument
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const publication = await createPublication(readerId)
+
+  const publicationUrl = publication.id
+  const publicationId = urlToId(publication.id)
+
+  const createdDocument = await createDocument(readerId, publicationUrl)
+
+  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+
+  const note = await createNote(app, token, readerId, {
+    body: { content: 'test content', motivation: 'test' },
+    publicationId,
+    documentUrl,
+    json: { property: 'value' }
+  })
+  const noteId = urlToId(note.id)
+
+  await tap.test('Update the content of a Note', async () => {
+    const newNote = Object.assign(note, {
+      body: { motivation: 'test', content: 'new content' }
+    })
+
+    const res = await request(app)
+      .put(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newNote))
+    console.log(res.error)
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.id, 'string')
+    await tap.type(body.body.content, 'string')
+    await tap.equal(body.body.content, 'new content')
+    await tap.notEqual(body.published, body.updated)
+    // check that old properties are still there
+    await tap.type(body.publicationId, 'string')
+    await tap.type(body.documentUrl, 'string')
+    await tap.equal(body.json.property, 'value')
+  })
+
+  await tap.test('Update the target of a Note', async () => {
+    const newNote = Object.assign(note, { target: { property1: 'something' } })
+
+    const res = await request(app)
+      .put(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newNote))
+
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.id, 'string')
+    await tap.type(body.target.property1, 'string')
+    await tap.equal(body.target.property1, 'something')
+  })
+
+  await tap.test(
+    'Try to update the target of a note to the wrong type',
+    async () => {
+      const newNote = Object.assign(note, { target: 'string!' })
+
+      const res = await request(app)
+        .put(`/notes/${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify(newNote))
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(error.details.type, 'Note')
+      await tap.equal(error.details.activity, 'Update Note')
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(error.details.validation.target[0].keyword, 'type')
+      await tap.equal(error.details.validation.target[0].params.type, 'object')
+    }
+  )
+
+  await tap.test('Try to update by removing the body', async () => {
+    const newNote = Object.assign(note, { target: undefined, body: undefined })
+
+    const res = await request(app)
+      .put(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newNote))
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    console.log(error)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(error.details.type, 'Note')
+    await tap.equal(error.details.activity, 'Update Note')
+  })
+
+  await tap.test('Try to update a Note that does not exist', async () => {
+    const res = await request(app)
+      .put(`/notes/${noteId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify(
+          Object.assign(note, { target: { property: 'new target' } })
+        )
+      )
+    await tap.equal(res.statusCode, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(error.details.type, 'Note')
+    await tap.type(error.details.id, 'string')
+    await tap.equal(error.details.activity, 'Update Note')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/note/note-put.test.js
+++ b/tests/integration/note/note-put.test.js
@@ -43,7 +43,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
       .send(JSON.stringify(newNote))
-    console.log(res.error)
+
     await tap.equal(res.statusCode, 200)
     const body = res.body
     await tap.type(body, 'object')
@@ -109,7 +109,6 @@ const test = async app => {
       .send(JSON.stringify(newNote))
     await tap.equal(res.status, 400)
     const error = JSON.parse(res.text)
-    console.log(error)
     await tap.equal(error.statusCode, 400)
     await tap.equal(error.error, 'Bad Request')
     await tap.equal(error.details.type, 'Note')

--- a/tests/integration/readerNotes/readerNotes-orderBy.test.js
+++ b/tests/integration/readerNotes/readerNotes-orderBy.test.js
@@ -114,7 +114,7 @@ const test = async app => {
     const id1 = urlToId(res.body.items[22].id)
     const id2 = urlToId(res.body.items[18].id)
 
-    const resUpdate1 = await request(app)
+    await request(app)
       .put(`/notes/${id1}`)
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)

--- a/tests/integration/readerNotes/readerNotes-orderBy.test.js
+++ b/tests/integration/readerNotes/readerNotes-orderBy.test.js
@@ -103,88 +103,67 @@ const test = async app => {
 
   // -------------------------------------- DATE UPDATED ---------------------------------------
 
-  // await tap.test('Order Notes by date updated', async () => {
-  //   // update two older notes:
-  //   const res = await request(app)
-  //     .get(`/notes?orderBy=created&limit=25`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type(
-  //       'application/ld+json'
-  //     )
+  await tap.test('Order Notes by date updated', async () => {
+    // update two older notes:
+    const res = await request(app)
+      .get(`/notes?orderBy=created&limit=25`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
 
-  //   const id1 = res.body.items[22].id
-  //   const id2 = res.body.items[18].id
+    const id1 = urlToId(res.body.items[22].id)
+    const id2 = urlToId(res.body.items[18].id)
 
-  //   await request(app)
-  //     .post(`/reader-${urlToId(readerId)}/activity`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type(
-  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-  //     )
-  //     .send(
-  //       JSON.stringify({
-  //         '@context': [
-  //           'https://www.w3.org/ns/activitystreams',
-  //           { reader: 'https://rebus.foundation/ns/reader' }
-  //         ],
-  //         type: 'Update',
-  //         object: {
-  //           type: 'Note',
-  //           id: id1,
-  //           content: 'new content1'
-  //         }
-  //       })
-  //     )
-  //   await request(app)
-  //     .post(`/reader-${urlToId(readerId)}/activity`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type(
-  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-  //     )
-  //     .send(
-  //       JSON.stringify({
-  //         '@context': [
-  //           'https://www.w3.org/ns/activitystreams',
-  //           { reader: 'https://rebus.foundation/ns/reader' }
-  //         ],
-  //         type: 'Update',
-  //         object: {
-  //           type: 'Note',
-  //           id: id2,
-  //           content: 'new content2'
-  //         }
-  //       })
-  //     )
+    const resUpdate1 = await request(app)
+      .put(`/notes/${id1}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type(
+        'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+      )
+      .send(
+        JSON.stringify(
+          Object.assign(res.body.items[22], {
+            body: { motivation: 'test', content: 'new content1' }
+          })
+        )
+      )
 
-  //   const res1 = await request(app)
-  //     .get(`/notes?orderBy=updated`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type(
-  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-  //     )
+    await request(app)
+      .put(`/notes/${id2}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify(
+          Object.assign(res.body.items[18], {
+            body: { motivation: 'test', content: 'new content2' }
+          })
+        )
+      )
 
-  //   await tap.equal(res1.body.items[0].content, 'new content2')
-  //   await tap.equal(res1.body.items[1].content, 'new content1')
-  //   await tap.equal(res1.body.items[2].content, 'last')
-  // })
+    const res1 = await request(app)
+      .get(`/notes?orderBy=updated`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
 
-  // await tap.test('Order Notes by date updated - reversed', async () => {
-  //   const res2 = await request(app)
-  //     .get(`/notes?orderBy=updated&reverse=true`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type(
-  //       'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
-  //     )
+    await tap.equal(res1.body.items[0].body.content, 'new content2')
+    await tap.equal(res1.body.items[1].body.content, 'new content1')
+    await tap.equal(res1.body.items[2].body.content, 'last')
+  })
 
-  //   await tap.equal(res2.body.items[0].content, 'first')
-  //   await tap.equal(res2.body.items[1].content, 'second')
-  //   await tap.equal(res2.body.items[2].content, 'third')
-  // })
+  await tap.test('Order Notes by date updated - reversed', async () => {
+    const res2 = await request(app)
+      .get(`/notes?orderBy=updated&reverse=true`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.body.items[0].body.content, 'first')
+    await tap.equal(res2.body.items[1].body.content, 'second')
+    await tap.equal(res2.body.items[2].body.content, 'third')
+  })
 
   await destroyDB(app)
 }


### PR DESCRIPTION
new endpoint: 

PUT /notes/:id

I also fixed the readerNotes orderBy updated filter. And also fixed the Get Note tests to use the new note model

