### PR TITLE
Note context routes

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -143,7 +143,10 @@ class Note extends BaseModel {
       'publicationId',
       'json',
       'readerId',
-      'documentUrl'
+      'documentUrl',
+      'contextId',
+      'previous',
+      'next'
     ])
     if (note.id) props.id = urlToId(note.id)
 
@@ -215,6 +218,8 @@ class Note extends BaseModel {
     } catch (err) {
       if (err.constraint === 'note_publicationid_foreign') {
         throw new Error('no publication')
+      } else if ((err.constraint = 'note_contextid_foreign')) {
+        throw new Error('no context')
       }
       throw err
     }

--- a/models/NoteBody.js
+++ b/models/NoteBody.js
@@ -39,8 +39,8 @@ class NoteBody extends BaseModel {
       properties: {
         id: { type: 'string' },
         noteId: { type: 'string' },
-        content: { type: 'string' },
-        language: { type: 'string' },
+        content: { type: ['string', 'null'] },
+        language: { type: ['string', 'null'] },
         motivation: { type: 'string' },
         readerId: { type: 'string' },
         published: { type: 'string', format: 'date-time' }

--- a/models/NoteContext.js
+++ b/models/NoteContext.js
@@ -69,6 +69,10 @@ class NoteContext extends BaseModel {
       props
     )
   }
+
+  static async delete (id /*: string */) /*: Promise<any> */ {
+    return await NoteContext.query().deleteById(id)
+  }
 }
 
 module.exports = { NoteContext }

--- a/models/NoteContext.js
+++ b/models/NoteContext.js
@@ -3,6 +3,8 @@
 const Model = require('objection').Model
 const { BaseModel } = require('./BaseModel.js')
 const _ = require('lodash')
