### PR TITLE
get readerNotes should not return notes with a contextId

### DIFF
--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -18,6 +18,7 @@ class ReaderNotes {
     let resultQuery = Note.query(Note.knex())
       .count()
       .whereNull('Note.deleted')
+      .whereNull('Note.contextId')
       .andWhere('Note.readerId', '=', readerId)
       .leftJoin('NoteBody', 'NoteBody.noteId', '=', 'Note.id')
 
@@ -171,6 +172,7 @@ class ReaderNotes {
           )
         })
         builder.whereNull('Note.deleted')
+        builder.whereNull('Note.contextId')
 
         // filters
         if (filters.publication) {


### PR DESCRIPTION
so the route used to get notes for a user: GET /notes now only returns notes that are not context-specific. Notes that are created in a context, whether they are new notes or copies of existing notes, should not be in the notes page. 

Correct?