### PR TITLE
Library orderBy type, search by attribution

### DIFF
--- a/models/library.js
+++ b/models/library.js
@@ -259,6 +259,12 @@ class Library {
           } else {
             builder.orderByRaw('"datePublished" DESC NULLS LAST')
           }
+        } else if (filter.orderBy === 'type') {
+          if (filter.reverse) {
+            builder.orderByRaw('"type" DESC NULLS FIRST')
+          } else {
+            builder.orderByRaw('"type" NULLS LAST')
+          }
         } else {
           if (filter.reverse) {
             builder.orderBy('Publication.updated')

--- a/models/library.js
+++ b/models/library.js
@@ -19,104 +19,99 @@ class Library {
         filter.workspace.charAt(0).toUpperCase() +
         filter.workspace.substring(1).toLowerCase()
     }
-    let resultQuery = Publication.query(Publication.knex())
-      .count()
-      .whereNull('Publication.deleted')
-      .andWhere('Publication.readerId', '=', readerId)
 
+    let builder = Publication.query(Publication.knex())
+      .select('Publication.id')
+      .from('Publication')
+    builder.distinct('Publication.id')
+    builder.whereNull('Publication.deleted')
+    builder.where('Publication.readerId', '=', readerId)
     if (filter.title) {
-      resultQuery = resultQuery.where(
-        'Publication.name',
-        'ilike',
-        `%${filter.title.toLowerCase()}%`
-      )
-    }
-    if (filter.type) {
-      resultQuery = resultQuery.where('Publication.type', '=', type)
+      const title = filter.title.toLowerCase()
+      builder.where('Publication.name', 'ilike', `%${title}%`)
     }
     if (filter.language) {
-      resultQuery = resultQuery.whereJsonSupersetOf(
-        'Publication.metadata:inLanguage',
-        [filter.language]
-      )
+      builder.whereJsonSupersetOf('Publication.metadata:inLanguage', [
+        filter.language
+      ])
     }
     if (filter.keyword) {
-      resultQuery = resultQuery.whereJsonSupersetOf(
-        'Publication.metadata:keywords',
-        [filter.keyword.toLowerCase()]
-      )
+      builder.whereJsonSupersetOf('Publication.metadata:keywords', [
+        filter.keyword.toLowerCase()
+      ])
     }
+    if (filter.type) {
+      builder.where('Publication.type', '=', type)
+    }
+    builder.leftJoin(
+      'Attribution',
+      'Attribution.publicationId',
+      '=',
+      'Publication.id'
+    )
+
     if (filter.author) {
-      resultQuery = resultQuery
-        .leftJoin(
-          'Attribution',
-          'Attribution.publicationId',
-          '=',
-          'Publication.id'
-        )
+      builder
         .where('Attribution.normalizedName', '=', author)
         .andWhere('Attribution.role', '=', 'author')
     }
     if (filter.attribution) {
-      resultQuery = resultQuery
-        .leftJoin(
-          'Attribution',
-          'Attribution.publicationId',
-          '=',
-          'Publication.id'
-        )
-        .where('Attribution.normalizedName', 'like', `%${attribution}%`)
+      builder.where('Attribution.normalizedName', 'like', `%${attribution}%`)
       if (filter.role) {
-        resultQuery = resultQuery.andWhere('Attribution.role', '=', filter.role)
+        builder.andWhere('Attribution.role', '=', filter.role)
       }
     }
+    builder.withGraphFetched('[tags, attributions]')
     if (filter.collection) {
-      resultQuery = resultQuery
-        .leftJoin(
-          'publication_tag as publication_tag_collection',
-          'publication_tag_collection.publicationId',
-          '=',
-          'Publication.id'
-        )
-        .leftJoin(
-          'Tag as Tag_collection',
-          'publication_tag_collection.tagId',
-          '=',
-          'Tag_collection.id'
-        )
+      builder.leftJoin(
+        'publication_tag as publication_tag_collection',
+        'publication_tag_collection.publicationId',
+        '=',
+        'Publication.id'
+      )
+      builder.leftJoin(
+        'Tag as Tag_collection',
+        'publication_tag_collection.tagId',
+        '=',
+        'Tag_collection.id'
+      )
+      builder.whereNull('Tag_collection.deleted')
+      builder
         .where('Tag_collection.name', '=', filter.collection)
         .andWhere('Tag_collection.type', '=', 'stack')
     }
     if (filter.workspace) {
-      resultQuery = resultQuery
-        .leftJoin(
-          'publication_tag as publication_tag_workspace',
-          'publication_tag_workspace.publicationId',
-          '=',
-          'Publication.id'
-        )
-        .leftJoin(
-          'Tag as Tag_workspace',
-          'publication_tag_workspace.tagId',
-          '=',
-          'Tag_workspace.id'
-        )
+      builder.leftJoin(
+        'publication_tag as publication_tag_workspace',
+        'publication_tag_workspace.publicationId',
+        '=',
+        'Publication.id'
+      )
+      builder.leftJoin(
+        'Tag as Tag_workspace',
+        'publication_tag_workspace.tagId',
+        '=',
+        'Tag_workspace.id'
+      )
+      builder.whereNull('Tag_workspace.deleted')
+      builder
         .where('Tag_workspace.name', '=', workspace)
         .andWhere('Tag_workspace.type', '=', 'workspace')
     }
     if (filter.search) {
       const search = filter.search.toLowerCase()
-      resultQuery = resultQuery.where(nestedQuery => {
-        nestedQuery
+      builder.where(nestedBuilder => {
+        nestedBuilder
           .where('Publication.name', 'ilike', `%${search}%`)
+          .orWhere('Attribution.normalizedName', 'ilike', `%${search}%`)
           .orWhere('Publication.abstract', 'ilike', `%${search}%`)
           .orWhere('Publication.description', 'ilike', `%${search}%`)
           .orWhereJsonSupersetOf('Publication.metadata:keywords', [search])
       })
     }
 
-    const result = await resultQuery
-    return result[0].count
+    const result = await builder
+    return result.length
   }
 
   static async getLibrary (
@@ -246,6 +241,7 @@ class Library {
           builder.where(nestedBuilder => {
             nestedBuilder
               .where('Publication.name', 'ilike', `%${search}%`)
+              .orWhere('Attribution.normalizedName', 'ilike', `%${search}%`)
               .orWhere('Publication.abstract', 'ilike', `%${search}%`)
               .orWhere('Publication.description', 'ilike', `%${search}%`)
               .orWhereJsonSupersetOf('Publication.metadata:keywords', [search])

--- a/routes/library-get.js
+++ b/routes/library-get.js
@@ -80,11 +80,16 @@ module.exports = app => {
    *         schema:
    *           type: string
    *       - in: query
+   *         name: search
+   *         schema:
+   *            type: string
+   *         description: searches in title, description, abstract, keywords and attributions
+   *       - in: query
    *         name: orderBy
    *         schema:
    *           type: string
-   *           enum: ['title', 'datePublished']
-   *         description: used to order either alphabetically by title or by date of creation of the publication object (most recent first)
+   *           enum: ['title', 'datePublished', 'type']
+   *         description: used to order either alphabetically by title or type or by date of creation of the publication object (most recent first)
    *       - in: query
    *         name: reverse
    *         schema:

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -15,6 +15,7 @@ const libraryFilterCombinedTests = require('./library/library-filter-combined.te
 const libraryOrderByDefaultTests = require('./library/library-orderBy-default.test')
 const libraryOrderByTitleTests = require('./library/library-orderBy-title.test')
 const libraryOrderByDatePublishedTests = require('./library/library-orderBy-datePublished.test')
+const libraryOrderByTypeTest = require('./library/library-orderBy-type.test')
 
 const noteGetTests = require('./note/note-get.test')
 const notePostTests = require('./note/note-post.test')
@@ -96,6 +97,7 @@ const allTests = async () => {
     await libraryFilterCombinedTests(app)
     await libraryOrderByDefaultTests(app)
     await libraryOrderByTitleTests(app)
+    await libraryOrderByTypeTest(app)
     await libraryOrderByDatePublishedTests(app)
     await libraryFilterKeyword(app)
     await libraryFilterSearch(app)

--- a/tests/integration/library/library-filter-combined.test.js
+++ b/tests/integration/library/library-filter-combined.test.js
@@ -161,7 +161,7 @@ const test = async () => {
   })
   await createPublicationSimplified({
     name: 'new book 5',
-    author: 'Jane Smith',
+    author: 'Jane Smith testing',
     editor: 'John Doe',
     inLanguage: ['en']
   })

--- a/tests/integration/library/library-filter-search.test.js
+++ b/tests/integration/library/library-filter-search.test.js
@@ -38,7 +38,8 @@ const test = async () => {
   await createPublicationSimplified({ name: 'Publication 8' })
   await createPublicationSimplified({ name: 'Publication 9' })
   await createPublicationSimplified({
-    name: 'Publication 10'
+    name: 'Publication 10',
+    author: 'super dude!'
   })
   await createPublicationSimplified({
     name: 'Publication 11'
@@ -54,7 +55,7 @@ const test = async () => {
   await createPublicationSimplified({ name: 'Super great book!' })
 
   await tap.test(
-    'Filter Library by searching through title, abstract, keywords and desription',
+    'Filter Library by searching through title, abstract, keywords, author and desription',
     async () => {
       const res = await request(app)
         .get(`/library?search=super`)
@@ -64,9 +65,9 @@ const test = async () => {
 
       await tap.equal(res.status, 200)
       await tap.ok(res.body)
-      await tap.equal(res.body.totalItems, 5)
+      await tap.equal(res.body.totalItems, 6)
       await tap.ok(res.body.items)
-      await tap.equal(res.body.items.length, 5)
+      await tap.equal(res.body.items.length, 6)
     }
   )
 
@@ -88,6 +89,14 @@ const test = async () => {
 
     await tap.equal(res3.body.totalItems, 14)
     await tap.equal(res3.body.items.length, 11)
+
+    const res4 = await request(app)
+      .get(`/library?search=publication&limit=50`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    console.log(res4.body.items.length)
   })
 
   await tap.test(

--- a/tests/integration/library/library-filter-search.test.js
+++ b/tests/integration/library/library-filter-search.test.js
@@ -89,14 +89,6 @@ const test = async () => {
 
     await tap.equal(res3.body.totalItems, 14)
     await tap.equal(res3.body.items.length, 11)
-
-    const res4 = await request(app)
-      .get(`/library?search=publication&limit=50`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type('application/ld+json')
-
-    console.log(res4.body.items.length)
   })
 
   await tap.test(

--- a/tests/integration/library/library-orderBy-type.test.js
+++ b/tests/integration/library/library-orderBy-type.test.js
@@ -1,0 +1,136 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication
+} = require('../../utils/testUtils')
+const app = require('../../../server').app
+const { urlToId } = require('../../../utils/utils')
+
+const test = async () => {
+  const token = getToken()
+  const readerCompleteUrl = await createUser(app, token)
+  const readerId = urlToId(readerCompleteUrl)
+
+  const createPublicationSimplified = async object => {
+    return await createPublication(readerId, object)
+  }
+
+  await createPublicationSimplified({
+    name: 'Publication 1',
+    type: 'Article',
+    author: 'anonymous'
+  })
+  await createPublicationSimplified({
+    name: 'Publication 2',
+    type: 'Manuscript'
+  })
+  await createPublicationSimplified({
+    name: 'Publication 3',
+    type: 'Book',
+    illustrator: 'anonymous'
+  })
+
+  await tap.test('Order Library by type', async () => {
+    const res = await request(app)
+      .get(`/library?orderBy=type`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.body.items[0].name, 'Publication 1')
+    await tap.equal(res.body.items[1].name, 'Publication 3')
+    await tap.equal(res.body.items[2].name, 'Publication 2')
+  })
+
+  await tap.test('Order Library by type, reversed', async () => {
+    const res = await request(app)
+      .get(`/library?orderBy=type&reverse=true`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.body.items[0].name, 'Publication 2')
+    await tap.equal(res.body.items[1].name, 'Publication 3')
+    await tap.equal(res.body.items[2].name, 'Publication 1')
+  })
+
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({
+    name: 'ZZZ',
+    type: 'Manuscript',
+    author: 'anonymous'
+  })
+  await createPublicationSimplified({ name: 'zzz', type: 'Article' })
+
+  await tap.test('Order Library by type with filter by title', async () => {
+    const res1 = await request(app)
+      .get(`/library?orderBy=type&title=z`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res1.body.items.length, 3)
+    await tap.equal(res1.body.items[0].name, 'zzz')
+    await tap.equal(res1.body.items[1].name, 'zbc')
+    await tap.equal(res1.body.items[2].name, 'ZZZ')
+  })
+
+  await tap.test('Order Library by type with filter by author', async () => {
+    const res2 = await request(app)
+      .get(`/library?orderBy=type&author=anonymous`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.body.items.length, 2)
+
+    await tap.equal(res2.body.items[0].name, 'Publication 1')
+    await tap.equal(res2.body.items[1].name, 'ZZZ')
+  })
+
+  await tap.test(
+    'Order Library by type with filter by attribution',
+    async () => {
+      const res3 = await request(app)
+        .get(`/library?orderBy=type&attribution=anonymous`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res3.body.items.length, 3)
+
+      await tap.equal(res3.body.items[0].name, 'Publication 1')
+      await tap.equal(res3.body.items[1].name, 'Publication 3')
+      await tap.equal(res3.body.items[2].name, 'ZZZ')
+    }
+  )
+
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+  await createPublicationSimplified({ name: 'zbc', type: 'Book' })
+
+  await tap.test('Order Library by type with pagination', async () => {
+    const res = await request(app)
+      .get(`/library?orderBy=type&limit=16`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.body.items.length, 16)
+    await tap.equal(res.body.items[0].type, 'Article')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test


### PR DESCRIPTION
new query:
GET /library?orderBy=type    or /library?orderBy=type&reverse=true

also, the search query will now search through:
- name
- description
- abstract
- keywords
- NEW: attributions (all of them)