### PR TITLE
Pub batch updates

### DIFF
--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -214,6 +214,17 @@ class Attribution extends BaseModel {
       publicationId
     )
   }
+  static async deleteAttribution (
+    publicationId /*: Array<string> */,
+    role /*: string */,
+    name /*: string */
+  ) /*: Promise<number> */ {
+    return await Attribution.query(Attribution.knex())
+      .where('normalizedName', name)
+      .andWhere('publicationId', '=', publicationId)
+      .andWhere('role', '=', role)
+      .del()
+  }
 
   static async deleteAttributionOfPub (
     publicationId /*: string */,

--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -115,6 +115,31 @@ class Attribution extends BaseModel {
     return props
   }
 
+  static async createSingleAttribution (
+    role /*: string */,
+    attribution /*: any */,
+    pubId /*: string */,
+    readerId /*: string */
+  ) {
+    if (!_.isString(attribution) && !_.isObject(attribution)) {
+      throw new Error(
+        `${role} attribution validation error: attribution should be either an attribution object or a string`
+      )
+    }
+    if (_.isString(attribution)) {
+      attribution = { type: 'Person', name: attribution }
+    }
+    let formattedAttribution = Attribution._formatAttribution(
+      attribution,
+      pubId,
+      readerId,
+      role
+    )
+    return await Attribution.query(Attribution.knex()).insert(
+      formattedAttribution
+    )
+  }
+
   static async createAttributionsForPublication (
     publication /*: any */,
     pubId /*: string */,

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -738,8 +738,6 @@ class Publication extends BaseModel {
           let normalizedName
           if (_.isString(attribution)) {
             normalizedName = Attribution.normalizeName(attribution)
-          } else if (_.isString(attribution.name)) {
-            normalizedName = Attribution.normalizeName(attribution.name)
           }
 
           // if attribution already exists, do nothing
@@ -802,8 +800,6 @@ class Publication extends BaseModel {
           let normalizedName = ''
           if (_.isString(attribution)) {
             normalizedName = Attribution.normalizeName(attribution)
-          } else if (_.isString(attribution.name)) {
-            normalizedName = Attribution.normalizeName(attribution.name)
           }
           // if attribution already exists, remove it
           if (

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -434,13 +434,15 @@ class Publication extends BaseModel {
         )
       }
     }
-
     // store metadata
-    const metadata = {}
+    let metadata = {}
     metadataProps.forEach(property => {
       metadata[property] = publication[property]
     })
-    publication.metadata = _.omitBy(metadata, _.isUndefined)
+    metadata = _.omitBy(metadata, _.isUndefined)
+    if (!_.isEmpty(metadata)) {
+      publication.metadata = metadata
+    }
 
     publication = _.pick(publication, [
       'id',
@@ -961,14 +963,16 @@ class Publication extends BaseModel {
     }
 
     const modifications = Publication._formatIncomingPub(null, body)
-    if (modifications.metadata) {
+    if (
+      modifications.metadata &&
+      Object.keys(modifications.metadata).length > 0
+    ) {
       modifications.metadata = _.omitBy(modifications.metadata, _.isUndefined)
       modifications.metadata = Object.assign(
         publication.metadata,
         modifications.metadata
       )
     }
-
     let updatedPub
     try {
       updatedPub = await Publication.query().patchAndFetchById(

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -555,6 +555,13 @@ class Publication extends BaseModel {
     return pub
   }
 
+  static async checkIfExists (id /*: string */) /*: Promise<boolean> */ {
+    const pub = await Publication.query().findById(id)
+    if (!pub || pub.deleted) {
+      return false
+    } else return true
+  }
+
   static async delete (id /*: string */) {
     // Mark documents associated with pub as deleted
     const { Document } = require('./Document')

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -580,7 +580,6 @@ class Publication extends BaseModel {
     await Document.deleteDocumentsByPubId(id)
 
     // Delete Publication_Tag associated with pub
-    const { Publication_Tag } = require('./Publications_Tags')
     await Publication_Tag.deletePubTagsOfPub(id)
 
     // remove documents from elasticsearch index

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -607,6 +607,28 @@ class Publication extends BaseModel {
       .where('publicationId', '=', id)
   }
 
+  static async batchUpdate (body /*: any */) /*: Promise<any> */ {
+    const arrayProperties = attributionTypes.concat(['keywords', 'inLanguage'])
+
+    if (body.operation === 'replace') {
+      if (arrayProperties.indexOf(body.property) > -1) {
+        throw new Error('no replace array')
+      }
+
+      let modification = {}
+      modification[body.property] = body.value
+      try {
+        Publication._validateIncomingPub(modification)
+      } catch (err) {
+        throw err
+      }
+      const modificationFormatted = this._formatIncomingPub(null, modification)
+      return await Publication.query()
+        .patch(modificationFormatted)
+        .whereIn('id', body.publications)
+    }
+  }
+
   async update (body /*: any */) /*: Promise<PublicationType|null> */ {
     const id = urlToId(this.id)
     const publication = this

--- a/models/Publications_Tags.js
+++ b/models/Publications_Tags.js
@@ -66,6 +66,18 @@ class Publication_Tag extends BaseModel {
     }
   }
 
+  static async removeTagFromPubNoError (
+    publicationId /*: string */,
+    tagId /*: string */
+  ) /*: Promise<PublicationTagType|Error> */ {
+    return await Publication_Tag.query()
+      .delete()
+      .where({
+        publicationId: urlToId(publicationId),
+        tagId
+      })
+  }
+
   static async deletePubTagsOfPub (
     publicationId /*: string */
   ) /*: Promise<number|Error> */ {

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -366,6 +366,22 @@ module.exports = function (app) {
             }
           } else {
             // TAGS
+            // check ownership of tags. First check that they are strings?
+
+            const result = await Publication.batchUpdateRemoveTags(
+              req.body,
+              urlToId(reader.id)
+            )
+            if (
+              !_.find(result, { status: 404 }) &&
+              !_.find(result, { status: 400 })
+            ) {
+              res.setHeader('Content-Type', 'application/ld+json')
+              res.status(204).end()
+            } else {
+              res.setHeader('Content-Type', 'application/ld+json')
+              res.status(207).end(JSON.stringify(result))
+            }
           }
 
           break

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -19,11 +19,6 @@ const batchUpdateSimpleProperties = [
 
 const batchUpdateArrayProperties = ['keywords', 'inLanguage']
 
-const batchUpdateProperties = batchUpdateSimpleProperties
-  .concat(batchUpdateArrayProperties)
-  .concat(Publication.attributionTypes)
-  .concat(['tags'])
-
 module.exports = function (app) {
   /**
    * @swagger
@@ -47,14 +42,15 @@ module.exports = function (app) {
    *             $ref: '#/definitions/publicationBatchUpdateRequest'
    *       description: body should only include fields to be updated
    *     responses:
-   *       200:
-   *         description: Successfully updated Publication
+   *       204:
+   *         description: Successfully updated Publications
+   *
+   *       207:
+   *         description: Multiple status. This is returned if at least one of the changes returned an error
    *         content:
    *           application/json:
    *             schema:
-   *               $ref: '#/definitions/publicationBatchUpdateResponse'
-   *       207:
-   *         description: Multiple status. This is returned if at least one of the changes returned an error
+   *               $ref: '#definitions/publicationBatchUpdateResponse'
    */
   app.use('/', router)
   router
@@ -233,7 +229,7 @@ module.exports = function (app) {
               res.status(204).end()
             } else {
               res.setHeader('Content-Type', 'application/ld+json')
-              res.status(207).end(JSON.stringify(result))
+              res.status(207).end(JSON.stringify({ status: result }))
             }
           } else if (
             Publication.attributionTypes.indexOf(req.body.property) > -1
@@ -251,7 +247,7 @@ module.exports = function (app) {
               res.status(204).end()
             } else {
               res.setHeader('Content-Type', 'application/ld+json')
-              res.status(207).end(JSON.stringify(result))
+              res.status(207).end(JSON.stringify({ status: result }))
             }
           } else {
             // TAGS
@@ -269,7 +265,7 @@ module.exports = function (app) {
               res.status(204).end()
             } else {
               res.setHeader('Content-Type', 'application/ld+json')
-              res.status(207).end(JSON.stringify(result))
+              res.status(207).end(JSON.stringify({ status: result }))
             }
           }
           break
@@ -324,7 +320,7 @@ module.exports = function (app) {
                 res.status(204).end()
               } else {
                 res.setHeader('Content-Type', 'application/ld+json')
-                res.status(207).end(JSON.stringify(result))
+                res.status(207).end(JSON.stringify({ status: result }))
               }
             } catch (err) {
               console.log(err)
@@ -362,7 +358,9 @@ module.exports = function (app) {
               res.status(204).end()
             } else {
               res.setHeader('Content-Type', 'application/ld+json')
-              res.status(207).end(JSON.stringify(result.concat(errors)))
+              res
+                .status(207)
+                .end(JSON.stringify({ status: result.concat(errors) }))
             }
           } else {
             // TAGS
@@ -380,89 +378,11 @@ module.exports = function (app) {
               res.status(204).end()
             } else {
               res.setHeader('Content-Type', 'application/ld+json')
-              res.status(207).end(JSON.stringify(result))
+              res.status(207).end(JSON.stringify({ status: result }))
             }
           }
 
           break
       }
-
-      // const pubId = req.params.pubId
-      // Publication.byId(pubId)
-      //   .then(async pub => {
-      //     if (!pub) {
-      //       return next(
-      //         boom.notFound(`No Publication found with id ${pubId}`, {
-      //           requestUrl: req.originalUrl,
-      //           requestBody: req.body
-      //         })
-      //       )
-      //     }
-      //     const reader = await Reader.byAuthId(req.user)
-      //     if (!reader || !checkOwnership(reader.id, pubId)) {
-      //       return next(
-      //         boom.forbidden(`Access to publication ${pubId} disallowed`, {
-      //           requestUrl: req.originalUrl,
-      //           requestBody: req.body
-      //         })
-      //       )
-      //     }
-
-      //     const body = req.body
-      //     if (typeof body !== 'object' || Object.keys(body).length === 0) {
-      //       return next(
-      //         boom.badRequest(
-      //           'Patch Publication Request Error: Body must be a JSON object',
-      //           {
-      //             requestUrl: req.originalUrl,
-      //             requestBody: req.body
-      //           }
-      //         )
-      //       )
-      //     }
-
-      //     // update pub
-      //     let updatedPub
-      //     try {
-      //       updatedPub = await pub.update(body)
-      //     } catch (err) {
-      //       if (err instanceof ValidationError) {
-      //         return next(
-      //           boom.badRequest(
-      //             `Validation Error on Patch Publication: ${err.message}`,
-      //             {
-      //               requestUrl: req.originalUrl,
-      //               requestBody: req.body,
-      //               validation: err.data
-      //             }
-      //           )
-      //         )
-      //       } else {
-      //         return next(
-      //           boom.badRequest(err.message, {
-      //             requestUrl: req.originalUrl,
-      //             requestBody: req.body
-      //           })
-      //         )
-      //       }
-      //     }
-
-      //     if (updatedPub === null) {
-      //       return next(
-      //         boom.notFound(`No Publication found with id ${body.id}`, {
-      //           requestUrl: req.originalUrl,
-      //           requestBody: req.body
-      //         })
-      //       )
-      //     }
-
-      //     await libraryCacheUpdate(reader.id)
-
-      //     res.setHeader('Content-Type', 'application/ld+json')
-      //     res.status(200).end(JSON.stringify(updatedPub.toJSON()))
-      //   })
-      //   .catch(err => {
-      //     next(err)
-      //   })
     })
 }

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -1,0 +1,176 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Publication } = require('../models/Publication')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { libraryCacheUpdate } = require('../utils/cache')
+const { checkOwnership } = require('../utils/utils')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /publications/batchUpdate:
+   *   patch:
+   *     tags:
+   *       - publications
+   *     description: Apply the same update to multiple publications
+   *     parameters:
+   *       - in: path
+   *         name: pubId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/publicationBatchUpdateRequest'
+   *       description: body should only include fields to be updated
+   *     responses:
+   *       200:
+   *         description: Successfully updated Publication
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/publicationBatchUpdateResponse'
+   *       207:
+   *         description: Multiple status. This is returned if at least one of the changes returned an error
+   */
+  app.use('/', router)
+  router
+    .route('/publications/batchUpdate')
+    .patch(jwtAuth, async function (req, res, next) {
+      let responses = []
+      const reader = await Reader.byAuthId(req.user)
+      req.body.publications.forEach(async publicationId => {
+        if (!checkOwnership(reader.id, publicationId)) {
+          responses.push({
+            publicationId,
+            statusCode: 403,
+            error: {
+              message: `Access to publication ${publicationId} disallowed`,
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            }
+          })
+        }
+      })
+
+      try {
+        await Publication.batchUpdate(req.body)
+        res.setHeader('Content-Type', 'application/ld+json')
+        res.status(204).end()
+      } catch (err) {
+        if (err instanceof ValidationError) {
+          return next(
+            boom.badRequest(
+              `Validation Error on Patch Publication: ${err.message}`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body,
+                validation: err.data
+              }
+            )
+          )
+        } else {
+          if (err.message === 'no replace array') {
+            return next(
+              boom.badRequest(
+                `Cannot use 'replace' to update an array property: ${
+                  req.body.property
+                }. Use 'add' or 'remove' instead`,
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          }
+        }
+      }
+
+      // const pubId = req.params.pubId
+      // Publication.byId(pubId)
+      //   .then(async pub => {
+      //     if (!pub) {
+      //       return next(
+      //         boom.notFound(`No Publication found with id ${pubId}`, {
+      //           requestUrl: req.originalUrl,
+      //           requestBody: req.body
+      //         })
+      //       )
+      //     }
+      //     const reader = await Reader.byAuthId(req.user)
+      //     if (!reader || !checkOwnership(reader.id, pubId)) {
+      //       return next(
+      //         boom.forbidden(`Access to publication ${pubId} disallowed`, {
+      //           requestUrl: req.originalUrl,
+      //           requestBody: req.body
+      //         })
+      //       )
+      //     }
+
+      //     const body = req.body
+      //     if (typeof body !== 'object' || Object.keys(body).length === 0) {
+      //       return next(
+      //         boom.badRequest(
+      //           'Patch Publication Request Error: Body must be a JSON object',
+      //           {
+      //             requestUrl: req.originalUrl,
+      //             requestBody: req.body
+      //           }
+      //         )
+      //       )
+      //     }
+
+      //     // update pub
+      //     let updatedPub
+      //     try {
+      //       updatedPub = await pub.update(body)
+      //     } catch (err) {
+      //       if (err instanceof ValidationError) {
+      //         return next(
+      //           boom.badRequest(
+      //             `Validation Error on Patch Publication: ${err.message}`,
+      //             {
+      //               requestUrl: req.originalUrl,
+      //               requestBody: req.body,
+      //               validation: err.data
+      //             }
+      //           )
+      //         )
+      //       } else {
+      //         return next(
+      //           boom.badRequest(err.message, {
+      //             requestUrl: req.originalUrl,
+      //             requestBody: req.body
+      //           })
+      //         )
+      //       }
+      //     }
+
+      //     if (updatedPub === null) {
+      //       return next(
+      //         boom.notFound(`No Publication found with id ${body.id}`, {
+      //           requestUrl: req.originalUrl,
+      //           requestBody: req.body
+      //         })
+      //       )
+      //     }
+
+      //     await libraryCacheUpdate(reader.id)
+
+      //     res.setHeader('Content-Type', 'application/ld+json')
+      //     res.status(200).end(JSON.stringify(updatedPub.toJSON()))
+      //   })
+      //   .catch(err => {
+      //     next(err)
+      //   })
+    })
+}

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -414,6 +414,19 @@ module.exports = function (app) {
           }
 
           break
+
+        default:
+          return next(
+            boom.badRequest(
+              `Batch Update Publication Request Error: ${
+                req.body.operation
+              } is not a valid operation. Must be 'replace', 'add' or 'remove' `,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
+            )
+          )
       }
     })
 }

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -79,7 +79,9 @@ module.exports = function (app) {
       if (!req.body.hasOwnProperty('property')) missingProps.push('property')
       if (!req.body.hasOwnProperty('value')) missingProps.push('value')
       if (!req.body.hasOwnProperty('operation')) missingProps.push('operation')
-      if (!req.body.hasOwnProperty('publications')) { missingProps.push('publications') }
+      if (!req.body.hasOwnProperty('publications')) {
+        missingProps.push('publications')
+      }
       if (missingProps.length) {
         return next(
           boom.badRequest(
@@ -233,8 +235,12 @@ module.exports = function (app) {
               res.status(207).end(JSON.stringify(result))
             }
           } else {
+            // ATTRIBUTIONS
             const result = await Publication.batchUpdateAddAttribution(req.body)
-            if (!_.find(result, { status: 404 })) {
+            if (
+              !_.find(result, { status: 404 }) &&
+              !_.find(result, { status: 400 })
+            ) {
               res.setHeader('Content-Type', 'application/ld+json')
               res.status(204).end()
             } else {

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -63,14 +63,15 @@ module.exports = function (app) {
       })
 
       try {
-        await Publication.batchUpdate(req.body)
+        const result = await Publication.batchUpdate(req.body)
+        console.log(result)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(204).end()
       } catch (err) {
         if (err instanceof ValidationError) {
           return next(
             boom.badRequest(
-              `Validation Error on Patch Publication: ${err.message}`,
+              `Validation Error on Batch Update Publication: ${err.message}`,
               {
                 requestUrl: req.originalUrl,
                 requestBody: req.body,
@@ -78,20 +79,25 @@ module.exports = function (app) {
               }
             )
           )
-        } else {
-          if (err.message === 'no replace array') {
-            return next(
-              boom.badRequest(
-                `Cannot use 'replace' to update an array property: ${
-                  req.body.property
-                }. Use 'add' or 'remove' instead`,
-                {
-                  requestUrl: req.originalUrl,
-                  requestBody: req.body
-                }
-              )
+        } else if (err.message === 'no replace array') {
+          return next(
+            boom.badRequest(
+              `Cannot use 'replace' to update an array property: ${
+                req.body.property
+              }. Use 'add' or 'remove' instead`,
+              {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              }
             )
-          }
+          )
+        } else {
+          return next(
+            boom.badRequest(err.message, {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
         }
       }
 

--- a/routes/publication-patch.js
+++ b/routes/publication-patch.js
@@ -87,7 +87,7 @@ module.exports = function (app) {
         // update pub
         let updatedPub
         try {
-          updatedPub = await pub.update(body)
+          updatedPub = await Publication.update(pub, body)
         } catch (err) {
           if (err instanceof ValidationError) {
             return next(

--- a/routes/swagger-definitions/pubBatchUpdate-def.js
+++ b/routes/swagger-definitions/pubBatchUpdate-def.js
@@ -26,11 +26,11 @@
  *     id:
  *       type: string
  *       description: publicationId
- *    message:
- *      type: string
- *      description: error message, in case of 400 or 404 status
- *    value:
- *      type: string
- *      description: the value of the update
+ *     message:
+ *       type: string
+ *       description: error message, in case of 400 or 404 status
+ *     value:
+ *       type: string
+ *       description: the value of the update
  *
  */

--- a/routes/swagger-definitions/pubBatchUpdate-def.js
+++ b/routes/swagger-definitions/pubBatchUpdate-def.js
@@ -1,0 +1,36 @@
+/**
+ * @swagger
+ * definition:
+ *   publicationBatchUpdateRequest:
+ *     properties:
+ *       publications:
+ *         type: array
+ *         items:
+ *           type: string
+ *           description: ids of publications to be updated
+ *       operation:
+ *         type: string
+ *         enum: ['replace', 'add', 'remove']
+ *       property:
+ *         type: string
+ *         enum: [  'type', 'bookFormat', 'status', 'encodingFormat', 'keywords', 'inLanguage',  'author', 'editor', 'contributor', 'creator', 'illustrator', 'publisher', 'translator', 'copyrightHolder']
+ *       value:
+ *         type: array
+ *         items:
+ *           type: string
+ *
+ *   publicationBatchUpdateResponseItem:
+ *     status:
+ *       type: integer
+ *       enum: [204, 400, 404]
+ *     id:
+ *       type: string
+ *       description: publicationId
+ *    message:
+ *      type: string
+ *      description: error message, in case of 400 or 404 status
+ *    value:
+ *      type: string
+ *      description: the value of the update
+ *
+ */

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ const publicationDeleteTagRoute = require('./routes/publication-delete-tag') // 
 const publicationGetRoute = require('./routes/publication-get') // GET /publications/:id
 const publicationDocumentRoute = require('./routes/publication-document') // GET /publication-:id/:path
 const readActivityPostRoute = require('./routes/readActivity-post') // POST /publications/:id/readActivity
+const publicationBatchUpdate = require('./routes/publication-batchUpdate') // PATCH /publications/batchUpdate
 
 // Search
 const searchRoute = require('./routes/search') // not working!
@@ -228,6 +229,7 @@ getTagsRoute(app)
 // new routes
 readActivityPostRoute(app)
 publicationPostRoute(app)
+publicationBatchUpdate(app)
 publicationPatchRoute(app)
 publicationDeleteRoute(app)
 publicationPutTagRoute(app)

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -153,6 +153,230 @@ const test = async app => {
     }
   )
 
+  // ------------------------ PUBLICATION BATCH UPDATE -------------------------------------
+  await tap.test(
+    'Try to batch update a publication belonging to another reader',
+    async () => {
+      // replace
+      const res1 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'replace',
+            publications: [publicationId],
+            property: 'type',
+            value: 'Article'
+          })
+        )
+
+      await tap.equal(res1.statusCode, 207)
+      const result1 = res1.body.status
+      await tap.equal(result1.length, 1)
+      await tap.equal(result1[0].status, 403)
+      await tap.equal(
+        result1[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // add metadata
+      const res2 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'add',
+            publications: [publicationId],
+            property: 'keywords',
+            value: 'something'
+          })
+        )
+
+      await tap.equal(res2.statusCode, 207)
+      const result2 = res2.body.status
+      await tap.equal(result2.length, 1)
+      await tap.equal(result2[0].status, 403)
+      await tap.equal(
+        result2[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // remove metadata
+      const res3 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'remove',
+            publications: [publicationId],
+            property: 'keywords',
+            value: 'something'
+          })
+        )
+
+      await tap.equal(res3.statusCode, 207)
+      const result3 = res3.body.status
+      await tap.equal(result3.length, 1)
+      await tap.equal(result3[0].status, 403)
+      await tap.equal(
+        result3[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // add attribution
+      const res4 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'add',
+            publications: [publicationId],
+            property: 'author',
+            value: 'something'
+          })
+        )
+
+      await tap.equal(res4.statusCode, 207)
+      const result4 = res4.body.status
+      await tap.equal(result4.length, 1)
+      await tap.equal(result4[0].status, 403)
+      await tap.equal(
+        result4[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // remove attribution
+      const res5 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'remove',
+            publications: [publicationId],
+            property: 'author',
+            value: 'something'
+          })
+        )
+
+      await tap.equal(res5.statusCode, 207)
+      const result5 = res5.body.status
+      await tap.equal(result5.length, 1)
+      await tap.equal(result5[0].status, 403)
+      await tap.equal(
+        result5[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // add tags
+      const res6 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'add',
+            publications: [publicationId],
+            property: 'tags',
+            value: ['something']
+          })
+        )
+
+      await tap.equal(res6.statusCode, 207)
+      const result6 = res6.body.status
+      await tap.equal(result6.length, 1)
+      await tap.equal(result6[0].status, 403)
+      await tap.equal(
+        result6[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+
+      // remove tags
+      const res7 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'remove',
+            publications: [publicationId],
+            property: 'tags',
+            value: 'something'
+          })
+        )
+
+      await tap.equal(res7.statusCode, 207)
+      const result7 = res7.body.status
+      await tap.equal(result7.length, 1)
+      await tap.equal(result7[0].status, 403)
+      await tap.equal(
+        result7[0].message,
+        `Access to publication ${publicationId} disallowed`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to batch update a publication by adding a tag that belongs to another user',
+    async () => {
+      const res = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'add',
+            publications: [publicationId2],
+            property: 'tags',
+            value: [tagId]
+          })
+        )
+
+      await tap.equal(res.statusCode, 207)
+      const result = res.body.status
+      await tap.equal(result.length, 1)
+      await tap.equal(result[0].status, 403)
+      await tap.equal(result[0].message, `Access to tag ${tagId} disallowed`)
+    }
+  )
+
+  await tap.test(
+    'Try to batch update a publication by removing a tag that belongs to another user',
+    async () => {
+      const res = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'remove',
+            publications: [publicationId2],
+            property: 'tags',
+            value: [tagId]
+          })
+        )
+
+      await tap.equal(res.statusCode, 207)
+      const result = res.body.status
+      await tap.equal(result.length, 1)
+      await tap.equal(result[0].status, 403)
+      await tap.equal(result[0].message, `Access to tag ${tagId} disallowed`)
+    }
+  )
+
   // --------------------------------------- NOTE ----------------------------
 
   await tap.test('Try to get note belonging to another reader', async () => {

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -34,14 +34,14 @@ const test = async app => {
   const readerId2 = urlToId(readerCompleteUrl2)
 
   // create publication and tag for reader 1
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
 
   const tag = await createTag(app, token)
   const tagId = urlToId(tag.id)
 
   // create publication and tag for reader 2
-  const publication2 = await createPublication(readerId2)
+  const publication2 = await createPublication(app, token2)
   publicationId2 = urlToId(publication2.id)
 
   const tag2 = await createTag(app, token2, readerUrl2)

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -35,7 +35,7 @@ const test = async app => {
   const tagId = urlToId(tag.id)
 
   // create publication for reader 2
-  const publication2 = await createPublication(readerCompleteUrl2)
+  const publication2 = await createPublication(app, token2)
   publicationId2 = urlToId(publication2.id)
 
   // --------------------------------------- READER ----------------------------------------

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -98,6 +98,17 @@ const test = async app => {
     await tap.equal(res10.statusCode, 401)
   })
 
+  await tap.test(
+    'Batch update Publication without Authentication',
+    async () => {
+      const res10 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res10.statusCode, 401)
+    }
+  )
+
   // ------------------------------------------- TAG ---------------------------------------
 
   await tap.test('Get Tags without Authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -111,11 +111,11 @@ const allTests = async () => {
   }
 
   if (!test || test === 'publication') {
-    await publicationGetTests(app)
-    await publicationDeleteTests(app)
-    await publicationPostTests(app)
-    await publicationPatchTests(app)
-    await readActivityPostTests(app)
+    // await publicationGetTests(app)
+    // await publicationDeleteTests(app)
+    // await publicationPostTests(app)
+    // await publicationPatchTests(app)
+    // await readActivityPostTests(app)
     await publicationBatchUpdateTests(app)
   }
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -111,11 +111,11 @@ const allTests = async () => {
   }
 
   if (!test || test === 'publication') {
-    // await publicationGetTests(app)
-    // await publicationDeleteTests(app)
-    // await publicationPostTests(app)
-    // await publicationPatchTests(app)
-    // await readActivityPostTests(app)
+    await publicationGetTests(app)
+    await publicationDeleteTests(app)
+    await publicationPostTests(app)
+    await publicationPatchTests(app)
+    await readActivityPostTests(app)
     await publicationBatchUpdateTests(app)
   }
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -111,12 +111,12 @@ const allTests = async () => {
   }
 
   if (!test || test === 'publication') {
-    await publicationGetTests(app)
-    await publicationDeleteTests(app)
-    await publicationPostTests(app)
-    await publicationPatchTests(app)
-    await readActivityPostTests(app)
-    // await publicationBatchUpdateTests(app)
+    // await publicationGetTests(app)
+    // await publicationDeleteTests(app)
+    // await publicationPostTests(app)
+    // await publicationPatchTests(app)
+    // await readActivityPostTests(app)
+    await publicationBatchUpdateTests(app)
   }
 
   if (!test || test === 'reader') {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -27,6 +27,7 @@ const publicationDeleteTests = require('./publication/publication-delete.test')
 const publicationPostTests = require('./publication/publication-post.test')
 const publicationPatchTests = require('./publication/publication-patch.test')
 const readActivityPostTests = require('./publication/readActivity-post.test')
+const publicationBatchUpdateTests = require('./publication/publication-batchUpdate.test')
 
 const readerCreateTests = require('./reader/reader-post.test')
 const readerGetTests = require('./reader/reader-get.test')
@@ -110,11 +111,12 @@ const allTests = async () => {
   }
 
   if (!test || test === 'publication') {
-    await publicationGetTests(app)
-    await publicationDeleteTests(app)
-    await publicationPostTests(app)
-    await publicationPatchTests(app)
-    await readActivityPostTests(app)
+    // await publicationGetTests(app)
+    // await publicationDeleteTests(app)
+    // await publicationPostTests(app)
+    // await publicationPatchTests(app)
+    // await readActivityPostTests(app)
+    await publicationBatchUpdateTests(app)
   }
 
   if (!test || test === 'reader') {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -111,12 +111,12 @@ const allTests = async () => {
   }
 
   if (!test || test === 'publication') {
-    // await publicationGetTests(app)
-    // await publicationDeleteTests(app)
-    // await publicationPostTests(app)
-    // await publicationPatchTests(app)
-    // await readActivityPostTests(app)
-    await publicationBatchUpdateTests(app)
+    await publicationGetTests(app)
+    await publicationDeleteTests(app)
+    await publicationPostTests(app)
+    await publicationPatchTests(app)
+    await readActivityPostTests(app)
+    // await publicationBatchUpdateTests(app)
   }
 
   if (!test || test === 'reader') {

--- a/tests/integration/library/library-filter-attribution.test.js
+++ b/tests/integration/library/library-filter-attribution.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-attribution.test.js
+++ b/tests/integration/library/library-filter-attribution.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-collection.test.js
+++ b/tests/integration/library/library-filter-collection.test.js
@@ -19,7 +19,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-collection.test.js
+++ b/tests/integration/library/library-filter-collection.test.js
@@ -1,6 +1,5 @@
 const request = require('supertest')
 const tap = require('tap')
-const urlparse = require('url').parse
 const {
   getToken,
   createUser,
@@ -10,13 +9,10 @@ const {
   createTag
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerUrl = urlparse(readerCompleteUrl).path
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-combined.test.js
+++ b/tests/integration/library/library-filter-combined.test.js
@@ -27,7 +27,7 @@ const test = async () => {
   const researchTagId = _.find(tagsres.body, { name: 'Research' }).id
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-combined.test.js
+++ b/tests/integration/library/library-filter-combined.test.js
@@ -14,8 +14,7 @@ const _ = require('lodash')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   // get reader workspace tags:
   const tagsres = await request(app)

--- a/tests/integration/library/library-filter-keyword.test.js
+++ b/tests/integration/library/library-filter-keyword.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-keyword.test.js
+++ b/tests/integration/library/library-filter-keyword.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-language.test.js
+++ b/tests/integration/library/library-filter-language.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-language.test.js
+++ b/tests/integration/library/library-filter-language.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-search.test.js
+++ b/tests/integration/library/library-filter-search.test.js
@@ -16,7 +16,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({ name: 'Publication 1' })

--- a/tests/integration/library/library-filter-search.test.js
+++ b/tests/integration/library/library-filter-search.test.js
@@ -8,12 +8,9 @@ const {
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
 
-const { urlToId } = require('../../../utils/utils')
-
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-title.test.js
+++ b/tests/integration/library/library-filter-title.test.js
@@ -16,7 +16,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({ name: 'Publication 1' })

--- a/tests/integration/library/library-filter-title.test.js
+++ b/tests/integration/library/library-filter-title.test.js
@@ -8,12 +8,9 @@ const {
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
 
-const { urlToId } = require('../../../utils/utils')
-
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-type.test.js
+++ b/tests/integration/library/library-filter-type.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-filter-type.test.js
+++ b/tests/integration/library/library-filter-type.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-workspace.test.js
+++ b/tests/integration/library/library-filter-workspace.test.js
@@ -14,8 +14,7 @@ const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-filter-workspace.test.js
+++ b/tests/integration/library/library-filter-workspace.test.js
@@ -18,7 +18,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   // get reader workspace tags:

--- a/tests/integration/library/library-get.test.js
+++ b/tests/integration/library/library-get.test.js
@@ -36,7 +36,7 @@ const test = async () => {
   })
 
   await tap.test('Get Library containing a publication', async () => {
-    await createPublication(readerId, {
+    await createPublication(app, token, {
       type: 'Book',
       name: 'Publication A',
       author: ['John Smith'],
@@ -195,7 +195,7 @@ const test = async () => {
     await tap.test(
       'Get Library with if-modified-since header - after publication created',
       async () => {
-        publication = await createPublication(readerId)
+        publication = await createPublication(app, token)
 
         const res = await request(app)
           .get('/library')

--- a/tests/integration/library/library-orderBy-datePublished.test.js
+++ b/tests/integration/library/library-orderBy-datePublished.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-orderBy-datePublished.test.js
+++ b/tests/integration/library/library-orderBy-datePublished.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-orderBy-default.test.js
+++ b/tests/integration/library/library-orderBy-default.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-orderBy-default.test.js
+++ b/tests/integration/library/library-orderBy-default.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-orderBy-title.test.js
+++ b/tests/integration/library/library-orderBy-title.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-orderBy-title.test.js
+++ b/tests/integration/library/library-orderBy-title.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-orderBy-type.test.js
+++ b/tests/integration/library/library-orderBy-type.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({

--- a/tests/integration/library/library-orderBy-type.test.js
+++ b/tests/integration/library/library-orderBy-type.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/library/library-paginate.test.js
+++ b/tests/integration/library/library-paginate.test.js
@@ -15,7 +15,7 @@ const test = async () => {
   const readerId = urlToId(readerCompleteUrl)
 
   const createPublicationSimplified = async object => {
-    return await createPublication(readerId, object)
+    return await createPublication(app, token, object)
   }
 
   await createPublicationSimplified({ name: 'Publication 1' })

--- a/tests/integration/library/library-paginate.test.js
+++ b/tests/integration/library/library-paginate.test.js
@@ -7,12 +7,10 @@ const {
   createPublication
 } = require('../../utils/testUtils')
 const app = require('../../../server').app
-const { urlToId } = require('../../../utils/utils')
 
 const test = async () => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const createPublicationSimplified = async object => {
     return await createPublication(app, token, object)

--- a/tests/integration/note/note-delete.test.js
+++ b/tests/integration/note/note-delete.test.js
@@ -15,13 +15,13 @@ const test = async app => {
   const readerUrl = await createUser(app, token)
   const readerId = urlToId(readerUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationUrl = publication.id
   const publicationId = urlToId(publication.id)
 
   const createdDocument = await createDocument(readerUrl, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const note = await createNote(app, token, readerId, {
     target: { property: 'value' },

--- a/tests/integration/note/note-get.test.js
+++ b/tests/integration/note/note-get.test.js
@@ -17,13 +17,13 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationUrl = publication.id
-  const publicationId = urlToId(publication.id)
+  const publicationId = publication.shortId
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const note = await createNote(app, token, urlToId(readerId), {
     body: { motivation: 'test', content: 'content goes here' },

--- a/tests/integration/note/note-post.test.js
+++ b/tests/integration/note/note-post.test.js
@@ -14,16 +14,16 @@ const test = async app => {
   const readerUrl = await createUser(app, token)
   const readerId = urlToId(readerUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
   const publicationUrl = publication.id
 
-  const publication2 = await createPublication(readerId)
+  const publication2 = await createPublication(app, token)
   const publicationId2 = urlToId(publication2.id)
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   await tap.test('Create Note with single body', async () => {
     const res = await request(app)

--- a/tests/integration/note/note-put.test.js
+++ b/tests/integration/note/note-put.test.js
@@ -15,14 +15,14 @@ const test = async app => {
   const readerUrl = await createUser(app, token)
   const readerId = urlToId(readerUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
 
   const publicationUrl = publication.id
   const publicationId = urlToId(publication.id)
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const note = await createNote(app, token, readerId, {
     body: { content: 'test content', motivation: 'test' },

--- a/tests/integration/noteContext/noteContext-addNote.test.js
+++ b/tests/integration/noteContext/noteContext-addNote.test.js
@@ -20,8 +20,8 @@ const test = async app => {
   const publicationId = urlToId(publication.id)
   const publicationUrl = publication.id
 
-  const publication2 = await createPublication(app, token)
-  const publicationId2 = urlToId(publication2.id)
+  // pub2
+  await createPublication(app, token)
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 

--- a/tests/integration/noteContext/noteContext-addNote.test.js
+++ b/tests/integration/noteContext/noteContext-addNote.test.js
@@ -16,16 +16,16 @@ const test = async app => {
   const readerUrl = await createUser(app, token)
   const readerId = urlToId(readerUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
   const publicationUrl = publication.id
 
-  const publication2 = await createPublication(readerId)
+  const publication2 = await createPublication(app, token)
   const publicationId2 = urlToId(publication2.id)
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const context = await createNoteContext(app, token, {
     type: 'test',

--- a/tests/integration/outline/outline-addNote.test.js
+++ b/tests/integration/outline/outline-addNote.test.js
@@ -17,16 +17,16 @@ const test = async app => {
   const readerUrl = await createUser(app, token)
   const readerId = urlToId(readerUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
   const publicationUrl = publication.id
 
-  const publication2 = await createPublication(readerId)
+  const publication2 = await createPublication(app, token)
   const publicationId2 = urlToId(publication2.id)
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const outline = await createNoteContext(app, token, {
     name: 'my outline',

--- a/tests/integration/outline/outline-deleteNote.test.js
+++ b/tests/integration/outline/outline-deleteNote.test.js
@@ -8,7 +8,6 @@ const {
   createNote,
   addNoteToOutline
 } = require('../../utils/testUtils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/outline/outlline-delete.test.js
+++ b/tests/integration/outline/outlline-delete.test.js
@@ -6,7 +6,6 @@ const {
   destroyDB,
   createNoteContext
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/publication/publication-batchUpdate.test.js
+++ b/tests/integration/publication/publication-batchUpdate.test.js
@@ -209,36 +209,69 @@ const test = async app => {
     }
   )
 
-  // await tap.test(
-  //   'Batch Update Publications - Try to replace with one publication that does not exist',
-  //   async () => {
-  //     const res = await request(app)
-  //       .patch(`/publications/batchUpdate`)
-  //       .set('Host', 'reader-api.test')
-  //       .set('Authorization', `Bearer ${token}`)
-  //       .type('application/ld+json')
-  //       .send(
-  //         JSON.stringify({
-  //           publications: [pub1.shortId, pub2.shortId + 'abc'],
-  //           operation: 'replace',
-  //           property: 'name',
-  //           value: 'new name'
-  //         })
-  //       )
+  await tap.test(
+    'Batch Update Publications - Try to replace with one publication that does not exist',
+    async () => {
+      const res = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            publications: [pub1.shortId, pub2.shortId + 'abc'],
+            operation: 'replace',
+            property: 'name',
+            value: 'new name'
+          })
+        )
 
-  //     await tap.equal(res.status, 400)
-  //     const error = JSON.parse(res.text)
-  //     await tap.equal(error.statusCode, 400)
-  //     await tap.equal(error.error, 'Bad Request')
-  //     await tap.equal(
-  //       error.message,
-  //       `Validation Error on Batch Update Publication: name: should be string`
-  //     )
-  //     await tap.equal(error.details.requestUrl, `/publications/batchUpdate`)
-  //     await tap.type(error.details.requestBody, 'object')
-  //     await tap.equal(error.details.requestBody.operation, 'replace')
-  //   }
-  // )
+      await tap.equal(res.status, 207)
+      const status = res.body.status
+      await tap.equal(status[0].id, pub1.shortId)
+      await tap.equal(status[0].status, 204)
+      await tap.equal(status[1].id, pub2.shortId + 'abc')
+      await tap.equal(status[1].status, 404)
+      await tap.equal(
+        status[1].message,
+        `No Publication found with id ${pub2.shortId}abc`
+      )
+    }
+  )
+
+  await tap.test(
+    'Batch Update Publications - Try to replace with both publications that do not exist',
+    async () => {
+      const res = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            publications: [pub1.shortId + 'abc', pub2.shortId + 'abc'],
+            operation: 'replace',
+            property: 'name',
+            value: 'new name'
+          })
+        )
+
+      await tap.equal(res.status, 207)
+      const status = res.body.status
+      await tap.equal(status[0].id, pub1.shortId + 'abc')
+      await tap.equal(status[0].status, 404)
+      await tap.equal(
+        status[0].message,
+        `No Publication found with id ${pub1.shortId}abc`
+      )
+      await tap.equal(status[1].id, pub2.shortId + 'abc')
+      await tap.equal(status[1].status, 404)
+      await tap.equal(
+        status[1].message,
+        `No Publication found with id ${pub2.shortId}abc`
+      )
+    }
+  )
 
   // await tap.test('Batch Update Publications - add a keyword', async () => {
 

--- a/tests/integration/publication/publication-batchUpdate.test.js
+++ b/tests/integration/publication/publication-batchUpdate.test.js
@@ -506,7 +506,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 2)
       await tap.equal(result[0].status, 404)
       await tap.equal(result[0].id, pub1.shortId + 'abc')
@@ -717,7 +717,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result[0].status, 400)
       await tap.equal(result[0].id, pub1.shortId)
       await tap.equal(
@@ -752,7 +752,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
 
       await tap.equal(result.length, 4)
 
@@ -808,7 +808,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
 
       await tap.equal(result.length, 4)
 
@@ -1044,7 +1044,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 2)
       await tap.equal(result[0].id, pub3.shortId)
       await tap.equal(result[0].status, 204)
@@ -1145,7 +1145,7 @@ const test = async app => {
           })
         )
       await tap.equal(res.status, 207)
-      const status = res.body
+      const status = res.body.status
       await tap.equal(status.length, 4)
 
       await tap.equal(status[0].id, pub1.shortId)
@@ -1218,7 +1218,7 @@ const test = async app => {
         )
 
       await tap.equal(res.status, 207)
-      const status = res.body
+      const status = res.body.status
       await tap.equal(status.length, 4)
 
       await tap.equal(status[0].id, pub1.shortId)
@@ -1423,7 +1423,7 @@ pub3: tag2, tag3, tag4, tag5
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 2)
       await tap.equal(result[0].status, 404)
       await tap.equal(result[0].id, pub1.shortId)
@@ -1468,7 +1468,7 @@ pub3: tag2, tag3, tag4, tag5
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 4)
       await tap.equal(result[0].status, 404)
       await tap.equal(result[0].id, pub2.shortId)
@@ -1521,7 +1521,7 @@ pub3: tag2, tag3, tag4, tag5
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 1)
       await tap.equal(result[0].status, 404)
       await tap.equal(result[0].id, pub2.shortId + 'abc')
@@ -1557,7 +1557,7 @@ pub3: tag2, tag3, tag4, tag5
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 2)
       await tap.equal(result[0].status, 204)
       await tap.equal(result[0].id, pub2.shortId)
@@ -1750,7 +1750,7 @@ pub3: tag4
         )
 
       await tap.equal(res.status, 207)
-      const result = res.body
+      const result = res.body.status
       await tap.equal(result.length, 1)
       await tap.equal(result[0].status, 404)
       await tap.equal(result[0].id, pub2.shortId + 'abc')

--- a/tests/integration/publication/publication-batchUpdate.test.js
+++ b/tests/integration/publication/publication-batchUpdate.test.js
@@ -1,0 +1,180 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerCompleteUrl = await createUser(app, token)
+  const readerId = urlToId(readerCompleteUrl)
+
+  const pub1 = await createPublication(app, token, {
+    type: 'Book',
+    name: 'Publication A',
+    author: ['John Smith'],
+    editor: 'Jané S. Doe',
+    contributor: ['Sample Contributor'],
+    bookFormat: 'EBook',
+    keywords: ['one', 'two']
+  })
+
+  const pub2 = await createPublication(app, token, {
+    type: 'Book',
+    name: 'Publication B',
+    author: ['John Smith'],
+    contributor: ['Contributor1', 'Contributor2'],
+    bookFormat: 'EBook',
+    keywords: ['one']
+  })
+
+  const pub3 = await createPublication(app, token, {
+    type: 'Book',
+    name: 'Publication C'
+  })
+
+  await tap.test('Batch Update Publications - replace type', async () => {
+    const res = await request(app)
+      .patch(`/publications/batchUpdate`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          publications: [pub1.shortId, pub2.shortId],
+          operation: 'replace',
+          property: 'type',
+          value: 'Article'
+        })
+      )
+
+    await tap.equal(res.status, 204)
+
+    const getPub1 = await request(app)
+      .get(`/publications/${pub1.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    const pub1Body = getPub1.body
+    await tap.equal(pub1Body.type, 'Article')
+    await tap.equal(pub1Body.name, 'Publication A')
+
+    const getPub2 = await request(app)
+      .get(`/publications/${pub2.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    const pub2Body = getPub2.body
+    await tap.equal(pub2Body.type, 'Article')
+    await tap.equal(pub2Body.name, 'Publication B')
+  })
+
+  await tap.test(
+    'Batch Update Publications - Try to replace an array property',
+    async () => {
+      const res = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            publications: [pub1.shortId, pub2.shortId],
+            operation: 'replace',
+            property: 'keywords',
+            value: ['one', 'two']
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        `Cannot use 'replace' to update an array property: keywords. Use 'add' or 'remove' instead`
+      )
+      await tap.equal(error.details.requestUrl, `/publications/batchUpdate`)
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.operation, 'replace')
+    }
+  )
+
+  // await tap.test('Batch Update Publications - add a keyword', async () => {
+
+  //   const res = await request(app)
+  //     .patch(`/publications/batchUpdate`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type('application/ld+json')
+  //     .send(
+  //       JSON.stringify({
+  //         publications: [pub1.shortId, pub3.shortId],
+  //         operation: 'add',
+  //         property: 'keywords',
+  //         value: ['three']
+  //       })
+  //     )
+
+  //   await tap.equal(res.status, 200)
+  //   const status = res.body.status
+  //   await res.equal(status.length, 2)
+  //   const index1 = _.findIndex(status, {publicationId: pub1.shortId})
+  //   await res.equal(status[index1].statusCode, 200)
+  //   await res.equal(status[index1].body.shortId, pub1.shortId)
+  //   await res.equal(status[index1].keywords.length, 3)
+  //   await res.ok(_.find(status[index1].keywords, 'one'))
+  //   await res.ok(_.find(status[index1].keywords, 'two'))
+  //   await res.ok(_.find(status[index1].keywords, 'three'))
+
+  //   const index3 = _.findIndex(status, {publicationId: pub3.shortId})
+  //   await res.equal(status[index3].statusCode, 200)
+  //   await res.equal(status[index3].body.shortId, pub3.shortId)
+  //   await res.equal(status[index3].keywords.length, 1)
+  //   await res.equal(status[index3].keywords[0], 'three')
+  // })
+
+  // await tap.test('Batch Update Publications - remove a keyword', async () => {
+
+  //   const res = await request(app)
+  //     .patch(`/publications/batchUpdate`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type('application/ld+json')
+  //     .send(
+  //       JSON.stringify({
+  //         publications: [pub1.shortId, pub2.shortId],
+  //         operation: 'remove',
+  //         property: 'keywords',
+  //         value: ['one', 'two']
+  //       })
+  //     )
+
+  //   await tap.equal(res.status, 200)
+  //   const status = res.body.status
+  //   await res.equal(status.length, 2)
+  //   const index1 = _.findIndex(status, {publicationId: pub1.shortId})
+  //   await res.equal(status[index1].statusCode, 200)
+  //   await res.equal(status[index1].body.shortId, pub1.shortId)
+  //   await res.equal(status[index1].keywords.length, 1)
+  //   await res.equal(status[index1].keywords[0], 'three')
+  //   await res.ok(_.find(status[index1].keywords, ''))
+  //   await res.ok(_.find(status[index1].keywords, 'two'))
+  //   await res.ok(_.find(status[index1].keywords, 'three'))
+
+  //   const index2 = _.findIndex(status, {publicationId: pub2.shortId})
+  //   await res.equal(status[index2].statusCode, 200)
+  //   await res.equal(status[index2].body.shortId, pub2.shortId)
+  //   await res.equal(status[index2].keywords.length, 0)
+  // })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/publication/publication-batchUpdate.test.js
+++ b/tests/integration/publication/publication-batchUpdate.test.js
@@ -34,7 +34,8 @@ const test = async app => {
 
   const pub3 = await createPublication(app, token, {
     type: 'Book',
-    name: 'Publication C'
+    name: 'Publication C',
+    keywords: []
   })
 
   await tap.test('Batch Update Publications - replace type', async () => {
@@ -273,39 +274,46 @@ const test = async app => {
     }
   )
 
-  // await tap.test('Batch Update Publications - add a keyword', async () => {
+  await tap.test('Batch Update Publications - add a keyword', async () => {
+    const res = await request(app)
+      .patch(`/publications/batchUpdate`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          publications: [pub1.shortId, pub3.shortId],
+          operation: 'add',
+          property: 'keywords',
+          value: ['three']
+        })
+      )
 
-  //   const res = await request(app)
-  //     .patch(`/publications/batchUpdate`)
-  //     .set('Host', 'reader-api.test')
-  //     .set('Authorization', `Bearer ${token}`)
-  //     .type('application/ld+json')
-  //     .send(
-  //       JSON.stringify({
-  //         publications: [pub1.shortId, pub3.shortId],
-  //         operation: 'add',
-  //         property: 'keywords',
-  //         value: ['three']
-  //       })
-  //     )
+    await tap.equal(res.status, 204)
 
-  //   await tap.equal(res.status, 200)
-  //   const status = res.body.status
-  //   await res.equal(status.length, 2)
-  //   const index1 = _.findIndex(status, {publicationId: pub1.shortId})
-  //   await res.equal(status[index1].statusCode, 200)
-  //   await res.equal(status[index1].body.shortId, pub1.shortId)
-  //   await res.equal(status[index1].keywords.length, 3)
-  //   await res.ok(_.find(status[index1].keywords, 'one'))
-  //   await res.ok(_.find(status[index1].keywords, 'two'))
-  //   await res.ok(_.find(status[index1].keywords, 'three'))
+    const getPub1 = await request(app)
+      .get(`/publications/${pub1.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
 
-  //   const index3 = _.findIndex(status, {publicationId: pub3.shortId})
-  //   await res.equal(status[index3].statusCode, 200)
-  //   await res.equal(status[index3].body.shortId, pub3.shortId)
-  //   await res.equal(status[index3].keywords.length, 1)
-  //   await res.equal(status[index3].keywords[0], 'three')
-  // })
+    const pub1Body = getPub1.body
+    console.log(pub1Body)
+    await tap.equal(pub1Body.keywords[0], 'one')
+    await tap.equal(pub1Body.keywords[1], 'two')
+    await tap.equal(pub1Body.keywords[2], 'three')
+    await tap.equal(pub1Body.name, 'Publication A')
+
+    const getPub3 = await request(app)
+      .get(`/publications/${pub3.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    const pub3Body = getPub3.body
+    await tap.equal((pub3Body.keywords[0] = 'three'))
+    await tap.equal(pub3Body.name, 'Publication C')
+  })
 
   // await tap.test('Batch Update Publications - remove a keyword', async () => {
 

--- a/tests/integration/publication/publication-delete.test.js
+++ b/tests/integration/publication/publication-delete.test.js
@@ -62,12 +62,12 @@ const test = async app => {
     json: { property: 'value' }
   }
 
-  const resCreatePub = await createPublication(readerId, publicationObject)
+  const resCreatePub = await createPublication(app, token, publicationObject)
   const publicationUrl = resCreatePub.id
   const publicationId = urlToId(resCreatePub.id)
 
   // second publication
-  await createPublication(readerId)
+  await createPublication(app, token)
 
   await tap.test('Delete Publication', async () => {
     // Create a Document for that publication

--- a/tests/integration/publication/publication-get.test.js
+++ b/tests/integration/publication/publication-get.test.js
@@ -73,7 +73,7 @@ const test = async app => {
     json: { property: 'value' }
   }
 
-  const resCreatePub = await createPublication(readerId, publicationObject)
+  const resCreatePub = await createPublication(app, token, publicationObject)
   const publicationUrl = resCreatePub.id
   const publicationId = urlToId(publicationUrl)
 

--- a/tests/integration/publication/publication-patch.test.js
+++ b/tests/integration/publication/publication-patch.test.js
@@ -73,7 +73,7 @@ const test = async app => {
     json: { property: 'value' }
   }
 
-  const resCreatePub = await createPublication(readerId, publicationObject)
+  const resCreatePub = await createPublication(app, token, publicationObject)
   const publicationUrl = resCreatePub.id
   const publicationId = urlToId(publicationUrl)
 

--- a/tests/integration/publication/publication-patch.test.js
+++ b/tests/integration/publication/publication-patch.test.js
@@ -10,8 +10,7 @@ const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const now = new Date().toISOString()
 

--- a/tests/integration/publication/publication-patch.test.js
+++ b/tests/integration/publication/publication-patch.test.js
@@ -151,6 +151,181 @@ const test = async app => {
     await tap.equal(body.translator[0].name, 'Sample Translator2')
   })
 
+  await tap.test('Update a single property', async () => {
+    const res = await request(app)
+      .patch(`/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          abstract: 'new new!'
+        })
+      )
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(body.name, 'New name for pub A')
+    await tap.equal(body.abstract, 'new new!')
+    // await tap.equal(body.datePublished, timestamp)
+    await tap.equal(body.json.property, 'New value for json property')
+    await tap.equal(body.numberOfPages, 444)
+    await tap.equal(body.encodingFormat, 'new')
+    await tap.equal(body.url, 'http://www.something2.com')
+    await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
+    await tap.equal(body.bookEdition, 'fourth')
+    await tap.equal(body.isbn, '12345')
+    await tap.equal(body.copyrightYear, 1978)
+    await tap.equal(body.genre, 'elf romance')
+    await tap.equal(body.license, 'http://www.mylicense2.com')
+    await tap.equal(body.inLanguage[0], 'en')
+    await tap.equal(body.inLanguage[1], 'fr')
+    await tap.equal(body.keywords[0], 'newkeyword1') // turned to lowercase
+    await tap.equal(body.keywords[1], 'newkeyword2')
+    await tap.ok(
+      body.author[0].name === 'New Org inc.' ||
+        body.author[0].name === 'New Sample Author'
+    )
+    await tap.ok(
+      body.author[1].name === 'New Org inc.' ||
+        body.author[1].name === 'New Sample Author'
+    )
+    await tap.equal(body.editor[0].name, 'New Sample Editor')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+    await tap.equal(body.creator[0].name, 'Sample Creator')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+    await tap.equal(body.translator[0].name, 'Sample Translator2')
+  })
+
+  await tap.test('Update a single attribution', async () => {
+    const res = await request(app)
+      .patch(`/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          author: 'new new author'
+        })
+      )
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(body.name, 'New name for pub A')
+    await tap.equal(body.abstract, 'new new!')
+    // await tap.equal(body.datePublished, timestamp)
+    await tap.equal(body.json.property, 'New value for json property')
+    await tap.equal(body.numberOfPages, 444)
+    await tap.equal(body.encodingFormat, 'new')
+    await tap.equal(body.url, 'http://www.something2.com')
+    await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
+    await tap.equal(body.bookEdition, 'fourth')
+    await tap.equal(body.isbn, '12345')
+    await tap.equal(body.copyrightYear, 1978)
+    await tap.equal(body.genre, 'elf romance')
+    await tap.equal(body.license, 'http://www.mylicense2.com')
+    await tap.equal(body.inLanguage[0], 'en')
+    await tap.equal(body.inLanguage[1], 'fr')
+    await tap.equal(body.keywords[0], 'newkeyword1') // turned to lowercase
+    await tap.equal(body.keywords[1], 'newkeyword2')
+    await tap.ok(body.author[0].name === 'new new author')
+    await tap.equal(body.author.length, 1)
+    await tap.equal(body.editor[0].name, 'New Sample Editor')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+    await tap.equal(body.creator[0].name, 'Sample Creator')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+    await tap.equal(body.translator[0].name, 'Sample Translator2')
+  })
+
+  await tap.test('Update a single metadata property', async () => {
+    // const timestamp = new Date(2018, 01, 30).toISOString()
+    const res = await request(app)
+      .patch(`/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          isbn: '111'
+        })
+      )
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(body.name, 'New name for pub A')
+    await tap.equal(body.abstract, 'new new!')
+    // await tap.equal(body.datePublished, timestamp)
+    await tap.equal(body.json.property, 'New value for json property')
+    await tap.equal(body.numberOfPages, 444)
+    await tap.equal(body.encodingFormat, 'new')
+    await tap.equal(body.url, 'http://www.something2.com')
+    await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
+    await tap.equal(body.bookEdition, 'fourth')
+    await tap.equal(body.isbn, '111')
+    await tap.equal(body.copyrightYear, 1978)
+    await tap.equal(body.genre, 'elf romance')
+    await tap.equal(body.license, 'http://www.mylicense2.com')
+    await tap.equal(body.inLanguage[0], 'en')
+    await tap.equal(body.inLanguage[1], 'fr')
+    await tap.equal(body.keywords[0], 'newkeyword1') // turned to lowercase
+    await tap.equal(body.keywords[1], 'newkeyword2')
+    await tap.ok(body.author[0].name === 'new new author')
+    await tap.equal(body.author.length, 1)
+    await tap.equal(body.editor[0].name, 'New Sample Editor')
+    await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+    await tap.equal(body.creator[0].name, 'Sample Creator')
+    await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+    await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+    await tap.equal(body.translator[0].name, 'Sample Translator2')
+  })
+
+  await tap.test(
+    'Update a single metadata property by setting it to null',
+    async () => {
+      // const timestamp = new Date(2018, 01, 30).toISOString()
+      const res = await request(app)
+        .patch(`/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            genre: null
+          })
+        )
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.shortId, urlToId(body.id))
+      await tap.equal(body.name, 'New name for pub A')
+      await tap.equal(body.abstract, 'new new!')
+      // await tap.equal(body.datePublished, timestamp)
+      await tap.equal(body.json.property, 'New value for json property')
+      await tap.equal(body.numberOfPages, 444)
+      await tap.equal(body.encodingFormat, 'new')
+      await tap.equal(body.url, 'http://www.something2.com')
+      await tap.equal(body.dateModified, new Date(2012, 3, 22).toISOString())
+      await tap.equal(body.bookEdition, 'fourth')
+      await tap.equal(body.isbn, '111')
+      await tap.equal(body.copyrightYear, 1978)
+      await tap.notOk(body.genre)
+      await tap.equal(body.license, 'http://www.mylicense2.com')
+      await tap.equal(body.inLanguage[0], 'en')
+      await tap.equal(body.inLanguage[1], 'fr')
+      await tap.equal(body.keywords[0], 'newkeyword1') // turned to lowercase
+      await tap.equal(body.keywords[1], 'newkeyword2')
+      await tap.ok(body.author[0].name === 'new new author')
+      await tap.equal(body.author.length, 1)
+      await tap.equal(body.editor[0].name, 'New Sample Editor')
+      await tap.equal(body.contributor[0].name, 'Sample Contributor2')
+      await tap.equal(body.creator[0].name, 'Sample Creator')
+      await tap.equal(body.illustrator[0].name, 'Sample Illustrator2')
+      await tap.equal(body.publisher[0].name, 'Sample Publisher2')
+      await tap.equal(body.translator[0].name, 'Sample Translator2')
+    }
+  )
+
   await tap.test(
     'Update a publication by setting a value to null',
     async () => {

--- a/tests/integration/publication/readActivity-post.test.js
+++ b/tests/integration/publication/readActivity-post.test.js
@@ -66,7 +66,7 @@ const test = async app => {
       )
 
     // Get the latests ReadActivity
-    const latestAct = await ReadActivity.getLatestReadActivity(publicationId)
+    await ReadActivity.getLatestReadActivity(publicationId)
     await tap.equal(readActivity.statusCode, 201)
     const body = readActivity.body
     await tap.equal(body.selector.type, 'XPathSelector')

--- a/tests/integration/publication/readActivity-post.test.js
+++ b/tests/integration/publication/readActivity-post.test.js
@@ -21,7 +21,7 @@ const test = async app => {
   const reader1 = await Reader.createReader(readerId, person)
 
   // Create Publication
-  const publication = await createPublication(urlToId(readerId))
+  const publication = await createPublication(app, token, urlToId(readerId))
   const publicationId = urlToId(publication.id)
 
   await tap.test('Create Read activity with only a selector', async () => {

--- a/tests/integration/readerNotes/readerNotes-filter-collection.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-collection.test.js
@@ -4,14 +4,11 @@ const {
   getToken,
   createUser,
   destroyDB,
-  createPublication,
   createNote,
-  createDocument,
   createTag,
   addNoteToCollection
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/readerNotes/readerNotes-filter-combined.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-combined.test.js
@@ -17,14 +17,14 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
   const publicationId1 = urlToId(publicationUrl)
 
   // create another publication
-  const publication2 = await createPublication(urlToId(readerId), {
+  const publication2 = await createPublication(app, token, {
     name: 'Publication B'
   })
   const publicationUrl2 = publication2.id
@@ -44,8 +44,8 @@ const test = async app => {
     url: 'http://something/124'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
-  const documentUrl2 = `${publicationUrl2}/${createdDocument2.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
+  const documentUrl2 = `${publicationUrl2}${createdDocument2.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-filter-dateRange.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-dateRange.test.js
@@ -4,14 +4,9 @@ const {
   getToken,
   createUser,
   destroyDB,
-  createPublication,
-  createNote,
-  createDocument,
-  createTag,
-  addNoteToCollection
+  createNote
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/readerNotes/readerNotes-filter-document.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-document.test.js
@@ -9,7 +9,6 @@ const {
   createDocument
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/readerNotes/readerNotes-filter-document.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-document.test.js
@@ -16,13 +16,13 @@ const test = async app => {
   const readerId = await createUser(app, token)
 
   // create two publications:
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
   const publicationId1 = urlToId(publicationUrl)
 
-  const publication2 = await createPublication(urlToId(readerId), {
+  const publication2 = await createPublication(app, token, {
     name: 'Publication B'
   })
   const publicationUrl2 = publication2.id
@@ -41,8 +41,8 @@ const test = async app => {
     url: 'http://something/124'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
-  const documentUrl2 = `${publicationUrl2}/${createdDocument2.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
+  const documentUrl2 = `${publicationUrl2}${createdDocument2.documentPath}`
 
   // create a whole bunch of notes:
   const createNoteSimplified = async object => {

--- a/tests/integration/readerNotes/readerNotes-filter-motivation.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-motivation.test.js
@@ -6,12 +6,9 @@ const {
   destroyDB,
   createPublication,
   createNote,
-  createDocument,
-  createTag,
-  addNoteToCollection
+  createDocument
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()
@@ -82,8 +79,6 @@ const test = async app => {
     publicationId: publicationId2,
     documentUrl: documentUrl2
   })
-
-  let noteId1, noteId2, noteId3
 
   await createNoteSimplified({
     publicationId: publicationId2,

--- a/tests/integration/readerNotes/readerNotes-filter-motivation.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-motivation.test.js
@@ -17,14 +17,14 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
   const publicationId1 = urlToId(publicationUrl)
 
   // create another publication
-  const publication2 = await createPublication(urlToId(readerId), {
+  const publication2 = await createPublication(app, token, {
     name: 'Publication B'
   })
   const publicationUrl2 = publication2.id
@@ -44,8 +44,8 @@ const test = async app => {
     url: 'http://something/124'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
-  const documentUrl2 = `${publicationUrl2}/${createdDocument2.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
+  const documentUrl2 = `${publicationUrl2}${createdDocument2.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-filter-publication.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-publication.test.js
@@ -9,7 +9,6 @@ const {
   createDocument
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/readerNotes/readerNotes-filter-publication.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-publication.test.js
@@ -15,14 +15,14 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
   const publicationId1 = urlToId(publicationUrl)
 
   // create another publication
-  const publication2 = await createPublication(urlToId(readerId), {
+  const publication2 = await createPublication(app, token, {
     name: 'Publication B'
   })
   const publicationUrl2 = publication2.id
@@ -42,8 +42,8 @@ const test = async app => {
     url: 'http://something/124'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
-  const documentUrl2 = `${publicationUrl2}/${createdDocument2.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
+  const documentUrl2 = `${publicationUrl2}${createdDocument2.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-filter-search.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-search.test.js
@@ -17,14 +17,14 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
   const publicationId1 = urlToId(publicationUrl)
 
   // create another publication
-  const publication2 = await createPublication(urlToId(readerId), {
+  const publication2 = await createPublication(app, token, {
     name: 'Publication B'
   })
   const publicationUrl2 = publication2.id
@@ -44,8 +44,8 @@ const test = async app => {
     url: 'http://something/124'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
-  const documentUrl2 = `${publicationUrl2}/${createdDocument2.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
+  const documentUrl2 = `${publicationUrl2}${createdDocument2.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-filter-search.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-search.test.js
@@ -6,12 +6,9 @@ const {
   destroyDB,
   createPublication,
   createNote,
-  createDocument,
-  createTag,
-  addNoteToCollection
+  createDocument
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
-const _ = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/readerNotes/readerNotes-get.test.js
+++ b/tests/integration/readerNotes/readerNotes-get.test.js
@@ -19,7 +19,7 @@ const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
@@ -31,7 +31,7 @@ const test = async app => {
     url: 'http://something/123'
   })
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-orderBy.test.js
+++ b/tests/integration/readerNotes/readerNotes-orderBy.test.js
@@ -13,7 +13,7 @@ const { urlToId } = require('../../../utils/utils')
 const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
@@ -21,7 +21,7 @@ const test = async app => {
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-paginate.test.js
+++ b/tests/integration/readerNotes/readerNotes-paginate.test.js
@@ -16,7 +16,7 @@ const test = async app => {
   const readerId = await createUser(app, token)
   const readerUrl = `/readers/${urlToId(readerId)}`
 
-  const publication = await createPublication(urlToId(readerId), {
+  const publication = await createPublication(app, token, {
     name: 'Publication A'
   })
   const publicationUrl = publication.id
@@ -24,7 +24,7 @@ const test = async app => {
 
   const createdDocument = await createDocument(readerId, publicationUrl)
 
-  const documentUrl = `${publicationUrl}/${createdDocument.documentPath}`
+  const documentUrl = `${publicationUrl}${createdDocument.documentPath}`
 
   const createNoteSimplified = async object => {
     const noteObj = Object.assign(

--- a/tests/integration/readerNotes/readerNotes-paginate.test.js
+++ b/tests/integration/readerNotes/readerNotes-paginate.test.js
@@ -14,7 +14,6 @@ const { urlToId } = require('../../../utils/utils')
 const test = async app => {
   const token = getToken()
   const readerId = await createUser(app, token)
-  const readerUrl = `/readers/${urlToId(readerId)}`
 
   const publication = await createPublication(app, token, {
     name: 'Publication A'

--- a/tests/integration/tag/publication-tag-delete.test.js
+++ b/tests/integration/tag/publication-tag-delete.test.js
@@ -15,7 +15,7 @@ const test = async app => {
   const readerCompleteUrl = await createUser(app, token)
   const readerId = urlToId(readerCompleteUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
 
   const invalidTagId = `${readerId}-123` // including readerId to avoid 403 error

--- a/tests/integration/tag/publication-tag-put.test.js
+++ b/tests/integration/tag/publication-tag-put.test.js
@@ -14,7 +14,7 @@ const test = async app => {
   const readerCompleteUrl = await createUser(app, token)
   const readerId = urlToId(readerCompleteUrl)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
   const publicationId = urlToId(publication.id)
 
   const invalidTagId = `${readerId}-123` // including readerId to avoid 403 error

--- a/tests/integration/tag/tag-delete.test.js
+++ b/tests/integration/tag/tag-delete.test.js
@@ -25,7 +25,7 @@ const test = async app => {
   }
   const reader1 = await Reader.createReader(readerId, person)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
 
   // Create a Document for that publication
   const documentObject = {
@@ -40,7 +40,7 @@ const test = async app => {
     documentObject
   )
 
-  const documentUrl = `${publication.id}/${document.documentPath}`
+  const documentUrl = `${publication.id}${document.documentPath}`
 
   // create Note for reader 1
   const note = await createNote(app, token, readerId, {

--- a/tests/integration/tag/tag-note-delete.test.js
+++ b/tests/integration/tag/tag-note-delete.test.js
@@ -23,7 +23,7 @@ const test = async app => {
   }
   await Reader.createReader(readerId, person)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
 
   // create Note for reader 1
   const note = await createNote(app, token, readerId, {

--- a/tests/integration/tag/tag-note-put.test.js
+++ b/tests/integration/tag/tag-note-put.test.js
@@ -23,7 +23,7 @@ const test = async app => {
   }
   const reader1 = await Reader.createReader(readerId, person)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
 
   // Create a Document for that publication
   const documentObject = {
@@ -38,7 +38,7 @@ const test = async app => {
     documentObject
   )
 
-  const documentUrl = `${publication.id}/${document.documentPath}`
+  const documentUrl = `${publication.id}${document.documentPath}`
 
   // create Note for reader 1
   const note = await createNote(app, token, readerId, {

--- a/tests/integration/tag/tag-put.test.js
+++ b/tests/integration/tag/tag-put.test.js
@@ -26,7 +26,7 @@ const test = async app => {
   }
   const reader1 = await Reader.createReader(readerId, person)
 
-  const publication = await createPublication(readerId)
+  const publication = await createPublication(app, token)
 
   // Create a Document for that publication
   const documentObject = {
@@ -41,7 +41,7 @@ const test = async app => {
     documentObject
   )
 
-  const documentUrl = `${publication.id}/${document.documentPath}`
+  const documentUrl = `${publication.id}${document.documentPath}`
 
   // create Note for reader 1
   const note = await createNote(app, token, readerId, {

--- a/tests/models/Publication.test.js
+++ b/tests/models/Publication.test.js
@@ -285,11 +285,9 @@ const test = async app => {
       name: 'New name for pub A'
     }
 
-    const pub = await Publication.byId(urlToId(publication.id))
     // Update the publication
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
-
     // Retrieve the Publication that has just been updated
     const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
@@ -304,13 +302,11 @@ const test = async app => {
       datePublished: timestamp
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
-
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
     await tap.equal(
@@ -324,12 +320,10 @@ const test = async app => {
       abstract: 'New description for Publication'
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
-
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -341,12 +335,11 @@ const test = async app => {
       json: { property: 'New value for json property' }
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -358,12 +351,11 @@ const test = async app => {
       numberOfPages: 555
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -375,12 +367,11 @@ const test = async app => {
       encodingFormat: 'pdf'
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -392,12 +383,11 @@ const test = async app => {
       type: 'Article'
     }
 
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -409,12 +399,11 @@ const test = async app => {
       inLanguage: ['en', 'fr'],
       keywords: ['newKeyWord1', 'newKeyWord2']
     }
-    const pub = await Publication.byId(publicationId)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     // Retrieve the Publication that has just been updated
-    const pubRetrieved = await Publication.byId(urlToId(publicationId))
+    const pubRetrieved = await Publication.byId(urlToId(publication.id))
 
     await tap.ok(newPub)
     await tap.ok(newPub instanceof Publication)
@@ -445,8 +434,7 @@ const test = async app => {
       editor: [{ type: 'Person', name: 'New Sample Editor' }]
     }
 
-    const pub = await Publication.byId(publicationId2)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     const attributions = await Attribution.getAttributionByPubId(publicationId2)
@@ -510,8 +498,7 @@ const test = async app => {
       translator: ['New Sample Translator']
     }
 
-    const pub = await Publication.byId(publicationId2)
-    const newPub = await pub.update(newPubObj)
+    const newPub = await Publication.update(publication, newPubObj)
     await tap.notOk(newPub instanceof Error)
 
     const attributions = await Attribution.getAttributionByPubId(publicationId2)

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -48,7 +48,7 @@ const destroyDB = async app => {
   }
 }
 
-const createPublication = async (readerId, object = {}) => {
+const createPublication = async (app, token, object = {}) => {
   const publicationDate = new Date(2002, 12, 25).toISOString()
   const pubObject = Object.assign(
     {
@@ -107,7 +107,15 @@ const createPublication = async (readerId, object = {}) => {
     },
     object
   )
-  return await Publication.createPublication({ id: readerId }, pubObject)
+
+  const response = await request(app)
+    .post('/publications')
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+    .send(JSON.stringify(pubObject))
+
+  return response.body
 }
 
 const createNote = async (app, token, readerId, object = {}) => {

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -1,12 +1,10 @@
 const jwt = require('jsonwebtoken')
 const request = require('supertest')
 const knexCleaner = require('knex-cleaner')
-const _ = require('lodash')
 const { Document } = require('../../models/Document')
 const { urlToId } = require('../../utils/utils')
 require('dotenv').config()
 const crypto = require('crypto')
-const { Publication } = require('../../models/Publication')
 
 const getToken = () => {
   const options = {


### PR DESCRIPTION
Finally!

I don't know that everything is super consistent with this endpoint. In fact, I know some things will be weird. If it causes problems, I will look at making some adjustments, but so far this was the easiest way to do.

So the endpoint is:
/publications/batchUpdate
It expects a request object: 
{
publications: [list of pubIds],
property: '',
value: (usually a string or an array of strings if you want to add/remove multiple items)
operation: 'replace', 'add', or 'remove'
}

The possible responses:
204 if everything went well.
In most cases, if there is an error, it will return a 207 status with a list of status objects. for example:
{
  id: publicationId,
  status: 400,
  message: '....'
  value: 'value'
}
The list can contain only errors or a mix of errors and 204 status.
The message is only there for error status. The value is not always returned, only when it is necessary.
In cases when you  send multiple values to multiple publications, you might get more status than expected. You MAY get a status for each pub-value combination. 

You can also have a 400 error if the request object doesn't make sense. 

Note that 403 errors will be passed in the list of status under a 207 status. 

Not sure if any of this makes sense. 

