### PR TITLE
post noteRelations route

### DIFF
--- a/routes/noteRelation-post.js
+++ b/routes/noteRelation-post.js
@@ -1,0 +1,133 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteRelation } = require('../models/NoteRelation')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteRelations:
+   *   post:
+   *     tags:
+   *       - noteRelations
+   *     description: Create a noteRelation
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteRelation'
+   *     responses:
+   *       201:
+   *         description: Successfully created NoteRelation
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/noteRelation'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no Note or NoteRelation found with id passed to 'to', 'from', 'previous' or 'next'
+   */
+  app.use('/', router)
+  router.route('/noteRelations').post(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object' || _.isEmpty(body)) {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        let createdNoteRelation
+        try {
+          createdNoteRelation = await NoteRelation.createNoteRelation(
+            body,
+            reader.id
+          )
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Create NoteRelation: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            let isNotFound
+            if (err.message === 'no to') {
+              err.message = `No Note found with id passed into 'to': ${body.to}`
+              isNotFound = true
+            }
+            if (err.message === 'no from') {
+              err.message = `No Note found with id passed into 'from': ${
+                body.from
+              }`
+              isNotFound = true
+            }
+            if (err.message === 'no previous') {
+              err.message = `No NoteRelation found with id passed into 'previous': ${
+                body.previous
+              }`
+              isNotFound = true
+            }
+            if (err.message === 'no next') {
+              err.message = `No NoteRelation found with id passed into 'next': ${
+                body.next
+              }`
+              isNotFound = true
+            }
+            if (isNotFound) {
+              return next(
+                boom.notFound(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(201).end(JSON.stringify(createdNoteRelation.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/swagger-definitions/noteRelation-def.js
+++ b/routes/swagger-definitions/noteRelation-def.js
@@ -1,0 +1,45 @@
+/**
+ * @swagger
+ * definition:
+ *   noteRelation:
+ *     properties:
+ *       id:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       readerId:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       type:
+ *         type: string
+ *       from:
+ *         type: string
+ *         format: url
+ *       to:
+ *         type: string
+ *         format: url
+ *       contextId:
+ *         type: string
+ *       previous:
+ *         type: string
+ *       next:
+ *         type: string
+ *       published:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *       updated:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *       json:
+ *         type: object
+ *   required:
+ *     - id
+ *     - from
+ *     - type
+ *     - published
+ *     - readerId
+ *
+ */

--- a/server.js
+++ b/server.js
@@ -57,6 +57,9 @@ const notePostRoute = require('./routes/note-post') // POST /notes
 const noteDeleteRoute = require('./routes/note-delete') // DELETE /notes/:id
 const notePutRoute = require('./routes/note-put') // PUT /notes/:id
 
+// NoteRelations
+const noteRelationPostRoute = require('./routes/noteRelation-post') // POST /noteRelations
+
 const setupKnex = async skip_migrate => {
   let config
 
@@ -225,6 +228,7 @@ noteDeleteTagRoute(app)
 notePostRoute(app)
 noteDeleteRoute(app)
 notePutRoute(app)
+noteRelationPostRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -54,6 +54,8 @@ const tagNoteDeleteTests = require('./tag/tag-note-delete.test')
 
 const jobGetTests = require('./job/job-get.test')
 
+const noteRelationPostTests = require('./noteRelation/noteRelation-post.test')
+
 const app = require('../../server').app
 
 require('dotenv').config()
@@ -138,6 +140,10 @@ const allTests = async () => {
 
   if (!test || test === 'jobs') {
     await jobGetTests(app)
+  }
+
+  if (!test || test === 'noteRelation') {
+    await noteRelationPostTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/noteRelation/noteRelation-post.test.js
+++ b/tests/integration/noteRelation/noteRelation-post.test.js
@@ -1,0 +1,283 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote,
+  createPublication,
+  createDocument
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const note1 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 1' }
+  })
+  const noteId1 = urlToId(note1.id)
+  const note2 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 2' }
+  })
+  const noteId2 = urlToId(note2.id)
+
+  let noteRelation1, noteRelation2
+
+  await tap.test('Create NoteRelation with single note', async () => {
+    const res = await request(app)
+      .post('/noteRelations')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          from: noteId1,
+          type: 'test'
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId1)
+    await tap.equal(body.type, 'test')
+    await tap.ok(body.published)
+    noteRelation1 = body
+  })
+
+  await tap.test('Create NoteRelation with two notes', async () => {
+    const res = await request(app)
+      .post('/noteRelations')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          from: noteId1,
+          to: noteId2,
+          type: 'test',
+          json: { property: 'value' }
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId1)
+    await tap.equal(body.to, noteId2)
+    await tap.equal(body.type, 'test')
+    await tap.equal(body.json.property, 'value')
+    await tap.ok(body.published)
+    noteRelation2 = body
+  })
+
+  await tap.test('Create NoteRelation with previous and next', async () => {
+    const res = await request(app)
+      .post('/noteRelations')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          from: noteId1,
+          to: noteId2,
+          previous: noteRelation1.id,
+          next: noteRelation2.id,
+          type: 'test'
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId1)
+    await tap.equal(body.to, noteId2)
+    await tap.equal(body.previous, noteRelation1.id)
+    await tap.equal(body.next, noteRelation2.id)
+    await tap.equal(body.type, 'test')
+    await tap.ok(body.published)
+  })
+
+  await tap.test(
+    'Try to create a noteRelation without a from property',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create NoteRelation: from: is a required property'
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Try to create a noteRelation without a type property',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: noteId1
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create NoteRelation: type: is a required property'
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.from, noteId1)
+    }
+  )
+
+  await tap.test(
+    'Try to create a noteRelation with an invalid from noteId',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: noteId1 + 'abc',
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Note found with id passed into 'from': ${noteId1}abc`
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Try to create a noteRelation with an invalid to noteId',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: noteId1,
+            to: noteId2 + 'abc',
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Note found with id passed into 'to': ${noteId2}abc`
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Try to create a noteRelation with an invalid previous noteRelationId',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: noteId1,
+            previous: noteRelation1.id + 'abc',
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteRelation found with id passed into 'previous': ${
+          noteRelation1.id
+        }abc`
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Try to create a noteRelation with an invalid next noteRelationId',
+    async () => {
+      const res = await request(app)
+        .post('/noteRelations')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: noteId1,
+            to: noteId2,
+            previous: noteRelation1.id,
+            next: noteRelation2.id + 'abc',
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteRelation found with id passed into 'next': ${
+          noteRelation2.id
+        }abc`
+      )
+      await tap.equal(error.details.requestUrl, `/noteRelations`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test


### PR DESCRIPTION
new endpoint:
POST /noteRelations
body:
```
{
  from: <noteId>,
  to: <noteId>,
  type: <string>
  previous: <noteRelationId>,
  next: <noteRelationId>,
  contextId: <noteRelationContextId>,
  json: <object>
}
```
required properties:
- from
- type

Note that 'to' is not a required property, so you can create a relation with just one note. The reason why I did that is that the noteRelationContext will contain noteRelations, not notes. So if we want, for example, to add some unsorted notes to an outline, they have to have a noteRelation. 

Also note that previous / next are noteRelations, not notes

noteRelation can only have one context. 