+const { urlToId } = require('../utils/utils')
+const crypto = require('crypto')
 
 class NoteContext extends BaseModel {
   static get tableName () /*: string */ {
@@ -48,8 +50,24 @@ class NoteContext extends BaseModel {
   ) /*: Promise<any> */ {
     const props = _.pick(object, ['type', 'name', 'description', 'json'])
     props.readerId = readerId
+    props.id = `${urlToId(readerId)}-${crypto.randomBytes(5).toString('hex')}`
 
     return await NoteContext.query(NoteContext.knex()).insertAndFetch(props)
+  }
+
+  static async update (object /*: any */) /*: Promise<any> */ {
+    const props = _.pick(object, [
+      'readerId',
+      'type',
+      'name',
+      'description',
+      'json'
+    ])
+
+    return await NoteContext.query(NoteContext.knex()).updateAndFetchById(
+      object.id,
+      props
+    )
   }
 }
 

--- a/routes/note-put.js
+++ b/routes/note-put.js
@@ -62,6 +62,7 @@ module.exports = function (app) {
         }
 
         const note = Object.assign(req.body, { id: urlToId(noteId) })
+        note.readerId = reader.id
         let updatedNote
         try {
           updatedNote = await Note.update(note)

--- a/routes/noteContext-addNote.js
+++ b/routes/noteContext-addNote.js
@@ -1,0 +1,143 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteContexts/:id/notes:
+   *   post:
+   *     tags:
+   *       - noteContexts
+   *     description: Add a Note to a NoteContext
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/note'
+   *     responses:
+   *       201:
+   *         description: Successfully added Note to Context
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/note'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: Publication (from note.publicationId) or Document (from note.documentUrl) not found. Or Context not found
+   */
+  app.use('/', router)
+  router
+    .route('/noteContexts/:id/notes')
+    .post(jwtAuth, function (req, res, next) {
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader) {
+            return next(
+              boom.unauthorized(`No user found for this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          const body = req.body
+          if (typeof body !== 'object' || _.isEmpty(body)) {
+            return next(
+              boom.badRequest('Body must be a JSON object', {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          body.contextId = req.params.id
+          let createdNote
+          try {
+            createdNote = await Note.createNote(reader, body)
+          } catch (err) {
+            if (err instanceof ValidationError) {
+              return next(
+                boom.badRequest(
+                  `Validation Error on Add Note to Context: ${err.message}`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body,
+                    validation: err.data
+                  }
+                )
+              )
+            } else if (err.message === 'no document') {
+              return next(
+                boom.notFound(
+                  `Add Note to Context Error: No Document found with documentUrl: ${
+                    body.documentUrl
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no publication') {
+              return next(
+                boom.notFound(
+                  `Add Note to Context Error: No Publication found with id: ${
+                    body.publicationId
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no context') {
+              return next(
+                boom.notFound(
+                  `Add Note to Context Error: No Context found with id: ${
+                    req.params.id
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else {
+              return next(
+                boom.badRequest(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.setHeader('Location', createdNote.id)
+          res.status(201).end(JSON.stringify(createdNote.toJSON()))
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/routes/noteContext-delete.js
+++ b/routes/noteContext-delete.js
@@ -1,0 +1,90 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteContext } = require('../models/NoteContext')
+const { checkOwnership } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteContexts/:id:
+   *   delete:
+   *     tags:
+   *       - noteContexts
+   *     description: Delete a noteContext
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteContext'
+   *     responses:
+   *       204:
+   *         description: Successfully deleted NoteContext
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no NoteContext found with id
+   */
+  app.use('/', router)
+  router.route('/noteContexts/:id').delete(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteContext ${req.params.id} disallowed`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+
+        let deleted
+        try {
+          deleted = await NoteContext.delete(req.params.id)
+        } catch (err) {
+          return next(
+            boom.badRequest(err.message, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!deleted) {
+          return next(
+            boom.notFound(`No NoteContext found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(204).end()
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/noteContext-post.js
+++ b/routes/noteContext-post.js
@@ -1,0 +1,98 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteContext } = require('../models/NoteContext')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteContexts:
+   *   post:
+   *     tags:
+   *       - noteContexts
+   *     description: Create a noteContext
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteContext'
+   *     responses:
+   *       201:
+   *         description: Successfully created NoteContext
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/noteContext'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   */
+  app.use('/', router)
+  router.route('/noteContexts').post(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object' || _.isEmpty(body)) {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        let createdNoteContext
+        try {
+          createdNoteContext = await NoteContext.createNoteContext(
+            body,
+            reader.id
+          )
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Create NoteContext: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(201).end(JSON.stringify(createdNoteContext.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/noteContext-put.js
+++ b/routes/noteContext-put.js
@@ -1,0 +1,123 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { urlToId, checkOwnership } = require('../utils/utils')
+const { NoteContext } = require('../models/NoteContext')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /noteContexts/:id:
+   *   put:
+   *     tags:
+   *       - noteContexts
+   *     description: Update a noteContext
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/noteContext'
+   *     responses:
+   *       200:
+   *         description: Successfully updated NoteContext
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/noteContext'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no NoteContext found with id {id}
+   */
+  app.use('/', router)
+  router.route('/noteContexts/:id').put(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object' || _.isEmpty(body)) {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        // check owndership of NoteContext
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteContext ${req.params.id} disallowed`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+
+        body.id = req.params.id
+        body.readerId = urlToId(reader.id)
+
+        let updatedNoteContext
+        try {
+          updatedNoteContext = await NoteContext.update(body)
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Update NoteContext: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        if (!updatedNoteContext) {
+          return next(
+            boom.notFound(`No NoteContext found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(200).end(JSON.stringify(updatedNoteContext.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/swagger-definitions/noteContext-def.js
+++ b/routes/swagger-definitions/noteContext-def.js
@@ -1,0 +1,36 @@
+/**
+ * @swagger
+ * definition:
+ *   noteContext:
+ *     properties:
+ *       id:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       readerId:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       type:
+ *         type: string
+ *       name:
+ *         type: string
+ *       description:
+ *         type: string
+ *       published:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *       updated:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *       json:
+ *         type: object
+ *   required:
+ *     - id
+ *     - type
+ *     - published
+ *     - readerId
+ *
+ */

--- a/server.js
+++ b/server.js
@@ -66,6 +66,7 @@ const noteRelationDeleteRoute = require('./routes/noteRelation-delete') // DELET
 const noteContextPostRoute = require('./routes/noteContext-post') // POST /noteContexts
 const noteContextPutRoute = require('./routes/noteContext-put') // PUT /noteContexts/:id
 const noteContextDeleteRoute = require('./routes/noteContext-delete') // DELETE /noteContexts/:id
+const noteContextAddNoteRoute = require('./routes/noteContext-addNote') // POST /noteContexts/:id/notes
 
 const setupKnex = async skip_migrate => {
   let config
@@ -241,6 +242,7 @@ noteRelationDeleteRoute(app)
 noteContextPostRoute(app)
 noteContextPutRoute(app)
 noteContextDeleteRoute(app)
+noteContextAddNoteRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -64,7 +64,8 @@ const noteRelationDeleteRoute = require('./routes/noteRelation-delete') // DELET
 
 // NoteContexts
 const noteContextPostRoute = require('./routes/noteContext-post') // POST /noteContexts
-const noteContextPutRoute = require('./routes/noteContext-put')
+const noteContextPutRoute = require('./routes/noteContext-put') // PUT /noteContexts/:id
+const noteContextDeleteRoute = require('./routes/noteContext-delete') // DELETE /noteContexts/:id
 
 const setupKnex = async skip_migrate => {
   let config
@@ -239,6 +240,7 @@ noteRelationPutRoute(app)
 noteRelationDeleteRoute(app)
 noteContextPostRoute(app)
 noteContextPutRoute(app)
+noteContextDeleteRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -64,6 +64,7 @@ const noteRelationDeleteRoute = require('./routes/noteRelation-delete') // DELET
 
 // NoteContexts
 const noteContextPostRoute = require('./routes/noteContext-post') // POST /noteContexts
+const noteContextPutRoute = require('./routes/noteContext-put')
 
 const setupKnex = async skip_migrate => {
   let config
@@ -237,6 +238,7 @@ noteRelationPostRoute(app)
 noteRelationPutRoute(app)
 noteRelationDeleteRoute(app)
 noteContextPostRoute(app)
+noteContextPutRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -62,6 +62,9 @@ const noteRelationPostRoute = require('./routes/noteRelation-post') // POST /not
 const noteRelationPutRoute = require('./routes/noteRelation-put') // PUT /noteRelations/:id
 const noteRelationDeleteRoute = require('./routes/noteRelation-delete') // DELETE /noteRelations/:id
 
+// NoteContexts
+const noteContextPostRoute = require('./routes/noteContext-post') // POST /noteContexts
+
 const setupKnex = async skip_migrate => {
   let config
 
@@ -233,6 +236,7 @@ notePutRoute(app)
 noteRelationPostRoute(app)
 noteRelationPutRoute(app)
 noteRelationDeleteRoute(app)
+noteContextPostRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -440,6 +440,30 @@ const test = async app => {
     }
   )
 
+  await tap.test(
+    'Try to delete a noteContext belonging to another user',
+    async () => {
+      const res = await request(app)
+        .delete(`/noteContexts/${noteContext1.id}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext1.id} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext1.id}`
+      )
+    }
+  )
+
   // ---------------------------------------- READER --------------------------
 
   await tap.test(

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -299,6 +299,14 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test('Delete NoteContext without authentication', async () => {
+    const res = await request(app)
+      .delete('/noteContexts/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -281,6 +281,16 @@ const test = async app => {
     await tap.equal(res24.statusCode, 401)
   })
 
+  // -------------------------------------NOTECONTEXT --------------------------------
+
+  await tap.test('POST NoteContext without authentication', async () => {
+    const res = await request(app)
+      .post('/noteContexts')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -291,6 +291,14 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test('PUT NoteContext without authentication', async () => {
+    const res = await request(app)
+      .put('/noteContexts/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -307,6 +307,17 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test(
+    'Add a Note to a NoteContext without authentication',
+    async () => {
+      const res = await request(app)
+        .post('/noteContexts/123/notes')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -58,6 +58,8 @@ const noteRelationPostTests = require('./noteRelation/noteRelation-post.test')
 const noteRelationPutTests = require('./noteRelation/noteRelation-put.test')
 const noteRelationDeleteTests = require('./noteRelation/noteRelation-delete.test')
 
+const noteContextPostTests = require('./noteContext/noteContext-post.test')
+
 const app = require('../../server').app
 
 require('dotenv').config()
@@ -148,6 +150,10 @@ const allTests = async () => {
     await noteRelationPostTests(app)
     await noteRelationPutTests(app)
     await noteRelationDeleteTests(app)
+  }
+
+  if (!test || test === 'noteContext') {
+    await noteContextPostTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -60,6 +60,7 @@ const noteRelationDeleteTests = require('./noteRelation/noteRelation-delete.test
 
 const noteContextPostTests = require('./noteContext/noteContext-post.test')
 const noteContextPutTests = require('./noteContext/noteContext-put.test')
+const noteContextDeleteTests = require('./noteContext/noteContext-delete.test')
 
 const app = require('../../server').app
 
@@ -156,6 +157,7 @@ const allTests = async () => {
   if (!test || test === 'noteContext') {
     await noteContextPostTests(app)
     await noteContextPutTests(app)
+    await noteContextDeleteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -59,6 +59,7 @@ const noteRelationPutTests = require('./noteRelation/noteRelation-put.test')
 const noteRelationDeleteTests = require('./noteRelation/noteRelation-delete.test')
 
 const noteContextPostTests = require('./noteContext/noteContext-post.test')
+const noteContextPutTests = require('./noteContext/noteContext-put.test')
 
 const app = require('../../server').app
 
@@ -154,6 +155,7 @@ const allTests = async () => {
 
   if (!test || test === 'noteContext') {
     await noteContextPostTests(app)
+    await noteContextPutTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -61,6 +61,7 @@ const noteRelationDeleteTests = require('./noteRelation/noteRelation-delete.test
 const noteContextPostTests = require('./noteContext/noteContext-post.test')
 const noteContextPutTests = require('./noteContext/noteContext-put.test')
 const noteContextDeleteTests = require('./noteContext/noteContext-delete.test')
+const noteContextAddNoteTests = require('./noteContext/noteContext-addNote.test')
 
 const app = require('../../server').app
 
@@ -158,6 +159,7 @@ const allTests = async () => {
     await noteContextPostTests(app)
     await noteContextPutTests(app)
     await noteContextDeleteTests(app)
+    await noteContextAddNoteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/noteContext/noteContext-addNote.test.js
+++ b/tests/integration/noteContext/noteContext-addNote.test.js
@@ -1,0 +1,237 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createDocument,
+  createNoteContext
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const publication = await createPublication(readerId)
+  const publicationId = urlToId(publication.id)
+  const publicationUrl = publication.id
+
+  const publication2 = await createPublication(readerId)
+  const publicationId2 = urlToId(publication2.id)
+
+  const createdDocument = await createDocument(readerId, publicationUrl)
+
+  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+
+  const context = await createNoteContext(app, token, {
+    type: 'test',
+    name: 'my context'
+  })
+  const contextId = context.id
+
+  await tap.test('Add to context a Note with a single body', async () => {
+    const res = await request(app)
+      .post(`/noteContexts/${contextId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, contextId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+  })
+
+  await tap.test('Create Note with two bodies', async () => {
+    const res = await request(app)
+      .post(`/noteContexts/${contextId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: [
+            {
+              content: 'this is the content of the note',
+              motivation: 'test'
+            },
+            {
+              motivation: 'test'
+            }
+          ],
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, contextId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.equal(body.body.length, 2)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+    await tap.notOk(body.body[1].content)
+    await tap.equal(body.body[1].motivation, 'test')
+  })
+
+  await tap.test('Create Note with documentUrl and publicationId', async () => {
+    const res = await request(app)
+      .post(`/noteContexts/${contextId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          publicationId,
+          documentUrl
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, contextId)
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+    await tap.equal(body.documentUrl, documentUrl)
+    await tap.equal(urlToId(body.publicationId), publicationId)
+  })
+
+  // ADD TESTS: notes should show up when fetching the context
+
+  // ------------------------------------- VALIDATION ERRORS ------------------------------------
+
+  await tap.test('Try to create a Note without a body', async () => {
+    const res = await request(app)
+      .post(`/noteContexts/${contextId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          canonical: 'one'
+        })
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Create Note Validation Error: body is a required property'
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/noteContexts/${contextId}/notes`
+    )
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.canonical, 'one')
+  })
+
+  await tap.test(
+    'Try to create a Note with a body but no motivation',
+    async () => {
+      const res = await request(app)
+        .post(`/noteContexts/${contextId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            canonical: 'one',
+            body: {
+              content: 'this should not show up!!!!!!!!',
+              language: 'en'
+            },
+            json: { property: 'this should not be saved!!' }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Note Validation Error: body.motivation is a required property'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${contextId}/notes`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.canonical, 'one')
+    }
+  )
+
+  await tap.test(
+    'Try to create a Note for a Context that does not exist',
+    async () => {
+      const res = await request(app)
+        .post(`/noteContexts/${contextId}abc/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            canonical: 'one',
+            body: {
+              content: 'test',
+              language: 'en'
+            },
+            json: { property: 'value' }
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Add Note to Context Error: No Context found with id: ${contextId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${contextId}abc/notes`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.canonical, 'one')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/noteContext/noteContext-delete.test.js
+++ b/tests/integration/noteContext/noteContext-delete.test.js
@@ -1,0 +1,92 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNoteContext
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const noteContext = await createNoteContext(app, token)
+
+  await tap.test('Delete a NoteContext', async () => {
+    const res = await request(app)
+      .delete(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+  })
+
+  await tap.test(
+    'Try to delete a NoteContext that was already deleted',
+    async () => {
+      const res = await request(app)
+        .delete(`/noteContexts/${noteContext.id}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteContext found with id ${noteContext.id}`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.id}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to delete a NoteContext that does not exist',
+    async () => {
+      const res = await request(app)
+        .delete(`/noteContexts/${noteContext.id}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteContext found with id ${noteContext.id}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.id}abc`
+      )
+    }
+  )
+
+  await tap.test('Try to update a noteContext that was deleted', async () => {
+    const res = await request(app)
+      .put(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(Object.assign(noteContext, { type: 'test2' })))
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `No NoteContext found with id ${noteContext.id}`
+    )
+    await tap.equal(error.details.requestUrl, `/noteContexts/${noteContext.id}`)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/noteContext/noteContext-post.test.js
+++ b/tests/integration/noteContext/noteContext-post.test.js
@@ -1,0 +1,118 @@
+const request = require('supertest')
+const tap = require('tap')
+const { getToken, createUser, destroyDB } = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  await tap.test('Create NoteContext', async () => {
+    const res = await request(app)
+      .post('/noteContexts')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          name: 'context1',
+          description: 'this is the description of context1',
+          type: 'outline',
+          json: { property: 'value' }
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.name, 'context1')
+    await tap.equal(body.description, 'this is the description of context1')
+    await tap.equal(body.type, 'outline')
+    await tap.equal(body.json.property, 'value')
+    await tap.ok(body.published)
+  })
+
+  await tap.test('Create NoteContext with only a type', async () => {
+    const res = await request(app)
+      .post('/noteContexts')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          type: 'outline'
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'outline')
+    await tap.ok(body.published)
+  })
+
+  await tap.test('Try to create NoteContext without a type', async () => {
+    const res = await request(app)
+      .post('/noteContexts')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          name: 'context1',
+          description: 'this is the description of context1',
+          json: { property: 'value' }
+        })
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Validation Error on Create NoteContext: type: is a required property'
+    )
+    await tap.equal(error.details.requestUrl, `/noteContexts`)
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.name, 'context1')
+  })
+
+  await tap.test(
+    'Try to create NoteContext without a name of the wrong type',
+    async () => {
+      const res = await request(app)
+        .post('/noteContexts')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 123,
+            description: 'this is the description of context1',
+            json: { property: 'value' },
+            type: 'test'
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create NoteContext: name: should be string,null'
+      )
+      await tap.equal(error.details.requestUrl, `/noteContexts`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.name, 123)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/noteContext/noteContext-put.test.js
+++ b/tests/integration/noteContext/noteContext-put.test.js
@@ -1,0 +1,128 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNoteContext
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const noteContext = await createNoteContext(app, token)
+
+  await tap.test('Update type of NoteContext', async () => {
+    const res = await request(app)
+      .put(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({ type: 'test2' }))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'test2')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+  })
+
+  await tap.test('Update name and description of NoteContext', async () => {
+    const res = await request(app)
+      .put(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          type: 'test2',
+          name: 'something',
+          description: 'description!'
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'test2')
+    await tap.equal(body.name, 'something')
+    await tap.equal(body.description, 'description!')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+  })
+
+  await tap.test('Update name and description to null', async () => {
+    const res = await request(app)
+      .put(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({ type: 'test2', name: null, description: null }))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'test2')
+    await tap.notOk(body.name)
+    await tap.notOk(body.description)
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+  })
+
+  await tap.test('Try to remove the type property', async () => {
+    const res = await request(app)
+      .put(`/noteContexts/${noteContext.id}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({ type: null }))
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Validation Error on Update NoteContext: type: should be string'
+    )
+    await tap.equal(error.details.requestUrl, `/noteContexts/${noteContext.id}`)
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.type, null)
+  })
+
+  await tap.test(
+    'Try to update a noteContext that does not exist',
+    async () => {
+      const res = await request(app)
+        .put(`/noteContexts/${noteContext.id}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ type: 'test3' }))
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No NoteContext found with id ${noteContext.id}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.id}abc`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test3')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/NoteContext.test.js
+++ b/tests/models/NoteContext.test.js
@@ -3,7 +3,7 @@ const { destroyDB } = require('../utils/testUtils')
 const { Reader } = require('../../models/Reader')
 const { urlToId } = require('../../utils/utils')
 const crypto = require('crypto')
-const { NoteRelationContext } = require('../../models/NoteContext')
+const { NoteContext } = require('../../models/NoteContext')
 const { ValidationError } = require('objection')
 
 const test = async app => {
@@ -13,31 +13,30 @@ const test = async app => {
   const random = crypto.randomBytes(13).toString('hex')
   const createdReader = await Reader.createReader(`auth0|foo${random}`, reader)
   const readerId = urlToId(createdReader.id)
+  let noteContextId
 
-  await tap.test(
-    'Create NoteRelationContext shouldn not throw an error',
-    async () => {
-      let error
-      try {
-        await NoteRelationContext.createNoteRelationContext(
-          {
-            type: 'test',
-            name: 'something',
-            description: 'a description goes here'
-          },
-          readerId
-        )
-      } catch (err) {
-        error = err
-      }
-      await tap.notOk(error)
-    }
-  )
-
-  await tap.test('Create NoteRelationContext with only a type', async () => {
+  await tap.test('Create NoteContext shouldn not throw an error', async () => {
     let error
     try {
-      await NoteRelationContext.createNoteRelationContext(
+      let noteContext = await NoteContext.createNoteContext(
+        {
+          type: 'test',
+          name: 'something',
+          description: 'a description goes here'
+        },
+        readerId
+      )
+      noteContextId = noteContext.id
+    } catch (err) {
+      error = err
+    }
+    await tap.notOk(error)
+  })
+
+  await tap.test('Create NoteContext with only a type', async () => {
+    let error
+    try {
+      await NoteContext.createNoteContext(
         {
           type: 'test'
         },
@@ -49,25 +48,42 @@ const test = async app => {
     await tap.notOk(error)
   })
 
-  await tap.test(
-    'Try to Create NoteRelationContext without a type',
-    async () => {
-      let error
-      try {
-        await NoteRelationContext.createNoteRelationContext(
-          {
-            name: 'something',
-            description: 'a description goes here'
-          },
-          readerId
-        )
-      } catch (err) {
-        error = err
-      }
-      await tap.ok(error)
-      await tap.ok(error instanceof ValidationError)
+  await tap.test('Update a NoteContext', async () => {
+    let error
+    try {
+      await NoteContext.update({ id: noteContextId, type: 'test2' })
+    } catch (err) {
+      error = err
     }
-  )
+    await tap.notOk(error)
+  })
+
+  await tap.test('Delete a NoteContext', async () => {
+    let error
+    try {
+      await NoteContext.delete(noteContextId)
+    } catch (err) {
+      error = err
+    }
+    await tap.notOk(error)
+  })
+
+  await tap.test('Try to Create NoteContext without a type', async () => {
+    let error
+    try {
+      await NoteContext.createNoteContext(
+        {
+          name: 'something',
+          description: 'a description goes here'
+        },
+        readerId
+      )
+    } catch (err) {
+      error = err
+    }
+    await tap.ok(error)
+    await tap.ok(error instanceof ValidationError)
+  })
 
   await destroyDB(app)
 }

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -176,6 +176,23 @@ const createNoteRelation = async (app, token, object) => {
   return res.body
 }
 
+const createNoteContext = async (app, token, object) => {
+  const contextObject = Object.assign(
+    {
+      type: 'test'
+    },
+    object
+  )
+
+  const res = await request(app)
+    .post('/noteContexts')
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .send(contextObject)
+
+  return res.body
+}
+
 const addPubToCollection = async (app, token, pubId, tagId) => {
   tagId = urlToId(tagId)
   pubId = urlToId(pubId)
@@ -206,5 +223,6 @@ module.exports = {
   createDocument,
   addPubToCollection,
   addNoteToCollection,
-  createNoteRelation
+  createNoteRelation,
+  createNoteContext
 }


### PR DESCRIPTION
POST /noteContexts
PUT /noteContexts/:id
DELETE /noteContexts/:id
POST /noteContexts/:id/notes
The last one works like POST /notes but also assigns a contextId to the note. 
It is also possible to use it to copy an existing note into a context:
POST /noteContexts/:id/notes?source=noteId
In that case, you don't need to pass in a body (in fact, if you do, it will be ignored)
Also, the new note will have a 'original' property, which will be the id of the original note. 

Technically, it is also possible to create a note using POST /notes and pass in a note with a contextId. I'll have to check of the validation of the context works there too. But for now, it's safer to use the POST /noteContexts/:id/notes route. 
