### PR TITLE
Post, Delete, Put Outlines, add / remove notes from outline

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -231,6 +231,10 @@ class Note extends BaseModel {
         throw new Error('no publication')
       } else if (err.constraint === 'note_contextid_foreign') {
         throw new Error('no context')
+      } else if (err.constraint === 'note_previous_foreign') {
+        throw new Error('no previous')
+      } else if (err.constraint === 'note_next_foreign') {
+        throw new Error('no next')
       }
       throw err
     }

--- a/models/NoteContext.js
+++ b/models/NoteContext.js
@@ -90,6 +90,13 @@ class NoteContext extends BaseModel {
     return noteContext
   }
 
+  static async checkIfExists (id /*: string */) /*: Promise<boolean> */ {
+    const noteContext = await NoteContext.query().findById(id)
+    if (!noteContext || noteContext.deleted) {
+      return false
+    } else return true
+  }
+
   static async update (object /*: any */) /*: Promise<any> */ {
     const props = _.pick(object, [
       'readerId',

--- a/routes/outline-addNote.js
+++ b/routes/outline-addNote.js
@@ -220,7 +220,6 @@ module.exports = function (app) {
             )
           }
         }
-
         // if createdNote.previous
         if (createdNote.previous) {
           const previousNote = await Note.byId(createdNote.previous)

--- a/routes/outline-addNote.js
+++ b/routes/outline-addNote.js
@@ -65,13 +65,10 @@ module.exports = function (app) {
         }
         if (!checkOwnership(reader.id, req.params.id)) {
           return next(
-            boom.forbidden(
-              `Access to NoteContext ${req.params.id} disallowed`,
-              {
-                requestUrl: req.originalUrl,
-                requestBody: req.body
-              }
-            )
+            boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
           )
         }
 

--- a/routes/outline-addNote.js
+++ b/routes/outline-addNote.js
@@ -1,0 +1,248 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { checkOwnership, urlToId } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines/:id/notes:
+   *   post:
+   *     tags:
+   *       - outlines
+   *     description: Add a Note to a NoteContext
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: query
+   *         name: source
+   *         schema:
+   *           type: string
+   *         description: id of the note to be copied. When source is used, no body is needed.
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/note'
+   *     responses:
+   *       201:
+   *         description: Successfully added Note to Context
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/note'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: Publication (from note.publicationId) or Document (from note.documentUrl) not found. Or Context not found
+   */
+  app.use('/', router)
+  router.route('/outlines/:id/notes').post(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(
+              `Access to NoteContext ${req.params.id} disallowed`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
+        }
+
+        // copy
+        if (req.query.source) {
+          if (!checkOwnership(reader.id, req.query.source)) {
+            return next(
+              boom.forbidden(`Access to Note ${req.query.source} disallowed`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          let copiedNote
+          try {
+            copiedNote = await Note.copyToContext(
+              req.query.source,
+              req.params.id
+            )
+          } catch (err) {
+            if (err.message === 'no context') {
+              return next(
+                boom.notFound(
+                  `Add Note to Outline Error: No Outline found with id: ${
+                    req.params.id
+                  }`,
+                  {
+                    requestUrl: req.originalUrl
+                  }
+                )
+              )
+            } else if (err.message === 'no note') {
+              return next(
+                boom.notFound(
+                  `Add Note to Outline Error: No Note found with id: ${
+                    req.query.source
+                  }`,
+                  {
+                    requestUrl: req.originalUrl
+                  }
+                )
+              )
+            }
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.setHeader('Location', copiedNote.id)
+          res.status(201).end(JSON.stringify(copiedNote.toJSON()))
+        }
+
+        // create new note
+        const body = req.body
+        if (typeof body !== 'object' || _.isEmpty(body)) {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        body.contextId = req.params.id
+
+        let createdNote
+        try {
+          createdNote = await Note.createNote(reader, body)
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Add Note to Outline: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else if (err.message === 'no document') {
+            return next(
+              boom.notFound(
+                `Add Note to Outline Error: No Document found with documentUrl: ${
+                  body.documentUrl
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          } else if (err.message === 'no publication') {
+            return next(
+              boom.notFound(
+                `Add Note to Outline Error: No Publication found with id: ${
+                  body.publicationId
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          } else if (err.message === 'no context') {
+            return next(
+              boom.notFound(
+                `Add Note to Outline Error: No Outline found with id: ${
+                  req.params.id
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          } else if (err.message === 'no previous') {
+            return next(
+              boom.notFound(
+                `Add Note to Outline Error: No Note found with for previous property: ${
+                  req.body.previous
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          } else if (err.message === 'no next') {
+            return next(
+              boom.notFound(
+                `Add Note to Outline Error: No Note found with for next property: ${
+                  req.body.next
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          } else {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        // if createdNote.previous
+        if (createdNote.previous) {
+          const previousNote = await Note.byId(createdNote.previous)
+          await Note.update(
+            Object.assign(previousNote, { next: urlToId(createdNote.id) })
+          )
+        }
+
+        // if createdNote.next
+        if (createdNote.next) {
+          const nextNote = await Note.byId(createdNote.next)
+          await Note.update(
+            Object.assign(nextNote, { previous: urlToId(createdNote.id) })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.setHeader('Location', createdNote.id)
+        res.status(201).end(JSON.stringify(createdNote.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/outline-delete.js
+++ b/routes/outline-delete.js
@@ -1,0 +1,87 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteContext } = require('../models/NoteContext')
+const { checkOwnership } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines/:id:
+   *   delete:
+   *     tags:
+   *       - outlines
+   *     description: Delete an outline
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/outline'
+   *     responses:
+   *       204:
+   *         description: Successfully deleted Outline
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no Outline found with id
+   */
+  app.use('/', router)
+  router.route('/outlines/:id').delete(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        let deleted
+        try {
+          deleted = await NoteContext.delete(req.params.id)
+        } catch (err) {
+          return next(
+            boom.badRequest(err.message, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!deleted) {
+          return next(
+            boom.notFound(`No Outline found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(204).end()
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/outline-deleteNote.js
+++ b/routes/outline-deleteNote.js
@@ -1,0 +1,142 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { checkOwnership, urlToId } = require('../utils/utils')
+const { NoteContext } = require('../models/NoteContext')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines/:id/notes/:noteId:
+   *   delete:
+   *     tags:
+   *       - outlines
+   *     description: Add a Note to a NoteContext
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: path
+   *         name: noteId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     responses:
+   *       204:
+   *         description: Successfully deleted Note in Outline
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: 'Outline or Note not found'
+   */
+  app.use('/', router)
+  router
+    .route('/outlines/:id/notes/:noteId')
+    .delete(jwtAuth, function (req, res, next) {
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader) {
+            return next(
+              boom.unauthorized(`No user found for this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+          if (!checkOwnership(reader.id, req.params.id)) {
+            return next(
+              boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+          if (!checkOwnership(reader.id, req.params.noteId)) {
+            return next(
+              boom.forbidden(`Access to Note ${req.params.noteId} disallowed`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          const outlineExists = await NoteContext.checkIfExists(req.params.id)
+          if (!outlineExists) {
+            return next(
+              boom.notFound(`No Outline found with id ${req.params.id}`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          // get Note
+          const note = await Note.byId(req.params.noteId)
+          if (!note || note.deleted) {
+            return next(
+              boom.notFound(`No Note found with id: ${req.params.noteId}`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+          if (note.contextId !== req.params.id) {
+            return next(
+              boom.badRequest(
+                `Note ${req.params.noteId} does not belong to outline ${
+                  req.params.id
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          }
+
+          // linked list adjustments
+          if (note.previous) {
+            const previousNote = await Note.byId(note.previous)
+            await Note.update(
+              Object.assign(previousNote, { next: urlToId(note.next) })
+            )
+          }
+          if (note.next) {
+            const nextNote = await Note.byId(note.next)
+            await Note.update(
+              Object.assign(nextNote, { previous: urlToId(note.previous) })
+            )
+          }
+
+          let deleted
+          try {
+            deleted = await Note.delete(req.params.noteId)
+          } catch (err) {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.status(204).end()
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/routes/outline-post.js
+++ b/routes/outline-post.js
@@ -1,0 +1,96 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { NoteContext } = require('../models/NoteContext')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines:
+   *   post:
+   *     tags:
+   *       - outlines
+   *     description: Create an Outline
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/outline'
+   *     responses:
+   *       201:
+   *         description: Successfully created Outline
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/outline'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   */
+  app.use('/', router)
+  router.route('/outlines').post(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object') {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        body.type = 'outline'
+
+        let createdOutline
+        try {
+          createdOutline = await NoteContext.createNoteContext(body, reader.id)
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Create Outline: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(201).end(JSON.stringify(createdOutline.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/outline-put.js
+++ b/routes/outline-put.js
@@ -62,19 +62,20 @@ module.exports = function (app) {
             })
           )
         }
-        if (body.type !== 'outline') {
+
+        // check owndership of Outline
+        if (!checkOwnership(reader.id, req.params.id)) {
           return next(
-            boom.badRequest(`Outline type must be 'outline'`, {
+            boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })
           )
         }
 
-        // check owndership of Outline
-        if (!checkOwnership(reader.id, req.params.id)) {
+        if (body.type !== 'outline') {
           return next(
-            boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+            boom.badRequest(`Outline type must be 'outline'`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/outline-put.js
+++ b/routes/outline-put.js
@@ -1,0 +1,128 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { urlToId, checkOwnership } = require('../utils/utils')
+const { NoteContext } = require('../models/NoteContext')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines/:id:
+   *   put:
+   *     tags:
+   *       - outlines
+   *     description: Update a outline
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/outline'
+   *     responses:
+   *       200:
+   *         description: Successfully updated Outline
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/outline'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: no Outline found with id {id}
+   */
+  app.use('/', router)
+  router.route('/outlines/:id').put(jwtAuth, function (req, res, next) {
+    Reader.byAuthId(req.user)
+      .then(async reader => {
+        if (!reader) {
+          return next(
+            boom.unauthorized(`No user found for this token`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        const body = req.body
+        if (typeof body !== 'object') {
+          return next(
+            boom.badRequest('Body must be a JSON object', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (body.type !== 'outline') {
+          return next(
+            boom.badRequest(`Outline type must be 'outline'`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        // check owndership of Outline
+        if (!checkOwnership(reader.id, req.params.id)) {
+          return next(
+            boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        body.id = req.params.id
+        body.readerId = urlToId(reader.id)
+
+        let updatedOutline
+        try {
+          updatedOutline = await NoteContext.update(body)
+        } catch (err) {
+          if (err instanceof ValidationError) {
+            return next(
+              boom.badRequest(
+                `Validation Error on Update Outline: ${err.message}`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body,
+                  validation: err.data
+                }
+              )
+            )
+          } else {
+            return next(
+              boom.badRequest(err.message, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+        }
+
+        if (!updatedOutline) {
+          return next(
+            boom.notFound(`No Outline found with id ${req.params.id}`, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(200).end(JSON.stringify(updatedOutline.toJSON()))
+      })
+      .catch(err => {
+        next(err)
+      })
+  })
+}

--- a/routes/swagger-definitions/noteContext-def.js
+++ b/routes/swagger-definitions/noteContext-def.js
@@ -1,7 +1,7 @@
 /**
  * @swagger
  * definition:
- *   noteContext:
+ *   noteContextGeneral:
  *     properties:
  *       id:
  *         type: string
@@ -11,8 +11,6 @@
  *         type: string
  *         format: url
  *         readOnly: true
- *       type:
- *         type: string
  *       name:
  *         type: string
  *       description:
@@ -32,5 +30,19 @@
  *     - type
  *     - published
  *     - readerId
+ *
+ *   noteContext:
+ *     allOf:
+ *       - $ref: '#/definitions/noteContextGeneral'
+ *     properties:
+ *       type:
+ *         type: string
+ *
+ *   outline:
+ *     allOf:
+ *       - $ref: '#/definitions/noteContextGeneral'
+ *     type:
+ *       type: string
+ *       enum: ['outline']
  *
  */

--- a/server.js
+++ b/server.js
@@ -71,6 +71,7 @@ const noteContextGetRoute = require('./routes/noteContext-get') // GET /noteCont
 
 // outlines
 const outlineGetRoute = require('./routes/outline-get') // GET /outlines/:id
+const outlinePostRoute = require('./routes/outline-post') // POST /outlines
 
 const setupKnex = async skip_migrate => {
   let config
@@ -249,6 +250,7 @@ noteContextDeleteRoute(app)
 noteContextAddNoteRoute(app)
 noteContextGetRoute(app)
 outlineGetRoute(app)
+outlinePostRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -74,6 +74,7 @@ const outlineGetRoute = require('./routes/outline-get') // GET /outlines/:id
 const outlinePostRoute = require('./routes/outline-post') // POST /outlines
 const outlineDeleteRoute = require('./routes/outline-delete') // DELETE /outlines/:id
 const outlinePutRoute = require('./routes/outline-put') // PUT /outlines:id
+const outlineAddNoteRoute = require('./routes/outline-addNote') // POST /outlines/:id/notes
 
 const setupKnex = async skip_migrate => {
   let config
@@ -255,6 +256,7 @@ outlineGetRoute(app)
 outlinePostRoute(app)
 outlineDeleteRoute(app)
 outlinePutRoute(app)
+outlineAddNoteRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -72,6 +72,7 @@ const noteContextGetRoute = require('./routes/noteContext-get') // GET /noteCont
 // outlines
 const outlineGetRoute = require('./routes/outline-get') // GET /outlines/:id
 const outlinePostRoute = require('./routes/outline-post') // POST /outlines
+const outlineDeleteRoute = require('./routes/outline-delete') // DELETE /outlines/:id
 
 const setupKnex = async skip_migrate => {
   let config
@@ -251,6 +252,7 @@ noteContextAddNoteRoute(app)
 noteContextGetRoute(app)
 outlineGetRoute(app)
 outlinePostRoute(app)
+outlineDeleteRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -75,6 +75,7 @@ const outlinePostRoute = require('./routes/outline-post') // POST /outlines
 const outlineDeleteRoute = require('./routes/outline-delete') // DELETE /outlines/:id
 const outlinePutRoute = require('./routes/outline-put') // PUT /outlines:id
 const outlineAddNoteRoute = require('./routes/outline-addNote') // POST /outlines/:id/notes
+const outlineDeleteNoteRoute = require('./routes/outline-deleteNote') // DELETE /outlines/:id/notes/:noteId
 
 const setupKnex = async skip_migrate => {
   let config
@@ -257,6 +258,7 @@ outlinePostRoute(app)
 outlineDeleteRoute(app)
 outlinePutRoute(app)
 outlineAddNoteRoute(app)
+outlineDeleteNoteRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -73,6 +73,7 @@ const noteContextGetRoute = require('./routes/noteContext-get') // GET /noteCont
 const outlineGetRoute = require('./routes/outline-get') // GET /outlines/:id
 const outlinePostRoute = require('./routes/outline-post') // POST /outlines
 const outlineDeleteRoute = require('./routes/outline-delete') // DELETE /outlines/:id
+const outlinePutRoute = require('./routes/outline-put') // PUT /outlines:id
 
 const setupKnex = async skip_migrate => {
   let config
@@ -253,6 +254,7 @@ noteContextGetRoute(app)
 outlineGetRoute(app)
 outlinePostRoute(app)
 outlineDeleteRoute(app)
+outlinePutRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -540,30 +540,27 @@ const test = async app => {
 
   // ------------------------------------- OUTLINE -----------------------
 
-  // await tap.test(
-  //   'Try to update an outline belonging to another user',
-  //   async () => {
-  //     const res = await request(app)
-  //       .put(`/outlines/${outline1.shortId}`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token2}`)
-  //       .type('application/ld+json')
-  //       .send(JSON.stringify({ type: 'test2' }))
+  await tap.test(
+    'Try to update an outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .put(`/outlines/${outline1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ type: 'outline' }))
 
-  //     await tap.equal(res.statusCode, 403)
-  //     const error = JSON.parse(res.text)
-  //     await tap.equal(error.statusCode, 403)
-  //     await tap.equal(error.error, 'Forbidden')
-  //     await tap.equal(
-  //       error.message,
-  //       `Access to Outline ${outline1.shortId} disallowed`
-  //     )
-  //     await tap.equal(
-  //       error.details.requestUrl,
-  //       `/outlines/${outline1.shortId}`
-  //     )
-  //   }
-  // )
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline1.shortId}`)
+    }
+  )
 
   await tap.test(
     'Try to delete an outline belonging to another user',

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -76,6 +76,10 @@ const test = async app => {
   const noteContext1 = await createNoteContext(app, token, { type: 'test' })
   const noteContext2 = await createNoteContext(app, token2, { type: 'test' })
 
+  // outlines
+  const outline1 = await createNoteContext(app, token, { type: 'outline' })
+  const outline2 = await createNoteContext(app, token2, { type: 'outline' })
+
   // ------------------------ PUBLICATION -------------------------------------
   await tap.test(
     'Try to get publication belonging to another reader',
@@ -531,6 +535,121 @@ const test = async app => {
         error.details.requestUrl,
         `/noteContexts/${noteContext1.shortId}`
       )
+    }
+  )
+
+  // ------------------------------------- OUTLINE -----------------------
+
+  // await tap.test(
+  //   'Try to update an outline belonging to another user',
+  //   async () => {
+  //     const res = await request(app)
+  //       .put(`/outlines/${outline1.shortId}`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token2}`)
+  //       .type('application/ld+json')
+  //       .send(JSON.stringify({ type: 'test2' }))
+
+  //     await tap.equal(res.statusCode, 403)
+  //     const error = JSON.parse(res.text)
+  //     await tap.equal(error.statusCode, 403)
+  //     await tap.equal(error.error, 'Forbidden')
+  //     await tap.equal(
+  //       error.message,
+  //       `Access to Outline ${outline1.shortId} disallowed`
+  //     )
+  //     await tap.equal(
+  //       error.details.requestUrl,
+  //       `/outlines/${outline1.shortId}`
+  //     )
+  //   }
+  // )
+
+  await tap.test(
+    'Try to delete an outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outline1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline1.shortId}`)
+    }
+  )
+
+  // await tap.test(
+  //   'Try to add a note to an outline belonging to another user',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`/outlines/${outline1.shortId}/notes`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token2}`)
+  //       .type('application/ld+json')
+  //       .send(JSON.stringify({ body: { motivation: 'test' } }))
+
+  //     await tap.equal(res.statusCode, 403)
+  //     const error = JSON.parse(res.text)
+  //     await tap.equal(error.statusCode, 403)
+  //     await tap.equal(error.error, 'Forbidden')
+  //     await tap.equal(
+  //       error.message,
+  //       `Access to Outline ${outline1.shortId} disallowed`
+  //     )
+  //     await tap.equal(
+  //       error.details.requestUrl,
+  //       `/outlines/${outline1.shortId}/notes`
+  //     )
+  //   }
+  // )
+
+  // await tap.test(
+  //   'Try to copy a note belonging to another user to an outline',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`/outlines/${outline2.shortId}/notes?source=${noteId}`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token2}`)
+  //       .type('application/ld+json')
+
+  //     await tap.equal(res.statusCode, 403)
+  //     const error = JSON.parse(res.text)
+  //     await tap.equal(error.statusCode, 403)
+  //     await tap.equal(error.error, 'Forbidden')
+  //     await tap.equal(error.message, `Access to Note ${noteId} disallowed`)
+  //     await tap.equal(
+  //       error.details.requestUrl,
+  //       `/outlines/${outline2.shortId}/notes?source=${noteId}`
+  //     )
+  //   }
+  // )
+
+  await tap.test(
+    'Try to get an Outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outline1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline1.shortId}`)
     }
   )
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -583,51 +583,96 @@ const test = async app => {
     }
   )
 
-  // await tap.test(
-  //   'Try to add a note to an outline belonging to another user',
-  //   async () => {
-  //     const res = await request(app)
-  //       .post(`/outlines/${outline1.shortId}/notes`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token2}`)
-  //       .type('application/ld+json')
-  //       .send(JSON.stringify({ body: { motivation: 'test' } }))
+  await tap.test(
+    'Try to add a note to an outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline1.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ body: { motivation: 'test' } }))
 
-  //     await tap.equal(res.statusCode, 403)
-  //     const error = JSON.parse(res.text)
-  //     await tap.equal(error.statusCode, 403)
-  //     await tap.equal(error.error, 'Forbidden')
-  //     await tap.equal(
-  //       error.message,
-  //       `Access to Outline ${outline1.shortId} disallowed`
-  //     )
-  //     await tap.equal(
-  //       error.details.requestUrl,
-  //       `/outlines/${outline1.shortId}/notes`
-  //     )
-  //   }
-  // )
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline1.shortId}/notes`
+      )
+    }
+  )
 
-  // await tap.test(
-  //   'Try to copy a note belonging to another user to an outline',
-  //   async () => {
-  //     const res = await request(app)
-  //       .post(`/outlines/${outline2.shortId}/notes?source=${noteId}`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token2}`)
-  //       .type('application/ld+json')
+  await tap.test(
+    'Try to copy a note belonging to another user to an outline',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline2.shortId}/notes?source=${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
 
-  //     await tap.equal(res.statusCode, 403)
-  //     const error = JSON.parse(res.text)
-  //     await tap.equal(error.statusCode, 403)
-  //     await tap.equal(error.error, 'Forbidden')
-  //     await tap.equal(error.message, `Access to Note ${noteId} disallowed`)
-  //     await tap.equal(
-  //       error.details.requestUrl,
-  //       `/outlines/${outline2.shortId}/notes?source=${noteId}`
-  //     )
-  //   }
-  // )
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.message, `Access to Note ${noteId} disallowed`)
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline2.shortId}/notes?source=${noteId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to delete a note from an outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outline1.shortId}/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline1.shortId}/notes/${note2.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to delete a note belonging to another user from an outline',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outline2.shortId}/notes/${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.message, `Access to Note ${noteId} disallowed`)
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline2.shortId}/notes/${noteId}`
+      )
+    }
+  )
 
   await tap.test(
     'Try to get an Outline belonging to another user',

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -336,13 +336,13 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
-  // await tap.test('PUT Outline without authentication', async () => {
-  //   const res = await request(app)
-  //     .put('/outlines/123')
-  //     .set('Host', 'reader-api.test')
-  //     .type('application/ld+json')
-  //   await tap.equal(res.statusCode, 401)
-  // })
+  await tap.test('PUT Outline without authentication', async () => {
+    const res = await request(app)
+      .put('/outlines/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
 
   await tap.test('Delete Outline without authentication', async () => {
     const res = await request(app)

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -352,16 +352,27 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
-  // await tap.test(
-  //   'Add a Note to an Outline without authentication',
-  //   async () => {
-  //     const res = await request(app)
-  //       .post('/outlines/123/notes')
-  //       .set('Host', 'reader-api.test')
-  //       .type('application/ld+json')
-  //     await tap.equal(res.statusCode, 401)
-  //   }
-  // )
+  await tap.test(
+    'Add a Note to an Outline without authentication',
+    async () => {
+      const res = await request(app)
+        .post('/outlines/123/notes')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
+
+  await tap.test(
+    'Delete a Note from an Outline without authentication',
+    async () => {
+      const res = await request(app)
+        .delete('/outlines/123/notes/123')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
 
   await tap.test('Get a Outline without authentication', async () => {
     const res = await request(app)

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -326,6 +326,51 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  // -------------------------------------OUTLINE --------------------------------
+
+  await tap.test('POST Outline without authentication', async () => {
+    const res = await request(app)
+      .post('/outlines')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
+  // await tap.test('PUT Outline without authentication', async () => {
+  //   const res = await request(app)
+  //     .put('/outlines/123')
+  //     .set('Host', 'reader-api.test')
+  //     .type('application/ld+json')
+  //   await tap.equal(res.statusCode, 401)
+  // })
+
+  await tap.test('Delete Outline without authentication', async () => {
+    const res = await request(app)
+      .delete('/outlines/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
+  // await tap.test(
+  //   'Add a Note to an Outline without authentication',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post('/outlines/123/notes')
+  //       .set('Host', 'reader-api.test')
+  //       .type('application/ld+json')
+  //     await tap.equal(res.statusCode, 401)
+  //   }
+  // )
+
+  await tap.test('Get a Outline without authentication', async () => {
+    const res = await request(app)
+      .get('/outlines/123')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -174,11 +174,11 @@ const allTests = async () => {
   }
 
   if (!test || test === 'outline') {
-    // await outlineGetTests(app)
-    // await outlinePostTests(app)
-    // await outlineDeleteTests(app)
-    // await outlinePutTests(app)
-    // await outlineAddNoteTests(app)
+    await outlineGetTests(app)
+    await outlinePostTests(app)
+    await outlineDeleteTests(app)
+    await outlinePutTests(app)
+    await outlineAddNoteTests(app)
     await outlineDeleteNoteTests(app)
   }
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -70,6 +70,7 @@ const outlinePostTests = require('./outline/outline-post.test')
 const outlineDeleteTests = require('./outline/outlline-delete.test')
 const outlinePutTests = require('./outline/outline-put.test')
 const outlineAddNoteTests = require('./outline/outline-addNote.test')
+const outlineDeleteNoteTests = require('./outline/outline-deleteNote.test')
 
 const app = require('../../server').app
 
@@ -173,11 +174,12 @@ const allTests = async () => {
   }
 
   if (!test || test === 'outline') {
-    await outlineGetTests(app)
-    await outlinePostTests(app)
-    await outlineDeleteTests(app)
-    await outlinePutTests(app)
-    await outlineAddNoteTests(app)
+    // await outlineGetTests(app)
+    // await outlinePostTests(app)
+    // await outlineDeleteTests(app)
+    // await outlinePutTests(app)
+    // await outlineAddNoteTests(app)
+    await outlineDeleteNoteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -69,6 +69,7 @@ const outlineGetTests = require('./outline/outline-get.test')
 const outlinePostTests = require('./outline/outline-post.test')
 const outlineDeleteTests = require('./outline/outlline-delete.test')
 const outlinePutTests = require('./outline/outline-put.test')
+const outlineAddNoteTests = require('./outline/outline-addNote.test')
 
 const app = require('../../server').app
 
@@ -176,6 +177,7 @@ const allTests = async () => {
     await outlinePostTests(app)
     await outlineDeleteTests(app)
     await outlinePutTests(app)
+    await outlineAddNoteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -68,6 +68,7 @@ const noteContextGetTests = require('./noteContext/noteContext-get.test')
 const outlineGetTests = require('./outline/outline-get.test')
 const outlinePostTests = require('./outline/outline-post.test')
 const outlineDeleteTests = require('./outline/outlline-delete.test')
+const outlinePutTests = require('./outline/outline-put.test')
 
 const app = require('../../server').app
 
@@ -174,6 +175,7 @@ const allTests = async () => {
     await outlineGetTests(app)
     await outlinePostTests(app)
     await outlineDeleteTests(app)
+    await outlinePutTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -67,6 +67,7 @@ const noteContextGetTests = require('./noteContext/noteContext-get.test')
 
 const outlineGetTests = require('./outline/outline-get.test')
 const outlinePostTests = require('./outline/outline-post.test')
+const outlineDeleteTests = require('./outline/outlline-delete.test')
 
 const app = require('../../server').app
 
@@ -172,6 +173,7 @@ const allTests = async () => {
   if (!test || test === 'outline') {
     await outlineGetTests(app)
     await outlinePostTests(app)
+    await outlineDeleteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -66,6 +66,7 @@ const noteContextAddNoteTests = require('./noteContext/noteContext-addNote.test'
 const noteContextGetTests = require('./noteContext/noteContext-get.test')
 
 const outlineGetTests = require('./outline/outline-get.test')
+const outlinePostTests = require('./outline/outline-post.test')
 
 const app = require('../../server').app
 
@@ -170,6 +171,7 @@ const allTests = async () => {
 
   if (!test || test === 'outline') {
     await outlineGetTests(app)
+    await outlinePostTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/outline/outline-addNote.test.js
+++ b/tests/integration/outline/outline-addNote.test.js
@@ -1,0 +1,547 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createDocument,
+  createNoteContext,
+  createNote
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+const _ = require('lodash')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const publication = await createPublication(readerId)
+  const publicationId = urlToId(publication.id)
+  const publicationUrl = publication.id
+
+  const publication2 = await createPublication(readerId)
+  const publicationId2 = urlToId(publication2.id)
+
+  const createdDocument = await createDocument(readerId, publicationUrl)
+
+  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+
+  const outline = await createNoteContext(app, token, {
+    name: 'my outline',
+    type: 'outline'
+  })
+  const outlineId = outline.shortId
+
+  const note = await createNote(app, token, readerId, {
+    body: { content: 'to be copied', motivation: 'test' }
+  })
+  const noteId = urlToId(note.id)
+  let noteCopy
+  let note1, note2, note3, note4, note5, note6
+
+  await tap.test('Add to outline a Note with a single body', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, outlineId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+  })
+
+  await tap.test('Create Note with two bodies', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: [
+            {
+              content: 'this is the content of the note',
+              motivation: 'test'
+            },
+            {
+              motivation: 'test'
+            }
+          ],
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, outlineId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.equal(body.body.length, 2)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+    await tap.notOk(body.body[1].content)
+    await tap.equal(body.body[1].motivation, 'test')
+  })
+
+  await tap.test('Create Note with documentUrl and publicationId', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          publicationId,
+          documentUrl
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, outlineId)
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+    await tap.equal(body.documentUrl, documentUrl)
+    await tap.equal(urlToId(body.publicationId), publicationId)
+  })
+
+  await tap.test('Notes should show up when fetching the outline', async () => {
+    const res = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.type, 'outline')
+    // notes & noteRelations
+    await tap.equal(body.notes.length, 3)
+    note1 = body.notes[0]
+    note2 = body.notes[1]
+    note3 = body.notes[2]
+  })
+
+  // 1 - 4
+  await tap.test('Add a note with a previous property', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          previous: note1.shortId
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.previous, note1.shortId)
+    note4 = body
+
+    // previous note should be updated too
+    const resPrevious = await request(app)
+      .get(`/notes/${note1.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resPrevious.body.next, note4.shortId)
+  })
+
+  // 5 - 1 - 4
+  await tap.test('Add a note with a next property', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          next: note1.shortId
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.next, note1.shortId)
+    note5 = body
+
+    // next note should be updated too
+    const resNext = await request(app)
+      .get(`/notes/${note1.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resNext.body.previous, note5.shortId)
+  })
+
+  // 5 - 6 - 1 - 4
+  await tap.test(
+    'Add a note with both a previous and a next property',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: {
+              content: 'this is the content of the note',
+              motivation: 'test'
+            },
+            previous: note5.shortId,
+            next: note1.shortId
+          })
+        )
+      await tap.equal(res.status, 201)
+      const body = res.body
+      await tap.ok(body.id)
+      await tap.equal(body.next, note1.shortId)
+      await tap.equal(body.previous, note5.shortId)
+      note6 = body
+
+      // next and previous notes should be updated too
+      const resNext = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resNext.body.previous, note6.shortId)
+
+      const resPrevious = await request(app)
+        .get(`/notes/${note5.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resPrevious.body.next, note6.shortId)
+    }
+  )
+
+  await tap.test(
+    'outline should reflect the order created in previous tests',
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outlineId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.ok(body.id)
+      await tap.equal(body.type, 'outline')
+      // notes & noteRelations
+      await tap.equal(body.notes.length, 6)
+      const indexOfFirst = _.findIndex(body.notes, { shortId: note5.shortId })
+      // 5 - 6 - 1 - 4
+      await tap.equal(body.notes[indexOfFirst + 1].shortId, note6.shortId)
+      await tap.equal(body.notes[indexOfFirst + 2].shortId, note1.shortId)
+      await tap.equal(body.notes[indexOfFirst + 3].shortId, note4.shortId)
+    }
+  )
+
+  // ------------------------------------- VALIDATION ERRORS ------------------------------------
+
+  await tap.test('Try to create a Note without a body', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          canonical: 'one'
+        })
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Create Note Validation Error: body is a required property'
+    )
+    await tap.equal(error.details.requestUrl, `/outlines/${outlineId}/notes`)
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.canonical, 'one')
+  })
+
+  await tap.test(
+    'Try to create a Note with a body but no motivation',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            canonical: 'one',
+            body: {
+              content: 'this should not show up!!!!!!!!',
+              language: 'en'
+            },
+            json: { property: 'this should not be saved!!' }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Note Validation Error: body.motivation is a required property'
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outlineId}/notes`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.canonical, 'one')
+    }
+  )
+
+  await tap.test(
+    'Try to create a Note for an Outline that does not exist',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}abc/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            canonical: 'one',
+            body: {
+              content: 'test',
+              language: 'en'
+            },
+            json: { property: 'value' }
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Add Note to Outline Error: No Outline found with id: ${outlineId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outlineId}abc/notes`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.canonical, 'one')
+    }
+  )
+
+  // copy existing note
+  await tap.test('Copy an existing note to the context', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes?source=${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.notEqual(body.shortId, noteId)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.contextId, outlineId)
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].content, 'to be copied')
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+    noteCopy = res.body
+  })
+
+  await tap.test(
+    'Updating the copied Note should not affect the original',
+    async () => {
+      const res = await request(app)
+        .put(`/notes/${noteCopy.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { content: 'new content', motivation: 'test' },
+            json: { property: 'new' }
+          })
+        )
+
+      await tap.equal(res.body.body[0].content, 'new content')
+      await tap.equal(res.body.json.property, 'new')
+
+      // get old note
+      const resNote = await request(app)
+        .get(`/notes/${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resNote.body.body[0].content, 'to be copied')
+      await tap.notOk(resNote.body.json)
+    }
+  )
+
+  await tap.test('Try to copy a note that does not exist', async () => {
+    const res = await request(app)
+      .post(`/outlines/${outlineId}/notes?source=${noteId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(
+      error.message,
+      `Add Note to Outline Error: No Note found with id: ${noteId}abc`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/outlines/${outlineId}/notes?source=${noteId}abc`
+    )
+  })
+
+  await tap.test(
+    'Try to copy a note to an Outline that does not exist',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}abc/notes?source=${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Add Note to Outline Error: No Outline found with id: ${outlineId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outlineId}abc/notes?source=${noteId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to add a note with a previous property pointing to a note that does not exist',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' },
+            previous: note1.shortId + 'abc'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Add Note to Outline Error: No Note found with for previous property: ${note1.shortId +
+          'abc'}`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outlineId}/notes`)
+      await tap.equal(error.details.requestBody.previous, note1.shortId + 'abc')
+    }
+  )
+
+  await tap.test(
+    'Try to add a note with a next property pointing to a note that does not exist',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' },
+            next: note1.shortId + 'abc'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Add Note to Outline Error: No Note found with for next property: ${note1.shortId +
+          'abc'}`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outlineId}/notes`)
+      await tap.equal(error.details.requestBody.next, note1.shortId + 'abc')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/outline/outline-deleteNote.test.js
+++ b/tests/integration/outline/outline-deleteNote.test.js
@@ -1,0 +1,161 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createDocument,
+  createNoteContext,
+  createNote,
+  addNoteToOutline
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+const _ = require('lodash')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const outline = await createNoteContext(app, token, {
+    name: 'my outline',
+    type: 'outline'
+  })
+  const outlineId = outline.shortId
+
+  const note1 = await addNoteToOutline(app, token, outlineId, {
+    body: { motivation: 'test' },
+    canonical: '1'
+  })
+  const note2 = await addNoteToOutline(app, token, outlineId, {
+    body: { motivation: 'test' },
+    canonical: '2'
+  })
+  const note3 = await addNoteToOutline(app, token, outlineId, {
+    body: { motivation: 'test' },
+    canonical: '3',
+    previous: note2.shortId
+  })
+  const note4 = await addNoteToOutline(app, token, outlineId, {
+    body: { motivation: 'test' },
+    canonical: '4',
+    previous: note3.shortId
+  })
+
+  const note5 = await createNote(app, token, outlineId)
+
+  await tap.test('Delete a note from an outline', async () => {
+    const resOutlineBefore = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(resOutlineBefore.body.notes.length, 4)
+
+    const res = await request(app)
+      .delete(`/outlines/${outlineId}/notes/${note1.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+
+    const resOutline = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resOutline.body.notes.length, 3)
+  })
+
+  await tap.test('Delete a note in a position from an outline', async () => {
+    const res = await request(app)
+      .delete(`/outlines/${outlineId}/notes/${note3.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+
+    const resOutline = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resOutline.body.notes.length, 2)
+    await tap.equal(resOutline.body.notes[0].shortId, note2.shortId)
+    await tap.equal(resOutline.body.notes[1].shortId, note4.shortId)
+  })
+
+  await tap.test(
+    'Try to Delete a Note from an outline that does not exist',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outlineId}abc/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Outline found with id ${outline.shortId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}abc/notes/${note2.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to Delete a Note that does not exist from an outline',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outlineId}/notes/${note2.shortId}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Note found with id: ${note2.shortId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes/${note2.shortId}abc`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to Delete a Note from an outline that does not belong to an outline',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outlineId}/notes/${note5.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Note ${note5.shortId} does not belong to outline ${outlineId}`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes/${note5.shortId}`
+      )
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/outline/outline-deleteNote.test.js
+++ b/tests/integration/outline/outline-deleteNote.test.js
@@ -4,13 +4,10 @@ const {
   getToken,
   createUser,
   destroyDB,
-  createPublication,
-  createDocument,
   createNoteContext,
   createNote,
   addNoteToOutline
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 const _ = require('lodash')
 
 const test = async app => {

--- a/tests/integration/outline/outline-get.test.js
+++ b/tests/integration/outline/outline-get.test.js
@@ -35,7 +35,7 @@ const test = async app => {
     await tap.equal(body.type, 'outline')
     await tap.ok(body.json)
     await tap.equal(body.json.property, 'value1')
-    // notes & noteRelations
+    // notes
     await tap.equal(body.notes.length, 0)
   })
 

--- a/tests/integration/outline/outline-post.test.js
+++ b/tests/integration/outline/outline-post.test.js
@@ -1,0 +1,82 @@
+const request = require('supertest')
+const tap = require('tap')
+const { getToken, createUser, destroyDB } = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  await tap.test('Create Outline', async () => {
+    const res = await request(app)
+      .post('/outlines')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          name: 'context1',
+          description: 'this is the description of context1',
+          json: { property: 'value' }
+        })
+      )
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.name, 'context1')
+    await tap.equal(body.description, 'this is the description of context1')
+    await tap.equal(body.type, 'outline')
+    await tap.equal(body.json.property, 'value')
+    await tap.ok(body.published)
+  })
+
+  await tap.test('Create an empty outline', async () => {
+    const res = await request(app)
+      .post('/outlines')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({}))
+
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'outline')
+    await tap.ok(body.published)
+  })
+
+  await tap.test('Try to create Outline with invalid name', async () => {
+    const res = await request(app)
+      .post('/outlines')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          name: 123,
+          description: 'this is the description of context1',
+          json: { property: 'value' }
+        })
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      'Validation Error on Create Outline: name: should be string,null'
+    )
+    await tap.equal(error.details.requestUrl, `/outlines`)
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.name, 123)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/outline/outline-put.test.js
+++ b/tests/integration/outline/outline-put.test.js
@@ -1,0 +1,102 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNoteContext
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const outline = await createNoteContext(app, token, { type: 'outline' })
+
+  await tap.test('Update name and description of Outline', async () => {
+    const res = await request(app)
+      .put(`/outlines/${outline.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          type: 'outline',
+          name: 'something',
+          description: 'description!'
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.type, 'outline')
+    await tap.equal(body.name, 'something')
+    await tap.equal(body.description, 'description!')
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+  })
+
+  await tap.test('Update name and description to null', async () => {
+    const res = await request(app)
+      .put(`/outlines/${outline.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({ type: 'outline', name: null, description: null }))
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.notOk(body.name)
+    await tap.notOk(body.description)
+    await tap.ok(body.published)
+    await tap.notEqual(body.updated, body.published)
+  })
+
+  await tap.test(
+    'Try to update an outline type to something other than outline',
+    async () => {
+      const res = await request(app)
+        .put(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ type: 'test' }))
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.message, `Outline type must be 'outline'`)
+      await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.type, 'test')
+    }
+  )
+
+  await tap.test('Try to update an outline that does not exist', async () => {
+    const res = await request(app)
+      .put(`/outlines/${outline.shortId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(JSON.stringify({ type: 'outline', name: 'new name' }))
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `No Outline found with id ${outline.shortId}abc`
+    )
+    await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}abc`)
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.name, 'new name')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/outline/outlline-delete.test.js
+++ b/tests/integration/outline/outlline-delete.test.js
@@ -1,0 +1,134 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNoteContext
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const outline = await createNoteContext(app, token)
+
+  await tap.test('Delete an Outline', async () => {
+    const res = await request(app)
+      .delete(`/outlines/${outline.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+  })
+
+  await tap.test(
+    'Try to delete an Outline that was already deleted',
+    async () => {
+      const res = await request(app)
+        .delete(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `No Outline found with id ${outline.shortId}`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+    }
+  )
+
+  await tap.test('Try to delete an Outline that does not exist', async () => {
+    const res = await request(app)
+      .delete(`/outlines/${outline.shortId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `No Outline found with id ${outline.shortId}abc`
+    )
+    await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}abc`)
+  })
+
+  await tap.test('Try to get an Outline that was deleted', async () => {
+    const res = await request(app)
+      .get(`/outlines/${outline.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `Get outline Error: No Outline found with id ${outline.shortId}`
+    )
+    await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+  })
+
+  // await tap.test(
+  //   'Try to add a note to an outline that was deleted',
+  //   async () => {
+  //     const res = await request(app)
+  //       .post(`/outlines/${outline.shortId}/notes`)
+  //       .set('Host', 'reader-api.test')
+  //       .set('Authorization', `Bearer ${token}`)
+  //       .type('application/ld+json')
+  //       .send(
+  //         JSON.stringify({
+  //           body: {
+  //             content: 'this is the content of the note',
+  //             motivation: 'test'
+  //           },
+  //           json: { property1: 'value1' }
+  //         })
+  //       )
+
+  //     await tap.equal(res.status, 404)
+  //     const error = JSON.parse(res.text)
+  //     await tap.equal(
+  //       error.message,
+  //       `Add Note to Outline Error: No Outline found with id: ${
+  //         outline.shortId
+  //       }`
+  //     )
+  //     await tap.equal(
+  //       error.details.requestUrl,
+  //       `/outlines/${outline.shortId}/notes`
+  //     )
+  //   }
+  // )
+
+  // await tap.test('Try to update an Outline that was deleted', async () => {
+  //   const res = await request(app)
+  //     .put(`/outlines/${outline.shortId}`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type('application/ld+json')
+  //     .send(JSON.stringify(Object.assign(outline, { type: 'test2' })))
+
+  //   await tap.equal(res.status, 404)
+  //   const error = JSON.parse(res.text)
+  //   await tap.equal(
+  //     error.message,
+  //     `No Outline found with id ${outline.shortId}`
+  //   )
+  //   await tap.equal(
+  //     error.details.requestUrl,
+  //     `/outlines/${outline.shortId}`
+  //   )
+  // })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/outline/outlline-delete.test.js
+++ b/tests/integration/outline/outlline-delete.test.js
@@ -108,25 +108,26 @@ const test = async app => {
   //   }
   // )
 
-  // await tap.test('Try to update an Outline that was deleted', async () => {
-  //   const res = await request(app)
-  //     .put(`/outlines/${outline.shortId}`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type('application/ld+json')
-  //     .send(JSON.stringify(Object.assign(outline, { type: 'test2' })))
+  await tap.test('Try to update an Outline that was deleted', async () => {
+    const res = await request(app)
+      .put(`/outlines/${outline.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify(
+          Object.assign(outline, { type: 'outline', name: 'something new' })
+        )
+      )
 
-  //   await tap.equal(res.status, 404)
-  //   const error = JSON.parse(res.text)
-  //   await tap.equal(
-  //     error.message,
-  //     `No Outline found with id ${outline.shortId}`
-  //   )
-  //   await tap.equal(
-  //     error.details.requestUrl,
-  //     `/outlines/${outline.shortId}`
-  //   )
-  // })
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `No Outline found with id ${outline.shortId}`
+    )
+    await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+  })
 
   await destroyDB(app)
 }

--- a/tests/integration/outline/outlline-delete.test.js
+++ b/tests/integration/outline/outlline-delete.test.js
@@ -75,38 +75,38 @@ const test = async app => {
     await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
   })
 
-  // await tap.test(
-  //   'Try to add a note to an outline that was deleted',
-  //   async () => {
-  //     const res = await request(app)
-  //       .post(`/outlines/${outline.shortId}/notes`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token}`)
-  //       .type('application/ld+json')
-  //       .send(
-  //         JSON.stringify({
-  //           body: {
-  //             content: 'this is the content of the note',
-  //             motivation: 'test'
-  //           },
-  //           json: { property1: 'value1' }
-  //         })
-  //       )
+  await tap.test(
+    'Try to add a note to an outline that was deleted',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: {
+              content: 'this is the content of the note',
+              motivation: 'test'
+            },
+            json: { property1: 'value1' }
+          })
+        )
 
-  //     await tap.equal(res.status, 404)
-  //     const error = JSON.parse(res.text)
-  //     await tap.equal(
-  //       error.message,
-  //       `Add Note to Outline Error: No Outline found with id: ${
-  //         outline.shortId
-  //       }`
-  //     )
-  //     await tap.equal(
-  //       error.details.requestUrl,
-  //       `/outlines/${outline.shortId}/notes`
-  //     )
-  //   }
-  // )
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Add Note to Outline Error: No Outline found with id: ${
+          outline.shortId
+        }`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes`
+      )
+    }
+  )
 
   await tap.test('Try to update an Outline that was deleted', async () => {
     const res = await request(app)

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -223,6 +223,26 @@ const addNoteToContext = async (app, token, contextId, object) => {
   return response.body
 }
 
+const addNoteToOutline = async (app, token, contextId, object) => {
+  const noteObject = Object.assign(
+    {
+      target: { property: 'something' },
+      body: {
+        motivation: 'test',
+        content: 'something should go here, usually.'
+      }
+    },
+    object
+  )
+  const response = await request(app)
+    .post(`/outlines/${contextId}/notes`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+    .send(JSON.stringify(noteObject))
+  return response.body
+}
+
 const addPubToCollection = async (app, token, pubId, tagId) => {
   tagId = urlToId(tagId)
   pubId = urlToId(pubId)
@@ -256,5 +276,6 @@ module.exports = {
   createNoteRelation,
   createNoteContext,
   addNoteToContext,
-  updateNote
+  updateNote,
+  addNoteToOutline
 }

--- a/utils/outline.js
+++ b/utils/outline.js
@@ -19,6 +19,7 @@ const orderLinkedList = list => {
       }
       orderedList.push(next)
       if (orderedList.length > list.length) {
+        console.log(orderedList)
         throw new Error('circular linked list')
       }
       current = next
@@ -29,6 +30,7 @@ const orderLinkedList = list => {
 }
 
 const notesListToTree = notes => {
+  let notesBefore = notes
   if (notes.length === 0) return notes
   notes = notes.map(note => {
     note.shortId = urlToId(note.id)


### PR DESCRIPTION
New endpoints:

POST /outlines
DELETE /outlines/:id 
currently a hard delete. Not sure why I did it that way. I could change that to a soft delete. 
PUT /outlines:id

add note to outline:
POST /outlines/:id/notes
optinally query: source=<noteId> to copy an existing note.
For new notes, it supports having a parentId, previous and/or next. It does not check that the position of the note makes sense. If it doesn't, you will find out when fetching the outline when you'll get an error. Not ideal, but doing those checks would be pretty complicated.
When copying an existing note, you can't give it a position because it wont use a body. I should however make sure that it deletes any position properties from that note if it has any. Right now it doesn't because it assumes that notes we copy in the outline don't come from a context and therefore shouldn't have a position. 

remove note from outline
DELETE /outlines/:id/notes/:noteId
soft delete. If the note as a position, it does the adjustments to previous and next notes. 

Most of those endpoints are similar to the noteContext endpoints. However, if, for example, you use the general noteContext endpoint to add or remove notes, it will NOT make adjustments to the position of other notes and will break the outline. 

