### PR TITLE
Update note in outline

### DIFF
--- a/routes/outline-patchNote.js
+++ b/routes/outline-patchNote.js
@@ -1,0 +1,242 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Note } = require('../models/Note')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { checkOwnership, urlToId } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /outlines/:id/notes/:noteId:
+   *   patch:
+   *     tags:
+   *       - outlines
+   *     description: Update a Note that is in an outline
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: path
+   *         name: noteId
+   *         schema:
+   *           type: string
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/note'
+   *         description: should only include properties that are being updated
+   *     responses:
+   *       200:
+   *         description: Successfully updated Note
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/note'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: Context or Note not found
+   */
+  app.use('/', router)
+  router
+    .route('/outlines/:id/notes/:noteId')
+    .patch(jwtAuth, function (req, res, next) {
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader) {
+            return next(
+              boom.unauthorized(`No user found for this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+          if (!checkOwnership(reader.id, req.params.id)) {
+            return next(
+              boom.forbidden(`Access to Outline ${req.params.id} disallowed`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          if (!checkOwnership(reader.id, req.params.noteId)) {
+            return next(
+              boom.forbidden(`Access to Note ${req.params.noteId} disallowed`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          const body = req.body
+          if (typeof body !== 'object' || _.isEmpty(body)) {
+            return next(
+              boom.badRequest('Body must be a JSON object', {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          // get Note
+          const note = await Note.byId(req.params.noteId)
+          if (!note || note.deleted) {
+            return next(
+              boom.notFound(`No Note found with id: ${req.params.noteId}`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+          if (note.contextId !== req.params.id) {
+            return next(
+              boom.badRequest(
+                `Note ${req.params.noteId} does not belong to outline ${
+                  req.params.id
+                }`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          }
+
+          // linked list adjustments
+          if (note.previous) {
+            const previousNote = await Note.byId(note.previous)
+            await Note.update(
+              Object.assign(previousNote, { next: urlToId(note.next) })
+            )
+          }
+          if (note.next) {
+            const nextNote = await Note.byId(note.next)
+            await Note.update(
+              Object.assign(nextNote, { previous: urlToId(note.previous) })
+            )
+          }
+
+          let updatedNote
+          try {
+            updatedNote = await Note.update(Object.assign(note, body))
+          } catch (err) {
+            if (err instanceof ValidationError) {
+              return next(
+                boom.badRequest(
+                  `Validation Error on Update Note in Outline: ${err.message}`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body,
+                    validation: err.data
+                  }
+                )
+              )
+            } else if (err.message === 'no document') {
+              return next(
+                boom.notFound(
+                  `Update Note in Outline Error: No Document found with documentUrl: ${
+                    body.documentUrl
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no publication') {
+              return next(
+                boom.notFound(
+                  `Update Note in Outline Error: No Publication found with id: ${
+                    body.publicationId
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no context') {
+              return next(
+                boom.notFound(
+                  `Update Note in Outline Error: No Outline found with id: ${
+                    req.params.id
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no previous') {
+              return next(
+                boom.notFound(
+                  `Update Note in Outline Error: No Note found with for previous property: ${
+                    req.body.previous
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else if (err.message === 'no next') {
+              return next(
+                boom.notFound(
+                  `Update Note in Outline Error: No Note found with for next property: ${
+                    req.body.next
+                  }`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else {
+              return next(
+                boom.badRequest(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+          }
+          // if updatedNote.previous
+          if (updatedNote.previous) {
+            const previousNote = await Note.byId(updatedNote.previous)
+            await Note.update(
+              Object.assign(previousNote, { next: urlToId(updatedNote.id) })
+            )
+          }
+
+          // if updatedNote.next
+          if (updatedNote.next) {
+            const nextNote = await Note.byId(updatedNote.next)
+            await Note.update(
+              Object.assign(nextNote, { previous: urlToId(updatedNote.id) })
+            )
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.setHeader('Location', updatedNote.id)
+          res.status(200).end(JSON.stringify(updatedNote.toJSON()))
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/server.js
+++ b/server.js
@@ -76,6 +76,7 @@ const outlineDeleteRoute = require('./routes/outline-delete') // DELETE /outline
 const outlinePutRoute = require('./routes/outline-put') // PUT /outlines:id
 const outlineAddNoteRoute = require('./routes/outline-addNote') // POST /outlines/:id/notes
 const outlineDeleteNoteRoute = require('./routes/outline-deleteNote') // DELETE /outlines/:id/notes/:noteId
+const outlinePatchNoteRoute = require('./routes/outline-patchNote') // PATCH /outlines/:id/notes/:noteId
 
 const setupKnex = async skip_migrate => {
   let config
@@ -259,6 +260,7 @@ outlineDeleteRoute(app)
 outlinePutRoute(app)
 outlineAddNoteRoute(app)
 outlineDeleteNoteRoute(app)
+outlinePatchNoteRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -675,6 +675,53 @@ const test = async app => {
   )
 
   await tap.test(
+    'Try to update a note from an outline belonging to another user',
+    async () => {
+      const res = await request(app)
+        .patch(`/outlines/${outline1.shortId}/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ json: { proprety: 'value' } }))
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline1.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline1.shortId}/notes/${note2.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to update a note belonging to another user from an outline',
+    async () => {
+      const res = await request(app)
+        .patch(`/outlines/${outline2.shortId}/notes/${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ json: { proprety: 'value' } }))
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(error.message, `Access to Note ${noteId} disallowed`)
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline2.shortId}/notes/${noteId}`
+      )
+    }
+  )
+
+  await tap.test(
     'Try to get an Outline belonging to another user',
     async () => {
       const res = await request(app)

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -374,6 +374,17 @@ const test = async app => {
     }
   )
 
+  await tap.test(
+    'Update a Note in an Outline without authentication',
+    async () => {
+      const res = await request(app)
+        .patch('/outlines/123/notes/123')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
+
   await tap.test('Get a Outline without authentication', async () => {
     const res = await request(app)
       .get('/outlines/123')

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -71,6 +71,7 @@ const outlineDeleteTests = require('./outline/outlline-delete.test')
 const outlinePutTests = require('./outline/outline-put.test')
 const outlineAddNoteTests = require('./outline/outline-addNote.test')
 const outlineDeleteNoteTests = require('./outline/outline-deleteNote.test')
+const outlinePatchNoteTests = require('./outline/outline-patchNote.test')
 
 const app = require('../../server').app
 
@@ -180,6 +181,7 @@ const allTests = async () => {
     await outlinePutTests(app)
     await outlineAddNoteTests(app)
     await outlineDeleteNoteTests(app)
+    await outlinePatchNoteTests(app)
   }
 
   await app.knex.migrate.rollback()

--- a/tests/integration/outline/outline-patchNote.test.js
+++ b/tests/integration/outline/outline-patchNote.test.js
@@ -1,0 +1,419 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  createNote,
+  destroyDB,
+  createNoteContext,
+  addNoteToOutline
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+const _ = require('lodash')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const outline = await createNoteContext(app, token, {
+    name: 'my outline',
+    type: 'outline'
+  })
+  const outlineId = outline.shortId
+
+  // linked list: 1 - 2 - 3 - 4 - 5
+  const note1 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '1'
+  })
+  const note2 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '2',
+    previous: note1.shortId
+  })
+  const note3 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '3',
+    previous: note2.shortId
+  })
+  const note4 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '4',
+    previous: note3.shortId
+  })
+  const note5 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '5',
+    previous: note4.shortId
+  })
+
+  // children of note 3:
+  const note6 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '6',
+    parentId: note3.shortId
+  })
+  const note7 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '7',
+    parentId: note3.shortId,
+    previous: note6.shortId
+  })
+
+  // notes not in list:
+  const note8 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '8',
+    body: { motivation: 'test', content: 'original content' },
+    json: { property: 'value' }
+  })
+  const note9 = await addNoteToOutline(app, token, outlineId, {
+    canonical: '9'
+  })
+
+  /*
+  1
+  2
+  3
+    6
+    7
+  4
+  5
+
+  unsorted: 8, 9
+   */
+
+  const note10 = await createNote(app, token, readerId)
+
+  await tap.test('Update the content of a note', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note8.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'new content',
+            motivation: 'test'
+          }
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.equal(body.body[0].content, 'new content')
+    // old properties stay the same
+    await tap.equal(body.json.property, 'value')
+  })
+
+  await tap.test(
+    'Update the content of a note that is in a specific position',
+    async () => {
+      const res = await request(app)
+        .patch(`/outlines/${outlineId}/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: {
+              content: 'new content',
+              motivation: 'test'
+            }
+          })
+        )
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.body[0].content, 'new content')
+      await tap.equal(body.previous, note1.shortId)
+      await tap.equal(body.next, note3.shortId)
+
+      // previous and next notes should remain the same
+      const resOutline = await request(app)
+        .get(`/outlines/${outlineId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const notes = resOutline.body.notes
+      const previousNote = _.find(notes, { shortId: note1.shortId })
+      await tap.equal(previousNote.next, note2.shortId)
+      const nextNote = _.find(notes, { shortId: note3.shortId })
+      await tap.equal(nextNote.previous, note2.shortId)
+    }
+  )
+
+  /*
+  1
+  2
+  3
+    6
+    7
+  4
+  **8**
+  5
+
+  unsorted:  9
+   */
+
+  await tap.test('Move an unsorted note to a position', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note8.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          previous: note4.shortId,
+          next: note5.shortId
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.previous, note4.shortId)
+    await tap.equal(res.body.next, note5.shortId)
+
+    const resOutline = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resOutline.status, 200)
+    const notes = resOutline.body.notes
+    await tap.equal(notes[1].shortId, note1.shortId)
+    await tap.equal(notes[2].shortId, note2.shortId)
+    await tap.equal(notes[3].shortId, note3.shortId)
+    await tap.equal(notes[4].shortId, note4.shortId)
+    await tap.equal(notes[5].shortId, note8.shortId)
+    await tap.equal(notes[6].shortId, note5.shortId)
+  })
+
+  /*
+  1
+  **4**
+  2
+  3
+    6
+    7
+  8
+  5
+
+  unsorted:  9
+   */
+
+  await tap.test('Move a sorted note to a new position', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note4.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          previous: note1.shortId,
+          next: note2.shortId
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.previous, note1.shortId)
+    await tap.equal(res.body.next, note2.shortId)
+
+    const resOutline = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resOutline.status, 200)
+    const notes = resOutline.body.notes
+    await tap.equal(notes[1].shortId, note1.shortId)
+    await tap.equal(notes[2].shortId, note4.shortId)
+    await tap.equal(notes[3].shortId, note2.shortId)
+    await tap.equal(notes[4].shortId, note3.shortId)
+    await tap.equal(notes[5].shortId, note8.shortId)
+    await tap.equal(notes[6].shortId, note5.shortId)
+  })
+
+  /*
+  1
+    **2**
+  4
+  3
+    6
+    7
+  8
+  5
+
+  unsorted:  9
+   */
+  await tap.test('Move a sorted note to a new nested position', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note2.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          parentId: note1.shortId,
+          previous: null,
+          next: null
+        })
+      )
+
+    await tap.equal(res.status, 200)
+    await tap.notOk(res.body.previous)
+    await tap.notOk(res.body.next)
+    await tap.equal(res.body.parentId, note1.shortId)
+
+    const resOutline = await request(app)
+      .get(`/outlines/${outlineId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resOutline.status, 200)
+    const notes = resOutline.body.notes
+    await tap.equal(notes[1].shortId, note1.shortId)
+    await tap.equal(notes[2].shortId, note4.shortId)
+    await tap.equal(notes[3].shortId, note3.shortId)
+    await tap.equal(notes[4].shortId, note8.shortId)
+    await tap.equal(notes[5].shortId, note5.shortId)
+
+    await tap.equal(notes[1].children[0].shortId, note2.shortId)
+  })
+
+  /*
+  1
+    2
+    **5**
+  4
+  3
+    6
+    7
+  8
+
+  unsorted:  9
+   */
+  await tap.test(
+    'Move a sorted note to a new nested position with order',
+    async () => {
+      const res = await request(app)
+        .patch(`/outlines/${outlineId}/notes/${note5.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            parentId: note1.shortId,
+            previous: note2.shortId,
+            next: null
+          })
+        )
+
+      await tap.equal(res.status, 200)
+      await tap.notOk(res.body.next)
+      await tap.equal(res.body.parentId, note1.shortId)
+      await tap.equal(res.body.previous, note2.shortId)
+
+      const resOutline = await request(app)
+        .get(`/outlines/${outlineId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resOutline.status, 200)
+      const notes = resOutline.body.notes
+      await tap.equal(notes[1].shortId, note1.shortId)
+      await tap.equal(notes[2].shortId, note4.shortId)
+      await tap.equal(notes[3].shortId, note3.shortId)
+      await tap.equal(notes[4].shortId, note8.shortId)
+
+      await tap.equal(notes[1].children[0].shortId, note2.shortId)
+      await tap.equal(notes[1].children[1].shortId, note5.shortId)
+    }
+  )
+
+  await tap.test('Try to update a note that does not exist', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note8.shortId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'new content',
+            motivation: 'test'
+          }
+        })
+      )
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.message, `No Note found with id: ${note8.shortId}abc`)
+    await tap.equal(
+      error.details.requestUrl,
+      `/outlines/${outline.shortId}/notes/${note8.shortId}abc`
+    )
+    await tap.equal(error.details.requestBody.body.content, 'new content')
+  })
+
+  await tap.test(
+    'Try to update a note that does not belong to the outline',
+    async () => {
+      const res = await request(app)
+        .patch(`/outlines/${outlineId}/notes/${note10.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: {
+              content: 'new content',
+              motivation: 'test'
+            }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Note ${note10.shortId} does not belong to outline ${outlineId}`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes/${note10.shortId}`
+      )
+      await tap.equal(error.details.requestBody.body.content, 'new content')
+    }
+  )
+
+  await tap.test('Try to update a note with invalid data', async () => {
+    const res = await request(app)
+      .patch(`/outlines/${outlineId}/notes/${note8.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 123,
+            motivation: 'test'
+          }
+        })
+      )
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      'Validation Error on Update Note in Outline: content: should be string,null'
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/outlines/${outline.shortId}/notes/${note8.shortId}`
+    )
+    await tap.equal(error.details.requestBody.body.content, 123)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/utils/outline.js
+++ b/utils/outline.js
@@ -19,7 +19,6 @@ const orderLinkedList = list => {
       }
       orderedList.push(next)
       if (orderedList.length > list.length) {
-        console.log(orderedList)
         throw new Error('circular linked list')
       }
       current = next
@@ -30,7 +29,6 @@ const orderLinkedList = list => {
 }
 
 const notesListToTree = notes => {
-  let notesBefore = notes
   if (notes.length === 0) return notes
   notes = notes.map(note => {
     note.shortId = urlToId(note.id)
@@ -41,11 +39,17 @@ const notesListToTree = notes => {
   if (orderedList.length !== notes.length) {
     throw new Error('Invalid linked list')
   }
-  const tree = arrayToTree(orderedList, {
-    id: 'shortId',
-    dataField: null,
-    throwIfOrphans: true
-  })
+
+  let tree
+  try {
+    tree = arrayToTree(orderedList, {
+      id: 'shortId',
+      dataField: null
+      // throwIfOrphans: true
+    })
+  } catch (err) {
+    throw err
+  }
 
   return tree
 }


### PR DESCRIPTION
new endpoint:

PATCH /outlines/:outlineId/notes/:noteId
body of request should contain only the property of the notes that are being updated.
You can use it to update the position of a note (parentId, previous, next) and other notes will be updated to reflect the new order. 

Will not throw an error if the new position of the note does not make sense. 