### PR TITLE
get notes with tags

### DIFF
--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -151,7 +151,7 @@ class ReaderNotes {
     }
 
     const readers = await qb
-      .withGraphFetched('replies.[publication.[attributions], body]')
+      .withGraphFetched('replies.[publication.[attributions], body, tags]')
       .modifyGraph('replies', builder => {
         builder.modifyGraph('body', bodyBuilder => {
           bodyBuilder.select('content', 'language', 'motivation')
@@ -268,7 +268,7 @@ class ReaderNotes {
           }
         }
 
-        if (filters.orderBy === 'updated') {
+        if (filters.orderBy === 'updated' || !filters.orderBy) {
           if (filters.reverse) {
             builder.orderBy('Note.updated')
           } else {

--- a/tests/integration/readerNotes/readerNotes-get.test.js
+++ b/tests/integration/readerNotes/readerNotes-get.test.js
@@ -8,7 +8,9 @@ const {
   createNote,
   createDocument,
   createNoteContext,
-  addNoteToContext
+  addNoteToContext,
+  addNoteToCollection,
+  createTag
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
 const _ = require('lodash')
@@ -59,9 +61,12 @@ const test = async app => {
     await createNoteSimplified({
       body: { content: 'second', motivation: 'test' }
     })
-    await createNoteSimplified({
+    const note3 = await createNoteSimplified({
       body: { content: 'third', motivation: 'test' }
     })
+
+    const tag = await createTag(app, token, { name: 'test' })
+    await addNoteToCollection(app, token, note3.shortId, tag.id)
 
     const res = await request(app)
       .get('/notes')
@@ -84,6 +89,9 @@ const test = async app => {
     await tap.type(firstItem.publication.name, 'string')
     await tap.ok(firstItem.publication.author)
     await tap.type(firstItem.publication.author[0].name, 'string')
+    // should include tags
+    await tap.ok(firstItem.tags)
+    await tap.equal(firstItem.tags.length, 1)
   })
 
   await tap.test(


### PR DESCRIPTION
GET /notes
will now return notes with a list of tags for each note

I also fixed is so that notes will by default be ordered by latest updated if no orderBy is specified. Until now, it was returning whatever default order the database returned, which could change from one time to another. 