### PR TITLE
Put and delete note relation

### DIFF
--- a/models/NoteRelation.js
+++ b/models/NoteRelation.js
@@ -121,10 +121,28 @@ class NoteRelation extends BaseModel {
       'json'
     ])
 
-    return await NoteRelation.query(NoteRelation.knex()).updateAndFetchById(
-      relationId,
-      props
-    )
+    let updatedRel
+    try {
+      updatedRel = await NoteRelation.query(
+        NoteRelation.knex()
+      ).updateAndFetchById(relationId, props)
+    } catch (err) {
+      if (!(err instanceof ValidationError)) {
+        if (err.constraint === 'noterelation_from_foreign') {
+          throw new Error('no from')
+        } else if (err.constraint === 'noterelation_to_foreign') {
+          throw new Error('no to')
+        } else if (err.constraint === 'noterelation_previous_foreign') {
+          throw new Error('no previous')
+        } else if (err.constraint === 'noterelation_next_foreign') {
+          throw new Error('no next')
+        }
+      }
+
+      throw err
+    }
+
+    return updatedRel
   }
 
   static async getRelationsForNote (

--- a/routes/noteRelation-delete.js
+++ b/routes/noteRelation-delete.js
@@ -1,0 +1,90 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteRelation } = require('../models/NoteRelation')
+const { checkOwnership } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteRelations/:id:
+   *   delete:
+   *     tags:
+   *       - noteRelations
+   *     description: Delete a noteRelation
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteRelation'
+   *     responses:
+   *       204:
+   *         description: Successfully deleted NoteRelation
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no NoteRelation found with id
+   */
+  app.use('/', router)
+  router.route('/noteRelations/:id').delete(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation ${req.params.id} disallowed`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+
+        let deleted
+        try {
+          deleted = await NoteRelation.delete(req.params.id)
+        } catch (err) {
+          return next(
+            boom.badRequest(err.message, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!deleted) {
+          return next(
+            boom.notFound(`No NoteRelation found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(204).end()
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/noteRelation-post.js
+++ b/routes/noteRelation-post.js
@@ -3,11 +3,11 @@ const router = express.Router()
 const passport = require('passport')
 const { Reader } = require('../models/Reader')
 const jwtAuth = passport.authenticate('jwt', { session: false })
-const { Note } = require('../models/Note')
 const boom = require('@hapi/boom')
 const _ = require('lodash')
 const { ValidationError } = require('objection')
 const { NoteRelation } = require('../models/NoteRelation')
+const { checkOwnership } = require('../utils/utils')
 
 module.exports = function (app) {
   /**
@@ -60,6 +60,56 @@ module.exports = function (app) {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })
+          )
+        }
+
+        // check owndership of 'to', 'from', 'previous', 'next' resources
+        if (body.from && !checkOwnership(reader.id, body.from)) {
+          return next(
+            boom.forbidden(
+              `Access to Note in 'from' property disallowed: ${body.from}`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.to && !checkOwnership(reader.id, body.to)) {
+          return next(
+            boom.forbidden(
+              `Access to Note in 'to' property disallowed: ${body.to}`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.previous && !checkOwnership(reader.id, body.previous)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation in 'previous' property disallowed: ${
+                body.previous
+              }`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.next && !checkOwnership(reader.id, body.next)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation in 'next' property disallowed: ${
+                body.next
+              }`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
           )
         }
 

--- a/routes/noteRelation-put.js
+++ b/routes/noteRelation-put.js
@@ -1,0 +1,141 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteRelation } = require('../models/NoteRelation')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteRelations/:id:
+   *   put:
+   *     tags:
+   *       - noteRelations
+   *     description: Update a noteRelation
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteRelation'
+   *     responses:
+   *       200:
+   *         description: Successfully updated NoteRelation
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/noteRelation'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no Note or NoteRelation found with id passed to 'to', 'from', 'previous' or 'next'
+   */
+  app.use('/', router)
+  router.route('/noteRelations/:id').put(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object' || _.isEmpty(body)) {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        body.id = req.params.id
+
+        let updatedNoteRelation
+        try {
+          updatedNoteRelation = await NoteRelation.updateNoteRelation(body)
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Update NoteRelation: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            let isNotFound
+            if (err.message === 'no to') {
+              err.message = `No Note found with id passed into 'to': ${body.to}`
+              isNotFound = true
+            }
+            if (err.message === 'no from') {
+              err.message = `No Note found with id passed into 'from': ${
+                body.from
+              }`
+              isNotFound = true
+            }
+            if (err.message === 'no previous') {
+              err.message = `No NoteRelation found with id passed into 'previous': ${
+                body.previous
+              }`
+              isNotFound = true
+            }
+            if (err.message === 'no next') {
+              err.message = `No NoteRelation found with id passed into 'next': ${
+                body.next
+              }`
+              isNotFound = true
+            }
+            if (isNotFound) {
+              return next(
+                boom.notFound(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        if (!updatedNoteRelation) {
+          return next(
+            boom.notFound(`No NoteRelation found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(200).end(JSON.stringify(updatedNoteRelation.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/noteRelation-put.js
+++ b/routes/noteRelation-put.js
@@ -8,6 +8,7 @@ const boom = require('@hapi/boom')
 const _ = require('lodash')
 const { ValidationError } = require('objection')
 const { NoteRelation } = require('../models/NoteRelation')
+const { urlToId, checkOwnership } = require('../utils/utils')
 
 module.exports = function (app) {
   /**
@@ -63,7 +64,69 @@ module.exports = function (app) {
           )
         }
 
+        // check owndership of 'to', 'from', 'previous', 'next' resources and the NoteRelation itself
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation ${req.params.id} disallowed`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.from && !checkOwnership(reader.id, body.from)) {
+          return next(
+            boom.forbidden(
+              `Access to Note in 'from' property disallowed: ${body.from}`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.to && !checkOwnership(reader.id, body.to)) {
+          return next(
+            boom.forbidden(
+              `Access to Note in 'to' property disallowed: ${body.to}`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.previous && !checkOwnership(reader.id, body.previous)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation in 'previous' property disallowed: ${
+                body.previous
+              }`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+        if (body.next && !checkOwnership(reader.id, body.next)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteRelation in 'next' property disallowed: ${
+                body.next
+              }`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+
         body.id = req.params.id
+        body.readerId = urlToId(reader.id)
 
         let updatedNoteRelation
         try {

--- a/server.js
+++ b/server.js
@@ -59,6 +59,7 @@ const notePutRoute = require('./routes/note-put') // PUT /notes/:id
 
 // NoteRelations
 const noteRelationPostRoute = require('./routes/noteRelation-post') // POST /noteRelations
+const noteRelationPutRoute = require('./routes/noteRelation-put') // PUT /noteRelations/:id
 
 const setupKnex = async skip_migrate => {
   let config
@@ -229,6 +230,7 @@ notePostRoute(app)
 noteDeleteRoute(app)
 notePutRoute(app)
 noteRelationPostRoute(app)
+noteRelationPutRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -60,6 +60,7 @@ const notePutRoute = require('./routes/note-put') // PUT /notes/:id
 // NoteRelations
 const noteRelationPostRoute = require('./routes/noteRelation-post') // POST /noteRelations
 const noteRelationPutRoute = require('./routes/noteRelation-put') // PUT /noteRelations/:id
+const noteRelationDeleteRoute = require('./routes/noteRelation-delete') // DELETE /noteRelations/:id
 
 const setupKnex = async skip_migrate => {
   let config
@@ -231,6 +232,7 @@ noteDeleteRoute(app)
 notePutRoute(app)
 noteRelationPostRoute(app)
 noteRelationPutRoute(app)
+noteRelationDeleteRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -255,6 +255,32 @@ const test = async app => {
     await tap.equal(res24.statusCode, 401)
   })
 
+  // -----------------------------------NOTERELATION --------------------------
+
+  await tap.test('Post NoteRelation without authentication', async () => {
+    const res24 = await request(app)
+      .post('/noteRelations')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res24.statusCode, 401)
+  })
+
+  await tap.test('Put NoteRelation without authentication', async () => {
+    const res24 = await request(app)
+      .put('/noteRelations/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res24.statusCode, 401)
+  })
+
+  await tap.test('Delete NoteRelation without authentication', async () => {
+    const res24 = await request(app)
+      .delete('/noteRelations/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res24.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -55,6 +55,7 @@ const tagNoteDeleteTests = require('./tag/tag-note-delete.test')
 const jobGetTests = require('./job/job-get.test')
 
 const noteRelationPostTests = require('./noteRelation/noteRelation-post.test')
+const noteRelationPutTests = require('./noteRelation/noteRelation-put.test')
 
 const app = require('../../server').app
 
@@ -144,6 +145,7 @@ const allTests = async () => {
 
   if (!test || test === 'noteRelation') {
     await noteRelationPostTests(app)
+    await noteRelationPutTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -56,6 +56,7 @@ const jobGetTests = require('./job/job-get.test')
 
 const noteRelationPostTests = require('./noteRelation/noteRelation-post.test')
 const noteRelationPutTests = require('./noteRelation/noteRelation-put.test')
+const noteRelationDeleteTests = require('./noteRelation/noteRelation-delete.test')
 
 const app = require('../../server').app
 
@@ -146,6 +147,7 @@ const allTests = async () => {
   if (!test || test === 'noteRelation') {
     await noteRelationPostTests(app)
     await noteRelationPutTests(app)
+    await noteRelationDeleteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/noteRelation/noteRelation-delete.test.js
+++ b/tests/integration/noteRelation/noteRelation-delete.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote,
+  createNoteRelation
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const note1 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 1' }
+  })
+  const noteId1 = urlToId(note1.id)
+  const note2 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 2' }
+  })
+  const noteId2 = urlToId(note2.id)
+
+  let noteRelation = await createNoteRelation(app, token, {
+    from: noteId1,
+    to: noteId2,
+    type: 'test',
+    json: { property: 'value' }
+  })
+
+  await tap.test('Delete a NoteRelation', async () => {
+    const res = await request(app)
+      .delete(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+  })
+
+  // TODO: test that it is really gone, once I can actually get the noteRelations
+
+  await tap.test(
+    'Try to delete a noteRelation that does not exist',
+    async () => {
+      const res = await request(app)
+        .delete(`/noteRelations/${noteRelation.id}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteRelation found with id ${noteRelation.id}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteRelations/${noteRelation.id}abc`
+      )
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/noteRelation/noteRelation-delete.test.js
+++ b/tests/integration/noteRelation/noteRelation-delete.test.js
@@ -64,6 +64,30 @@ const test = async app => {
     }
   )
 
+  await tap.test('Try to update a noteRelation that was deleted', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify(
+          Object.assign(noteRelation, { type: 'test2', from: noteId1 })
+        )
+      )
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `No NoteRelation found with id ${noteRelation.id}`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/noteRelations/${noteRelation.id}`
+    )
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/integration/noteRelation/noteRelation-post.test.js
+++ b/tests/integration/noteRelation/noteRelation-post.test.js
@@ -42,6 +42,7 @@ const test = async app => {
     await tap.equal(res.status, 201)
     const body = res.body
     await tap.ok(body.id)
+    await tap.ok(body.id.startsWith(readerId))
     await tap.equal(urlToId(body.readerId), readerId)
     await tap.equal(body.from, noteId1)
     await tap.equal(body.type, 'test')

--- a/tests/integration/noteRelation/noteRelation-put.test.js
+++ b/tests/integration/noteRelation/noteRelation-put.test.js
@@ -1,0 +1,228 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote,
+  createNoteRelation
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const note1 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 1' }
+  })
+  const noteId1 = urlToId(note1.id)
+  const note2 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 2' }
+  })
+  const noteId2 = urlToId(note2.id)
+  const note3 = await createNote(app, token, readerId, {
+    body: { motivation: 'test', content: 'note 3' }
+  })
+  const noteId3 = urlToId(note3.id)
+
+  let noteRelation = await createNoteRelation(app, token, {
+    from: noteId1,
+    to: noteId2,
+    type: 'test',
+    json: { property: 'value' }
+  })
+
+  await tap.test('Update type of NoteRelation', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteRelation, { type: 'test2' })))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId1)
+    await tap.equal(body.type, 'test2')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+    await tap.equal(body.json.property, 'value')
+    noteRelation = body
+  })
+
+  await tap.test('Update from in noteRelation', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteRelation, { from: noteId3 })))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId3)
+    await tap.equal(body.to, noteId2)
+    await tap.equal(body.type, 'test2')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+    await tap.equal(body.json.property, 'value')
+    noteRelation = body
+  })
+
+  await tap.test('Update to property to null', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteRelation, { to: null })))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId3)
+    await tap.notOk(body.to)
+    await tap.equal(body.type, 'test2')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+    await tap.equal(body.json.property, 'value')
+    noteRelation = body
+  })
+
+  await tap.test('Update json object to null', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteRelation, { json: null })))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.from, noteId3)
+    await tap.equal(body.type, 'test2')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+    await tap.notOk(body.json)
+    noteRelation = body
+  })
+
+  await tap.test('Try to remove the from property', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteRelation, { from: null })))
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Validation Error on Update NoteRelation: from: should be string'
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/noteRelations/${noteRelation.id}`
+    )
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.type, 'test2')
+  })
+
+  await tap.test('Try to remove the type property', async () => {
+    const res = await request(app)
+      .put(`/noteRelations/${noteRelation.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify(
+          Object.assign(noteRelation, { from: noteId1, type: null })
+        )
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Validation Error on Update NoteRelation: type: should be string'
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/noteRelations/${noteRelation.id}`
+    )
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.type, null)
+  })
+
+  await tap.test(
+    'Try to update the from property to an invalid noteId',
+    async () => {
+      const res = await request(app)
+        .put(`/noteRelations/${noteRelation.id}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify(
+            Object.assign(noteRelation, { type: 'test', from: noteId1 + 'abc' })
+          )
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Note found with id passed into 'from': ${noteId1}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteRelations/${noteRelation.id}`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Try to update a noteRelation that does not exist',
+    async () => {
+      const res = await request(app)
+        .put(`/noteRelations/${noteRelation.id}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify(Object.assign(noteRelation, { from: noteId1 })))
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteRelation found with id ${noteRelation.id}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteRelations/${noteRelation.id}abc`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -166,6 +166,16 @@ const createDocument = async (readerId, publicationId, object = {}) => {
   )
 }
 
+const createNoteRelation = async (app, token, object) => {
+  const res = await request(app)
+    .post('/noteRelations')
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .send(object)
+
+  return res.body
+}
+
 const addPubToCollection = async (app, token, pubId, tagId) => {
   tagId = urlToId(tagId)
   pubId = urlToId(pubId)
@@ -195,5 +205,6 @@ module.exports = {
   createTag,
   createDocument,
   addPubToCollection,
-  addNoteToCollection
+  addNoteToCollection,
+  createNoteRelation
 }


### PR DESCRIPTION
Two new endpoints:

PUT /noteRelations/:id
DELETE /noteRelations/:id

the delete is a soft delete.
Aside from that, works as expected.

I also added some validation for the PUT and POST endpoints to make sure that the notes and noteRelation ids passed to properties like 'from', 'to', 'previous', and 'next' point to object owned by the same reader. It would be weird if it ever came up, but better safe than sorry. 