### PR TITLE
Delete reader

### DIFF
--- a/models/Attribution.js
+++ b/models/Attribution.js
@@ -235,6 +235,18 @@ class Attribution extends BaseModel {
       .andWhere('publicationId', '=', publicationId)
       .del()
   }
+
+  $beforeUpdate (queryOptions /*: any */, context /*: any */) {
+    const parent = super.$beforeUpdate(queryOptions, context)
+    let doc = this
+    return Promise.resolve(parent).then(function () {
+      doc.updated = undefined
+
+      Object.keys(doc).forEach(
+        key => (doc[key] === undefined ? delete doc[key] : '')
+      )
+    })
+  }
 }
 
 module.exports = { Attribution }

--- a/models/Publication.js
+++ b/models/Publication.js
@@ -975,10 +975,14 @@ class Publication extends BaseModel {
     }
     let updatedPub
     try {
-      updatedPub = await Publication.query().patchAndFetchById(
-        id,
-        modifications
-      )
+      if (_.isEmpty(modifications)) {
+        updatedPub = await Publication.query().findById(id)
+      } else {
+        updatedPub = await Publication.query().patchAndFetchById(
+          id,
+          modifications
+        )
+      }
     } catch (err) {
       throw err
     }

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -8,6 +8,10 @@ const { Job } = require('./Job')
 const { Tag } = require('./Tag')
 const { Attribution } = require('./Attribution')
 const { urlToId } = require('../utils/utils')
+const { Document } = require('./Document')
+const { NoteContext } = require('./NoteContext')
+const { NoteBody } = require('./NoteBody')
+const { NoteRelation } = require('./NoteRelation')
 
 const short = require('short-uuid')
 const translator = short()
@@ -54,7 +58,7 @@ class Reader extends BaseModel {
   ) /*: Promise<ReaderType> */ {
     const qb = Reader.query(Reader.knex()).where('id', '=', id)
     const readers = await qb.withGraphFetched(eager)
-
+    if (readers.length === 0 || readers[0].deleted) return null
     return readers[0]
   }
 
@@ -66,12 +70,12 @@ class Reader extends BaseModel {
       '=',
       authId
     )
-    return readers.length > 0
+    return readers.length > 0 && !readers[0].deleted
   }
 
   static async checkIfExistsById (id /*: string */) /*: Promise<boolean> */ {
     const readers = await Reader.query(Reader.knex()).where('id', '=', id)
-    return readers.length > 0
+    return readers.length > 0 && !readers[0].deleted
   }
 
   static async createReader (
@@ -189,6 +193,7 @@ class Reader extends BaseModel {
         },
         published: { type: 'string', format: 'date-time' },
         updated: { type: 'string', format: 'date-time' },
+        deleted: { type: 'string', format: 'date-time' },
         json: {
           type: ['object', 'null'],
           additionalProperties: true
@@ -212,8 +217,36 @@ class Reader extends BaseModel {
     return await Reader.query().updateAndFetchById(urlToId(id), modifications)
   }
 
+  static async softDelete (id /*: string */) /*: Promise<number> */ {
+    id = urlToId(id)
+    const now = new Date().toISOString()
+    await Publication.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    // await Document.query().patch({deleted: now}).where('readerId', '=', id)
+    await NoteContext.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    await Note.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    await Tag.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    await Attribution.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    await NoteBody.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+    await NoteRelation.query()
+      .patch({ deleted: now })
+      .where('readerId', '=', id)
+
+    return await Reader.query().patchAndFetchById(id, { deleted: now })
+  }
+
   static get relationMappings () /*: any */ {
-    const { Document } = require('./Document')
     return {
       publications: {
         relation: Model.HasManyRelation,

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -70,9 +70,13 @@ class Reader extends BaseModel {
       '=',
       authId
     )
-    return readers.length > 0 && !readers[0].deleted
+    return readers.length > 0
   }
 
+  /**
+   *
+   * Important: will return true if the Reader has been soft-deleted
+   */
   static async checkIfExistsById (id /*: string */) /*: Promise<boolean> */ {
     const readers = await Reader.query(Reader.knex()).where('id', '=', id)
     return readers.length > 0 && !readers[0].deleted

--- a/routes/library-get.js
+++ b/routes/library-get.js
@@ -161,9 +161,9 @@ module.exports = app => {
           )
         })
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No Reader found with id ${req.user}`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/note-delete-tag.js
+++ b/routes/note-delete-tag.js
@@ -46,7 +46,7 @@ module.exports = function (app) {
       const tagId = req.params.tagId
       Reader.byAuthId(req.user)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
               boom.notFound(`No reader with this token`, {
                 requestUrl: req.originalUrl

--- a/routes/note-delete-tag.js
+++ b/routes/note-delete-tag.js
@@ -48,7 +48,7 @@ module.exports = function (app) {
         .then(reader => {
           if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/note-delete.js
+++ b/routes/note-delete.js
@@ -39,7 +39,14 @@ module.exports = function (app) {
 
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader || !checkOwnership(reader.id, noteId)) {
+        if (!reader || reader.deleted) {
+          return next(
+            boom.notFound('No reader found with this token', {
+              requestUrl: req.originalUrl
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, noteId)) {
           return next(
             boom.forbidden(`Access to Note ${noteId} disallowed`, {
               requestUrl: req.originalUrl

--- a/routes/note-post.js
+++ b/routes/note-post.js
@@ -43,9 +43,9 @@ module.exports = function (app) {
   router.route('/notes').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/note-put-tag.js
+++ b/routes/note-put-tag.js
@@ -48,9 +48,9 @@ module.exports = function (app) {
       const tagId = req.params.tagId
       Reader.byAuthId(req.user)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/note-put.js
+++ b/routes/note-put.js
@@ -52,7 +52,15 @@ module.exports = function (app) {
 
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader || !checkOwnership(reader.id, noteId)) {
+        if (!reader || reader.deleted) {
+          return next(
+            boom.notFound('No reader found with this token', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, noteId)) {
           return next(
             boom.forbidden(`Access to Note ${noteId} disallowed`, {
               requestUrl: req.originalUrl,

--- a/routes/noteContext-addNote.js
+++ b/routes/noteContext-addNote.js
@@ -57,9 +57,9 @@ module.exports = function (app) {
     .post(jwtAuth, function (req, res, next) {
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.unauthorized(`No user found for this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl,
                 requestBody: req.body
               })

--- a/routes/noteContext-delete.js
+++ b/routes/noteContext-delete.js
@@ -39,9 +39,9 @@ module.exports = function (app) {
   router.route('/noteContexts/:id').delete(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteContext-post.js
+++ b/routes/noteContext-post.js
@@ -41,9 +41,9 @@ module.exports = function (app) {
   router.route('/noteContexts').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteContext-put.js
+++ b/routes/noteContext-put.js
@@ -44,9 +44,9 @@ module.exports = function (app) {
   router.route('/noteContexts/:id').put(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteRelation-delete.js
+++ b/routes/noteRelation-delete.js
@@ -39,9 +39,9 @@ module.exports = function (app) {
   router.route('/noteRelations/:id').delete(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteRelation-post.js
+++ b/routes/noteRelation-post.js
@@ -46,7 +46,7 @@ module.exports = function (app) {
       .then(async reader => {
         if (!reader || reader.deleted) {
           return next(
-            boom.notFound(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteRelation-post.js
+++ b/routes/noteRelation-post.js
@@ -44,9 +44,9 @@ module.exports = function (app) {
   router.route('/noteRelations').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No user found for this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/noteRelation-put.js
+++ b/routes/noteRelation-put.js
@@ -45,9 +45,9 @@ module.exports = function (app) {
   router.route('/noteRelations/:id').put(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/outline-addNote.js
+++ b/routes/outline-addNote.js
@@ -55,9 +55,9 @@ module.exports = function (app) {
   router.route('/outlines/:id/notes').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/outline-delete.js
+++ b/routes/outline-delete.js
@@ -39,9 +39,9 @@ module.exports = function (app) {
   router.route('/outlines/:id').delete(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound('No reader found with this token', {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/outline-deleteNote.js
+++ b/routes/outline-deleteNote.js
@@ -47,9 +47,9 @@ module.exports = function (app) {
     .delete(jwtAuth, function (req, res, next) {
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.unauthorized(`No user found for this token`, {
+              boom.notFound('No reader found with this token', {
                 requestUrl: req.originalUrl,
                 requestBody: req.body
               })

--- a/routes/outline-patchNote.js
+++ b/routes/outline-patchNote.js
@@ -57,9 +57,9 @@ module.exports = function (app) {
     .patch(jwtAuth, function (req, res, next) {
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.unauthorized(`No user found for this token`, {
+              boom.notFound('No reader found with this token', {
                 requestUrl: req.originalUrl,
                 requestBody: req.body
               })

--- a/routes/outline-post.js
+++ b/routes/outline-post.js
@@ -41,9 +41,9 @@ module.exports = function (app) {
   router.route('/outlines').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound('No reader found with this token', {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/outline-put.js
+++ b/routes/outline-put.js
@@ -44,9 +44,9 @@ module.exports = function (app) {
   router.route('/outlines/:id').put(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound('No reader found with this token', {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/publication-batchUpdate.js
+++ b/routes/publication-batchUpdate.js
@@ -90,6 +90,15 @@ module.exports = function (app) {
       }
 
       const reader = await Reader.byAuthId(req.user)
+      if (!reader || reader.deleted) {
+        return next(
+          boom.notFound('No reader found with this token', {
+            requestUrl: req.originalUrl,
+            requestBody: req.body
+          })
+        )
+      }
+
       req.body.publications.forEach(publicationId => {
         if (!checkOwnership(reader.id, publicationId)) {
           errors.push({

--- a/routes/publication-delete-tag.js
+++ b/routes/publication-delete-tag.js
@@ -47,9 +47,9 @@ module.exports = function (app) {
       const tagId = req.params.tagId
       Reader.byAuthId(req.user)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/publication-delete.js
+++ b/routes/publication-delete.js
@@ -41,7 +41,15 @@ module.exports = function (app) {
       const pubId = req.params.pubId
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader || !checkOwnership(reader.id, pubId)) {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound('No reader found with this token', {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+
+          if (!checkOwnership(reader.id, pubId)) {
             const pub = await Publication.byId(pubId)
             if (!pub) {
               return next(

--- a/routes/publication-patch.js
+++ b/routes/publication-patch.js
@@ -62,7 +62,15 @@ module.exports = function (app) {
           )
         }
         const reader = await Reader.byAuthId(req.user)
-        if (!reader || !checkOwnership(reader.id, pubId)) {
+        if (!reader || reader.deleted) {
+          return next(
+            boom.notFound('No reader found with this token', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, pubId)) {
           return next(
             boom.forbidden(`Access to publication ${pubId} disallowed`, {
               requestUrl: req.originalUrl,

--- a/routes/publication-post.js
+++ b/routes/publication-post.js
@@ -42,9 +42,9 @@ module.exports = function (app) {
   router.route('/publications').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/publication-put-tag.js
+++ b/routes/publication-put-tag.js
@@ -49,9 +49,9 @@ module.exports = function (app) {
       const tagId = req.params.tagId
       Reader.byAuthId(req.user)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/readActivity-post.js
+++ b/routes/readActivity-post.js
@@ -51,9 +51,9 @@ module.exports = function (app) {
       const pubId = req.params.pubId
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.unauthorized(`No user found for this token`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl,
                 requestBody: req.body
               })

--- a/routes/reader-delete.js
+++ b/routes/reader-delete.js
@@ -11,7 +11,7 @@ module.exports = function (app) {
   /**
    * @swagger
    * /readers/{id}:
-   *   put:
+   *   delete:
    *     tags:
    *       - readers
    *     description: Update reader
@@ -24,20 +24,9 @@ module.exports = function (app) {
    *         description: the id of the reader
    *     security:
    *       - Bearer: []
-   *     requestBody:
-   *       content:
-   *         application/json:
-   *           schema:
-   *             $ref: '#/definitions/reader'
    *     responses:
-   *       200:
-   *         description: Updated
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/definitions/reader'
-   *       400:
-   *         description: Validation Error
+   *       204:
+   *         description: Deleted
    *       401:
    *         description: No Authentication
    *       403:
@@ -46,7 +35,7 @@ module.exports = function (app) {
    *         description: Reader not found
    */
   app.use('/', router)
-  router.put(
+  router.delete(
     '/readers/:id',
     passport.authenticate('jwt', { session: false }),
     async function (req, res, next) {
@@ -70,34 +59,12 @@ module.exports = function (app) {
           })
         )
       }
-      let updatedReader
-      try {
-        updatedReader = await Reader.update(req.params.id, req.body)
-      } catch (err) {
-        if (err instanceof ValidationError) {
-          return next(
-            boom.badRequest(
-              `Validation error on update Reader: ${err.message}`,
-              {
-                requestUrl: req.originalUrl,
-                requestBody: req.body,
-                validation: err.data
-              }
-            )
-          )
-        } else {
-          return next(
-            boom.badRequest(err.message, {
-              requestUrl: req.originalUrl,
-              requestBody: req.body
-            })
-          )
-        }
-      }
+
+      await Reader.softDelete(req.params.id)
 
       res.setHeader('Content-Type', 'application/ld+json')
-      res.status(200)
-      res.send(JSON.stringify(updatedReader.toJSON()))
+      res.status(204)
+      res.end()
     }
   )
 }

--- a/routes/reader-get.js
+++ b/routes/reader-get.js
@@ -45,7 +45,7 @@ module.exports = app => {
     function (req, res, next) {
       Reader.byId(req.params.id)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
               boom.notFound(
                 `Get Reader Error: No Reader found with id ${req.params.id}`,

--- a/routes/readerNotes-get.js
+++ b/routes/readerNotes-get.js
@@ -145,9 +145,9 @@ module.exports = app => {
       let returnedReader
       ReaderNotes.getNotes(req.user, req.query.limit, req.skip, filters)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with ID ${req.user}`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/routes/tag-delete.js
+++ b/routes/tag-delete.js
@@ -48,7 +48,14 @@ module.exports = function (app) {
         }
 
         const reader = await Reader.byAuthId(req.user)
-        if (!reader || !checkOwnership(reader.id, tagId)) {
+        if (!reader || reader.deleted) {
+          return next(
+            boom.notFound('No reader found with this token', {
+              requestUrl: req.originalUrl
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, tagId)) {
           return next(
             boom.forbidden(`Access to tag ${tagId} disallowed`, {
               requestUrl: req.originalUrl

--- a/routes/tag-post.js
+++ b/routes/tag-post.js
@@ -42,9 +42,9 @@ module.exports = function (app) {
   router.route('/tags').post(jwtAuth, function (req, res, next) {
     Reader.byAuthId(req.user)
       .then(async reader => {
-        if (!reader) {
+        if (!reader || reader.deleted) {
           return next(
-            boom.unauthorized(`No user found for this token`, {
+            boom.notFound(`No reader found with this token`, {
               requestUrl: req.originalUrl,
               requestBody: req.body
             })

--- a/routes/tag-put.js
+++ b/routes/tag-put.js
@@ -62,7 +62,15 @@ module.exports = function (app) {
         }
 
         const reader = await Reader.byAuthId(req.user)
-        if (!reader || !checkOwnership(reader.id, tagId)) {
+        if (!reader || reader.deleted) {
+          return next(
+            boom.notFound('No reader found with this token', {
+              requestUrl: req.originalUrl,
+              requestBody: req.body
+            })
+          )
+        }
+        if (!checkOwnership(reader.id, tagId)) {
           return next(
             boom.forbidden(`Access to tag ${tagId} disallowed`, {
               requestUrl: req.originalUrl,

--- a/routes/tags-get.js
+++ b/routes/tags-get.js
@@ -39,7 +39,7 @@ module.exports = function (app) {
     function (req, res, next) {
       Reader.byAuthId(req.user)
         .then(async reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
               boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl

--- a/routes/whoami.js
+++ b/routes/whoami.js
@@ -36,9 +36,9 @@ module.exports = app => {
     function (req, res, next) {
       Reader.byAuthId(req.user)
         .then(reader => {
-          if (!reader) {
+          if (!reader || reader.deleted) {
             return next(
-              boom.notFound(`No reader with ID ${req.user}`, {
+              boom.notFound(`No reader found with this token`, {
                 requestUrl: req.originalUrl
               })
             )

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const whoamiRoute = require('./routes/whoami') // GET /whoami
 const readersRoute = require('./routes/reader-post') // POST /readers
 const readerGetRoute = require('./routes/reader-get') // GET /readers/:id
 const readerPutRoute = require('./routes/reader-put') // PUT /readers/:id
+const readerDeleteRoute = require('./routes/reader-delete') // DELETE /readers/:id
 
 // Uploads
 const fileUploadRoute = require('./routes/file-upload') // POST /reader-:id/file-upload
@@ -265,6 +266,7 @@ outlineAddNoteRoute(app)
 outlineDeleteNoteRoute(app)
 outlinePatchNoteRoute(app)
 readerPutRoute(app)
+readerDeleteRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -32,6 +32,7 @@ const publicationBatchUpdateTests = require('./publication/publication-batchUpda
 const readerCreateTests = require('./reader/reader-post.test')
 const readerGetTests = require('./reader/reader-get.test')
 const readerPutTests = require('./reader/reader-put.test')
+const readerDeleteTests = require('./reader/reader-delete.test')
 
 const readerNotesGetTests = require('./readerNotes/readerNotes-get.test')
 const readerNotesPaginateTests = require('./readerNotes/readerNotes-paginate.test')
@@ -124,6 +125,7 @@ const allTests = async () => {
     await readerCreateTests(app)
     await readerGetTests(app)
     await readerPutTests(app)
+    await readerDeleteTests(app)
   }
 
   if (!test || test === 'note') {

--- a/tests/integration/reader/reader-delete.test.js
+++ b/tests/integration/reader/reader-delete.test.js
@@ -62,6 +62,19 @@ const test = async app => {
       `Get Reader Error: No Reader found with id ${reader.shortId}`
     )
     await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}`)
+
+    const res1 = await request(app)
+      .get(`/whoami`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res1.status, 404)
+    const error1 = JSON.parse(res1.text)
+    await tap.equal(error1.statusCode, 404)
+    await tap.equal(error1.error, 'Not Found')
+    await tap.equal(error1.message, `No reader found with this token`)
+    await tap.equal(error1.details.requestUrl, `/whoami`)
   })
 
   await tap.test(
@@ -79,7 +92,7 @@ const test = async app => {
       await tap.equal(errorPub.error, 'Not Found')
       await tap.equal(
         errorPub.message,
-        `Get Reader Error: No Publication found with id ${pub.shortId}`
+        `No Publication found with id ${pub.shortId}`
       )
       await tap.equal(
         errorPub.details.requestUrl,
@@ -98,7 +111,7 @@ const test = async app => {
       await tap.equal(errorNote.error, 'Not Found')
       await tap.equal(
         errorNote.message,
-        `Get Reader Error: No Note found with id ${note1.shortId}`
+        `Get Note Error: No Note found with id ${note1.shortId}`
       )
       await tap.equal(errorNote.details.requestUrl, `/notes/${note1.shortId}`)
 
@@ -114,7 +127,7 @@ const test = async app => {
       await tap.equal(errorContext.error, 'Not Found')
       await tap.equal(
         errorContext.message,
-        `Get Reader Error: No NoteContext found with id ${context.shortId}`
+        `Get NoteContext Error: No NoteContext found with id ${context.shortId}`
       )
       await tap.equal(
         errorContext.details.requestUrl,
@@ -131,11 +144,34 @@ const test = async app => {
       const errorTags = JSON.parse(resTags.text)
       await tap.equal(errorTags.statusCode, 404)
       await tap.equal(errorTags.error, 'Not Found')
-      await tap.equal(
-        errorTags.message,
-        `Get Reader Error: No Note found with id ${note1.shortId}`
-      )
+      await tap.equal(errorTags.message, `No reader found with this token`)
       await tap.equal(errorTags.details.requestUrl, `/tags`)
+
+      const resLibrary = await request(app)
+        .get(`/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resLibrary.status, 404)
+      const errorLibrary = JSON.parse(resLibrary.text)
+      await tap.equal(errorLibrary.statusCode, 404)
+      await tap.equal(errorLibrary.error, 'Not Found')
+      await tap.equal(errorLibrary.message, `No reader found with this token`)
+      await tap.equal(errorLibrary.details.requestUrl, `/library`)
+
+      const resNotes = await request(app)
+        .get(`/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resNotes.status, 404)
+      const errorNotes = JSON.parse(resNotes.text)
+      await tap.equal(errorNotes.statusCode, 404)
+      await tap.equal(errorNotes.error, 'Not Found')
+      await tap.equal(errorNotes.message, `No reader found with this token`)
+      await tap.equal(errorNotes.details.requestUrl, `/notes`)
     }
   )
 
@@ -152,7 +188,7 @@ const test = async app => {
     await tap.equal(error.error, 'Not Found')
     await tap.equal(
       error.message,
-      `Get Reader Error: No Reader found with id ${reader.shortId}abc`
+      `No Reader found with id ${reader.shortId}abc`
     )
     await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}abc`)
   })
@@ -168,10 +204,7 @@ const test = async app => {
     const error = JSON.parse(res.text)
     await tap.equal(error.statusCode, 404)
     await tap.equal(error.error, 'Not Found')
-    await tap.equal(
-      error.message,
-      `Get Reader Error: No Reader found with id ${reader.shortId}`
-    )
+    await tap.equal(error.message, `No Reader found with id ${reader.shortId}`)
     await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}`)
   })
 

--- a/tests/integration/reader/reader-delete.test.js
+++ b/tests/integration/reader/reader-delete.test.js
@@ -7,7 +7,9 @@ const {
   createPublication,
   createNote,
   createNoteContext,
-  createTag
+  createTag,
+  createNoteRelation,
+  createOutline
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
 
@@ -30,11 +32,19 @@ const test = async app => {
   // add stuff for reader
   const pub = await createPublication(app, token)
   const note1 = await createNote(app, token, reader.shortId)
+  const note2 = await createNote(app, token, reader.shortId)
   const context = await createNoteContext(app, token, {
     type: 'test',
     name: 'my context'
   })
-  await createTag(app, token)
+  const noteRelation = await createNoteRelation(app, token, {
+    from: note1.shortId,
+    to: note2.shortId,
+    type: 'test',
+    json: { property: 'value' }
+  })
+  const tag = await createTag(app, token)
+  const outline = await createOutline(app, token)
 
   await tap.test('Delete reader', async () => {
     const res = await request(app)
@@ -172,6 +182,471 @@ const test = async app => {
       await tap.equal(errorNotes.error, 'Not Found')
       await tap.equal(errorNotes.message, `No reader found with this token`)
       await tap.equal(errorNotes.details.requestUrl, `/notes`)
+    }
+  )
+
+  await tap.test(
+    'Try to create a user with the same token after reader deleted',
+    async () => {
+      const res = await request(app)
+        .post('/readers')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'Jane Doe',
+            profile: { property: 'value' },
+            preferences: { favoriteColor: 'blueish brown' },
+            json: { something: '!!!!' }
+          })
+        )
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.ok(error.message.startsWith('Reader already exists with id'))
+      await tap.equal(error.details.requestUrl, '/readers')
+      await tap.equal(error.details.requestBody.name, 'Jane Doe')
+    }
+  )
+
+  await tap.test(
+    'Routes should not work if accessed with the token for a deleted reader',
+    async () => {
+      // *************** Publications **************************
+
+      // POST /publications
+      const res1 = await request(app)
+        .post('/publications')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ name: 'something', type: 'Book' }))
+
+      await tap.equal(res1.status, 404)
+      const error1 = JSON.parse(res1.text)
+      await tap.equal(error1.message, `No reader found with this token`)
+      await tap.ok(error1.details.requestUrl)
+
+      // PATCH /publications/:id
+      const res2 = await request(app)
+        .patch(`/publications/${pub.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify({ name: 'something', type: 'Book' }))
+
+      await tap.equal(res2.status, 404)
+      const error2 = JSON.parse(res2.text)
+      await tap.equal(
+        error2.message,
+        `No Publication found with id ${pub.shortId}`
+      )
+      await tap.ok(error2.details.requestUrl)
+
+      // DELETE /publications/:id
+      const res3 = await request(app)
+        .delete(`/publications/${pub.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res3.status, 404)
+      const error3 = JSON.parse(res3.text)
+      await tap.equal(error3.message, `No reader found with this token`)
+      await tap.ok(error3.details.requestUrl)
+
+      // PUT /publications/:pubId/tags/:tagId
+      const res4 = await request(app)
+        .put(`/publications/${pub.shortId}/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res4.status, 404)
+      const error4 = JSON.parse(res4.text)
+      await tap.equal(error4.message, `No reader found with this token`)
+      await tap.ok(error4.details.requestUrl)
+
+      // DELETE /publications/:pubId/tags/:tagId
+      const res5 = await request(app)
+        .delete(`/publications/${pub.shortId}/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res5.status, 404)
+      const error5 = JSON.parse(res5.text)
+      await tap.equal(error5.message, `No reader found with this token`)
+      await tap.ok(error5.details.requestUrl)
+
+      // POST /publications/:id/readActivity
+      const res6 = await request(app)
+        .post(`/publications/${pub.shortId}/readActivity`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            selector: {
+              type: 'XPathSelector',
+              value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+            }
+          })
+        )
+
+      await tap.equal(res6.status, 404)
+      const error6 = JSON.parse(res6.text)
+      await tap.equal(error6.message, `No reader found with this token`)
+      await tap.ok(error6.details.requestUrl)
+
+      // PATCH /publications/batchUpdate
+      const res7 = await request(app)
+        .patch(`/publications/batchUpdate`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            operation: 'add',
+            property: 'keywords',
+            publications: [pub.shortId],
+            value: 'test'
+          })
+        )
+
+      await tap.equal(res7.status, 404)
+      const error7 = JSON.parse(res7.text)
+      await tap.equal(error7.message, `No reader found with this token`)
+      await tap.ok(error7.details.requestUrl)
+
+      // ************************ tags **********************
+
+      // POST /tags
+      const res8 = await request(app)
+        .post(`/tags`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'something',
+            type: 'tag'
+          })
+        )
+
+      await tap.equal(res8.status, 404)
+      const error8 = JSON.parse(res8.text)
+      await tap.equal(error8.message, `No reader found with this token`)
+      await tap.ok(error8.details.requestUrl)
+
+      // PUT /tags/:id
+      const res9 = await request(app)
+        .put(`/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'something',
+            type: 'tag'
+          })
+        )
+
+      await tap.equal(res9.status, 404)
+      const error9 = JSON.parse(res9.text)
+      await tap.equal(error9.message, `No reader found with this token`)
+      await tap.ok(error9.details.requestUrl)
+
+      // DELETE /tags/:id
+      const res10 = await request(app)
+        .delete(`/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res10.status, 404)
+      const error10 = JSON.parse(res10.text)
+      await tap.equal(error10.message, `No reader found with this token`)
+      await tap.ok(error10.details.requestUrl)
+
+      // ************************** notes ****************************
+
+      // PUT /notes/:noteId/tags/:tagId
+      const res11 = await request(app)
+        .put(`/notes/${note1.shortId}/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res11.status, 404)
+      const error11 = JSON.parse(res11.text)
+      await tap.equal(error11.message, `No reader found with this token`)
+      await tap.ok(error11.details.requestUrl)
+
+      // DELETE /notes/:noteId/tags/:tagId
+      const res12 = await request(app)
+        .delete(`/notes/${note1.shortId}/tags/${tag.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res12.status, 404)
+      const error12 = JSON.parse(res12.text)
+      await tap.equal(error12.message, `No reader found with this token`)
+      await tap.ok(error12.details.requestUrl)
+
+      // POST /notes
+      const res13 = await request(app)
+        .post(`/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({ body: { motivation: 'test', content: 'something' } })
+        )
+
+      await tap.equal(res13.status, 404)
+      const error13 = JSON.parse(res13.text)
+      await tap.equal(error13.message, `No reader found with this token`)
+      await tap.ok(error13.details.requestUrl)
+
+      // PUT /notes/:id
+      const res14 = await request(app)
+        .put(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({ body: { motivation: 'test', content: 'something' } })
+        )
+
+      await tap.equal(res14.status, 404)
+      const error14 = JSON.parse(res14.text)
+      await tap.equal(error14.message, `No reader found with this token`)
+      await tap.ok(error14.details.requestUrl)
+
+      // DELETE /notes/:id
+      const res15 = await request(app)
+        .delete(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res15.status, 404)
+      const error15 = JSON.parse(res15.text)
+      await tap.equal(error15.message, `No reader found with this token`)
+      await tap.ok(error15.details.requestUrl)
+
+      // ************************* noteRelations *******************
+
+      // POST /noteRelations
+      const res16 = await request(app)
+        .post(`/noteRelations`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: note1.shortId,
+            to: note2.shortId,
+            type: 'test',
+            json: { property: 'value' }
+          })
+        )
+      await tap.equal(res16.status, 404)
+      const error16 = JSON.parse(res16.text)
+      await tap.equal(error16.message, `No reader found with this token`)
+      await tap.ok(error16.details.requestUrl)
+
+      // PUT /noteRelations/:id
+      const res17 = await request(app)
+        .put(`/noteRelations/${noteRelation.id}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            from: note1.shortId,
+            to: note2.shortId,
+            type: 'test',
+            json: { property: 'value' }
+          })
+        )
+      await tap.equal(res17.status, 404)
+      const error17 = JSON.parse(res17.text)
+      await tap.equal(error17.message, `No reader found with this token`)
+      await tap.ok(error17.details.requestUrl)
+
+      // DELETE /noteRelations/:id
+      const res18 = await request(app)
+        .delete(`/noteRelations/${noteRelation.id}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res18.status, 404)
+      const error18 = JSON.parse(res18.text)
+      await tap.equal(error18.message, `No reader found with this token`)
+      await tap.ok(error18.details.requestUrl)
+
+      // ****************************** NoteContext *******************
+
+      // POST /noteContexts
+      const res19 = await request(app)
+        .post(`/noteContexts`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'context1',
+            description: 'this is the description of context1',
+            type: 'outline',
+            json: { property: 'value' }
+          })
+        )
+      await tap.equal(res19.status, 404)
+      const error19 = JSON.parse(res19.text)
+      await tap.equal(error19.message, `No reader found with this token`)
+      await tap.ok(error19.details.requestUrl)
+
+      // PUT /noteContexts/:id
+      const res20 = await request(app)
+        .put(`/noteContexts/${context.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'context1',
+            description: 'this is the description of context1',
+            type: 'outline',
+            json: { property: 'value' }
+          })
+        )
+      await tap.equal(res20.status, 404)
+      const error20 = JSON.parse(res20.text)
+      await tap.equal(error20.message, `No reader found with this token`)
+      await tap.ok(error20.details.requestUrl)
+
+      // DELETE /noteContexts/:id
+      const res21 = await request(app)
+        .delete(`/noteContexts/${context.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res21.status, 404)
+      const error21 = JSON.parse(res21.text)
+      await tap.equal(error21.message, `No reader found with this token`)
+      await tap.ok(error21.details.requestUrl)
+
+      // POST /noteContexts/:id/notes
+      const res22 = await request(app)
+        .post(`/noteContexts/${context.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test', content: 'something' }
+          })
+        )
+      await tap.equal(res22.status, 404)
+      const error22 = JSON.parse(res22.text)
+      await tap.equal(error22.message, `No reader found with this token`)
+      await tap.ok(error22.details.requestUrl)
+
+      // **************** outline ***************************
+
+      // GET /outlines/:id
+      const res23 = await request(app)
+        .get(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res23.status, 404)
+      const error23 = JSON.parse(res23.text)
+      await tap.equal(
+        error23.message,
+        `Get outline Error: No Outline found with id ${outline.shortId}`
+      )
+      await tap.ok(error23.details.requestUrl)
+
+      // POST /outlines
+      const res24 = await request(app)
+        .post(`/outlines`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res24.status, 404)
+      const error24 = JSON.parse(res24.text)
+      await tap.equal(error24.message, `No reader found with this token`)
+      await tap.ok(error24.details.requestUrl)
+
+      // DELETE /outlines/:id
+      const res25 = await request(app)
+        .delete(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res25.status, 404)
+      const error25 = JSON.parse(res25.text)
+      await tap.equal(error25.message, `No reader found with this token`)
+      await tap.ok(error25.details.requestUrl)
+
+      // PUT /outlines/:id
+      const res26 = await request(app)
+        .delete(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res26.status, 404)
+      const error26 = JSON.parse(res26.text)
+      await tap.equal(error26.message, `No reader found with this token`)
+      await tap.ok(error26.details.requestUrl)
+
+      // POST /outlines/:id/notes
+      const res27 = await request(app)
+        .post(`/outlines/${outline.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res27.status, 404)
+      const error27 = JSON.parse(res27.text)
+      await tap.equal(error27.message, `No reader found with this token`)
+      await tap.ok(error27.details.requestUrl)
+
+      // DELETE /outlines/:id/notes/:noteId
+      const res28 = await request(app)
+        .delete(`/outlines/${outline.shortId}/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res28.status, 404)
+      const error28 = JSON.parse(res28.text)
+      await tap.equal(error28.message, `No reader found with this token`)
+      await tap.ok(error28.details.requestUrl)
+
+      // PATCH /outlines/:id/notes/:noteId
+      const res29 = await request(app)
+        .patch(`/outlines/${outline.shortId}/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res29.status, 404)
+      const error29 = JSON.parse(res29.text)
+      await tap.equal(error29.message, `No reader found with this token`)
+      await tap.ok(error29.details.requestUrl)
     }
   )
 

--- a/tests/integration/reader/reader-delete.test.js
+++ b/tests/integration/reader/reader-delete.test.js
@@ -1,0 +1,181 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  destroyDB,
+  createReader,
+  createPublication,
+  createNote,
+  createNoteContext,
+  createTag
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+
+  const reader = await createReader(app, token, {
+    name: 'Joe Smith',
+    profile: {
+      favoriteColor: 'blue'
+    },
+    preferences: {
+      property: 'value1'
+    },
+    json: {
+      property2: 'value2'
+    }
+  })
+
+  // add stuff for reader
+  const pub = await createPublication(app, token)
+  const note1 = await createNote(app, token, reader.shortId)
+  const context = await createNoteContext(app, token, {
+    type: 'test',
+    name: 'my context'
+  })
+  await createTag(app, token)
+
+  await tap.test('Delete reader', async () => {
+    const res = await request(app)
+      .delete(`/readers/${reader.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+  })
+
+  await tap.test('Cannot get deleted reader', async () => {
+    const res = await request(app)
+      .get(`/readers/${reader.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(
+      error.message,
+      `Get Reader Error: No Reader found with id ${reader.shortId}`
+    )
+    await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}`)
+  })
+
+  await tap.test(
+    'Cannot get deleted publication, note, noteContext, tag... belonging to deleted reader',
+    async () => {
+      const resPub = await request(app)
+        .get(`/publications/${pub.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resPub.status, 404)
+      const errorPub = JSON.parse(resPub.text)
+      await tap.equal(errorPub.statusCode, 404)
+      await tap.equal(errorPub.error, 'Not Found')
+      await tap.equal(
+        errorPub.message,
+        `Get Reader Error: No Publication found with id ${pub.shortId}`
+      )
+      await tap.equal(
+        errorPub.details.requestUrl,
+        `/publications/${pub.shortId}`
+      )
+
+      const resNote = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resNote.status, 404)
+      const errorNote = JSON.parse(resNote.text)
+      await tap.equal(errorNote.statusCode, 404)
+      await tap.equal(errorNote.error, 'Not Found')
+      await tap.equal(
+        errorNote.message,
+        `Get Reader Error: No Note found with id ${note1.shortId}`
+      )
+      await tap.equal(errorNote.details.requestUrl, `/notes/${note1.shortId}`)
+
+      const resNoteContext = await request(app)
+        .get(`/noteContexts/${context.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resNoteContext.status, 404)
+      const errorContext = JSON.parse(resNoteContext.text)
+      await tap.equal(errorContext.statusCode, 404)
+      await tap.equal(errorContext.error, 'Not Found')
+      await tap.equal(
+        errorContext.message,
+        `Get Reader Error: No NoteContext found with id ${context.shortId}`
+      )
+      await tap.equal(
+        errorContext.details.requestUrl,
+        `/noteContexts/${context.shortId}`
+      )
+
+      const resTags = await request(app)
+        .get(`/tags`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resTags.status, 404)
+      const errorTags = JSON.parse(resTags.text)
+      await tap.equal(errorTags.statusCode, 404)
+      await tap.equal(errorTags.error, 'Not Found')
+      await tap.equal(
+        errorTags.message,
+        `Get Reader Error: No Note found with id ${note1.shortId}`
+      )
+      await tap.equal(errorTags.details.requestUrl, `/tags`)
+    }
+  )
+
+  await tap.test('Try to delete reader that does not exist', async () => {
+    const res = await request(app)
+      .delete(`/readers/${reader.shortId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(
+      error.message,
+      `Get Reader Error: No Reader found with id ${reader.shortId}abc`
+    )
+    await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}abc`)
+  })
+
+  await tap.test('Try to delete reader that was already deleted', async () => {
+    const res = await request(app)
+      .delete(`/readers/${reader.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(
+      error.message,
+      `Get Reader Error: No Reader found with id ${reader.shortId}`
+    )
+    await tap.equal(error.details.requestUrl, `/readers/${reader.shortId}`)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/reader/reader-put.test.js
+++ b/tests/integration/reader/reader-put.test.js
@@ -26,7 +26,6 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
       .send(JSON.stringify(Object.assign(reader, { name: 'Joe Smith Jr.' })))
-
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
     await tap.equal(res.body.shortId, urlToId(res.body.id))

--- a/tests/integration/reader/reader-put.test.js
+++ b/tests/integration/reader/reader-put.test.js
@@ -26,6 +26,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
       .send(JSON.stringify(Object.assign(reader, { name: 'Joe Smith Jr.' })))
+
     await tap.equal(res.status, 200)
     await tap.ok(res.body)
     await tap.equal(res.body.shortId, urlToId(res.body.id))

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -247,6 +247,22 @@ const addNoteToContext = async (app, token, contextId, object) => {
   return response.body
 }
 
+const createOutline = async (app, token, object) => {
+  const contextObject = Object.assign(
+    {
+      type: 'outline'
+    },
+    object
+  )
+  const res = await request(app)
+    .post('/outlines')
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .send(contextObject)
+
+  return res.body
+}
+
 const addNoteToOutline = async (app, token, contextId, object) => {
   const noteObject = Object.assign(
     {
@@ -302,5 +318,6 @@ module.exports = {
   addNoteToContext,
   updateNote,
   addNoteToOutline,
-  createReader
+  createReader,
+  createOutline
 }


### PR DESCRIPTION
delete /readers/:id

This is a soft delete.
It will also soft delete: 
- Publications
- Documents
- NoteContexts (including outlines)
- Notes
- Tags
- Attributions
- NoteBody
- NoteRelation 
... belonging to the reader
However, it does not delete:
- ReadActivity
- Pub_Tag Relation
- Note_Tag Relation
- Jobs
because these do not have a 'deleted' field and/or a 'readerId' field. 
This will need to be fixed when we start doing hard deletes. I haven't decided how yet.

I have also checked that once a reader is deleted, none of the other routes will work with that token. All will return a 404 status, usually with a message about 'reader not found'. In some cases, the message would be different. For example, Patch publication will complain about 'publication not found' instead. It all depends on the implementation. I didn't change that because both are true. 

Trying to create a new user with the same token will return a 400 error complaining about duplicate reader since the authId already exists in the database. 

