### PR TITLE
Get notebook

### DIFF
--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -150,6 +150,12 @@ class Notebook extends BaseModel {
       )
   }
 
+  static async byReader (id /*: string */) /*: Promise<Array<any>> */ {
+    return await Notebook.query()
+      .where('readerId', '=', id)
+      .withGraphFetched('tags')
+  }
+
   static async update (object /*: any */) /*: Promise<any> */ {
     const props = this._formatNotebook(object, null)
     props.readerId = object.readerId

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -86,7 +86,7 @@ class Notebook extends BaseModel {
           from: 'Notebook.id',
           through: {
             from: 'notebook_pub.notebookId',
-            to: 'notebook_pub.pubId'
+            to: 'notebook_pub.publicationId'
           },
           to: 'Publication.id'
         }
@@ -146,7 +146,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notebookTags, noteContexts]' // add
+        '[reader, notebookTags, noteContexts, tags, publications, notes]'
       )
   }
 

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -154,6 +154,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .where('readerId', '=', id)
       .withGraphFetched('tags')
+      .whereNull('deleted')
   }
 
   static async update (object /*: any */) /*: Promise<any> */ {

--- a/routes/notebook-get.js
+++ b/routes/notebook-get.js
@@ -1,0 +1,79 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Note } = require('../models/Note')
+const debug = require('debug')('hobb:routes:document')
+const utils = require('../utils/utils')
+const boom = require('@hapi/boom')
+const { Notebook } = require('../models/Notebook')
+
+module.exports = app => {
+  app.use('/', router)
+
+  /**
+   * @swagger
+   * /notebooks/{id}:
+   *   get:
+   *     tags:
+   *       - notebooks
+   *     description: GET /notebooks/:id
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         schema:
+   *           type: string
+   *         required: true
+   *         description: the short id of the notebook
+   *     security:
+   *       - Bearer: []
+   *     produces:
+   *       - application/json
+   *     responses:
+   *       200:
+   *         description: A Notebook Object with a list of notes and noteRelations
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/notebook'
+   *       401:
+   *         desription: 'No Authentication'
+   *       403:
+   *         description: 'Access to Notebook {id} disallowed'
+   *       404:
+   *         description: 'No Notebook with ID {id}'
+   */
+
+  router.get(
+    '/notebooks/:id',
+    passport.authenticate('jwt', { session: false }),
+    function (req, res, next) {
+      const id = req.params.id
+      Notebook.byId(id)
+        .then(notebook => {
+          if (!notebook || notebook.deleted) {
+            return next(
+              boom.notFound(
+                `Get Notebook Error: No Notebook found with id ${id}`,
+                {
+                  requestUrl: req.originalUrl
+                }
+              )
+            )
+          } else if (!utils.checkReader(req, notebook.reader)) {
+            return next(
+              boom.forbidden(`Access to Notebook ${id} disallowed`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          } else {
+            res.setHeader('Content-Type', 'application/ld+json')
+            res.end(JSON.stringify(notebook.toJSON()))
+          }
+        })
+        .catch(err => {
+          console.log(err)
+          next(err)
+        })
+    }
+  )
+}

--- a/routes/notebooks.get.js
+++ b/routes/notebooks.get.js
@@ -26,7 +26,7 @@ module.exports = function (app) {
    *             schema:
    *               type: array
    *               items:
-   *                 $ref: '#/definitions/notebook'
+   *                 $ref: '#/definitions/notebook-ref'
    *       401:
    *         description: No Authenticationd
    *       404:

--- a/routes/notebooks.get.js
+++ b/routes/notebooks.get.js
@@ -1,0 +1,57 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../models/Reader')
+const boom = require('@hapi/boom')
+const { urlToId } = require('../utils/utils')
+const { Notebook } = require('../models/Notebook')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /notebooks:
+   *   get:
+   *     tags:
+   *       - notebooks
+   *     description: Get a list of notebooks for a reader
+   *     security:
+   *       - Bearer: []
+   *     produces:
+   *       - application/json
+   *     responses:
+   *       200:
+   *         description: An array of notebooks for the reader (based on the validation token)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/definitions/notebook'
+   *       401:
+   *         description: No Authenticationd
+   *       404:
+   *         description: 'No Reader found'
+   */
+  app.use('/', router)
+  router.get(
+    '/notebooks',
+    passport.authenticate('jwt', { session: false }),
+    function (req, res, next) {
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+          let notebooks = await Notebook.byReader(urlToId(reader.id))
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.end(JSON.stringify(notebooks))
+        })
+        .catch(next)
+    }
+  )
+}

--- a/routes/swagger-definitions/notebook-def.js
+++ b/routes/swagger-definitions/notebook-def.js
@@ -1,0 +1,75 @@
+/**
+ * @swagger
+ * definition:
+ *   notebook-ref:
+ *     properties:
+ *       id:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       readerId:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       name:
+ *         type: string
+ *       description:
+ *         type: string
+ *       status:
+ *         type: string
+ *         enum: ['active', 'archived']
+ *         default: 'active'
+ *       settings:
+ *         type: object
+ *       tags:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/tag'
+ *         readOnly: true
+ *         description: tags assigned to this notebook
+ *       published:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *       updated:
+ *         type: string
+ *         format: date-time
+ *         readOnly: true
+ *   required:
+ *     - id
+ *     - name
+ *     - status
+ *     - published
+ *     - readerId
+ *
+ *   notebook:
+ *     allOf:
+ *       - $ref: '#/definitions/notebook-ref'
+ *     properties:
+ *       notebookTags:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/tag'
+ *         readOnly: true
+ *         description: tags that belong to the notebook
+ *       publications:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/publication'
+ *         readOnly: true
+ *         description: publications assigned to the notebook
+ *       notes:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/note'
+ *         readOnly: true
+ *         description: notes assigned to the notebook
+ *       noteContexts:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/noteContext'
+ *         readOnly: true
+ *         description: noteContexts that belong to this notebook
+ *
+ *
+ */

--- a/server.js
+++ b/server.js
@@ -83,7 +83,8 @@ const outlinePatchNoteRoute = require('./routes/outline-patchNote') // PATCH /ou
 
 // notebooks
 const notebookPostRoute = require('./routes/notebook-post') // POST /notebooks
-const notebookGetRoute = require('./routes/notebook-get')
+const notebookGetRoute = require('./routes/notebook-get') // GET /notebooks/:id
+const notebooksGetRoute = require('./routes/notebooks.get') // GET /notebooks
 
 const setupKnex = async skip_migrate => {
   let config
@@ -273,6 +274,7 @@ readerPutRoute(app)
 readerDeleteRoute(app)
 notebookPostRoute(app)
 notebookGetRoute(app)
+notebooksGetRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -83,6 +83,7 @@ const outlinePatchNoteRoute = require('./routes/outline-patchNote') // PATCH /ou
 
 // notebooks
 const notebookPostRoute = require('./routes/notebook-post') // POST /notebooks
+const notebookGetRoute = require('./routes/notebook-get')
 
 const setupKnex = async skip_migrate => {
   let config
@@ -271,6 +272,7 @@ outlinePatchNoteRoute(app)
 readerPutRoute(app)
 readerDeleteRoute(app)
 notebookPostRoute(app)
+notebookGetRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -431,6 +431,14 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test('GET notebooks list without authentication', async () => {
+    const res = await request(app)
+      .get('/notebooks')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -423,6 +423,14 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test('GET notebook without authentication', async () => {
+    const res = await request(app)
+      .get('/notebooks/abc')
+      .set('Host', 'reader-api.test')
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 401)
+  })
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -78,6 +78,7 @@ const outlinePatchNoteTests = require('./outline/outline-patchNote.test')
 
 const notebookPostTests = require('./notebook/notebook-post.test')
 const notebookGetTests = require('./notebook/notebook-get.test')
+const notebooksGetTests = require('./notebook/notebooks-get.test')
 
 const app = require('../../server').app
 
@@ -241,6 +242,7 @@ const allTests = async () => {
     try {
       await notebookPostTests(app)
       await notebookGetTests(app)
+      await notebooksGetTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -77,6 +77,7 @@ const outlineDeleteNoteTests = require('./outline/outline-deleteNote.test')
 const outlinePatchNoteTests = require('./outline/outline-patchNote.test')
 
 const notebookPostTests = require('./notebook/notebook-post.test')
+const notebookGetTests = require('./notebook/notebook-get.test')
 
 const app = require('../../server').app
 
@@ -239,6 +240,7 @@ const allTests = async () => {
   if (!test || test === 'notebook') {
     try {
       await notebookPostTests(app)
+      await notebookGetTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/notebook/notebook-get.test.js
+++ b/tests/integration/notebook/notebook-get.test.js
@@ -1,0 +1,71 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  await tap.test('Get empty notebook', async () => {
+    const res = await request(app)
+      .get(`/notebooks/${notebook.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.name, 'notebook1')
+    await tap.equal(body.description, 'test')
+    await tap.equal(body.status, 'archived')
+    await tap.equal(body.settings.property, 'value')
+    // notes, tags, notebookTags, pubs, noteContexts
+    await tap.equal(body.notes.length, 0)
+    await tap.equal(body.tags.length, 0)
+    await tap.equal(body.notebookTags.length, 0)
+    await tap.equal(body.publications.length, 0)
+    await tap.equal(body.noteContexts.length, 0)
+  })
+
+  // TODO: add tests for notebook with notes, tags, notebookTags, noteContexts and publications
+
+  await tap.test('Try to get a Notebook that does not exist', async () => {
+    const res = await request(app)
+      .get(`/notebooks/${notebook.shortId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 404)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 404)
+    await tap.equal(error.error, 'Not Found')
+    await tap.equal(
+      error.message,
+      `Get Notebook Error: No Notebook found with id ${notebook.shortId}abc`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebook.shortId}abc`
+    )
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get.test.js
+++ b/tests/integration/notebook/notebooks-get.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  await tap.test('Get Notebooks for a reader with no notebooks', async () => {
+    const res = await request(app)
+      .get('/notebooks')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.length, 0)
+  })
+
+  await createNotebook(app, token, {
+    name: 'outline1',
+    description: 'description1',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'outline2',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  await tap.test('Get Notebooks', async () => {
+    const res = await request(app)
+      .get('/notebooks')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.length, 2)
+
+    const body = res.body[0]
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.ok(body.name)
+    await tap.ok(body.description)
+    await tap.ok(body.settings)
+    await tap.equal(body.status, 'active')
+    await tap.ok(body.published)
+    await tap.ok(body.updated)
+    await tap.equal(body.tags.length, 0)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/Notebook.test.js
+++ b/tests/models/Notebook.test.js
@@ -101,6 +101,13 @@ const test = async app => {
     await tap.ok(error instanceof ValidationError)
   })
 
+  await tap.test('Get notebooks for a reader', async () => {
+    let notebooks = await Notebook.byReader(urlToId(createdReader.id))
+
+    await tap.equal(notebooks.length, 2)
+    await tap.ok(notebooks[0].tags)
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -303,6 +303,22 @@ const addNoteToCollection = async (app, token, noteId, tagId) => {
     .type('application/ld+json')
 }
 
+const createNotebook = async (app, token, object) => {
+  const notebookObject = Object.assign(
+    {
+      name: 'test'
+    },
+    object
+  )
+  const res = await request(app)
+    .post('/notebooks')
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .send(notebookObject)
+
+  return res.body
+}
+
 module.exports = {
   getToken,
   createUser,
@@ -319,5 +335,6 @@ module.exports = {
   updateNote,
   addNoteToOutline,
   createReader,
-  createOutline
+  createOutline,
+  createNotebook
 }


### PR DESCRIPTION
Two endpoints:

GET /notebooks/:id
returns the notebook with:
- tags (tags assigned to the notebook)
- notebookTags (tags that are used to tag things within the notebook)
- publications
- notes
- noteContexts

GET /notebooks
returns all notebooks for a reader. Each notebook includes:
- tags (tags assigned to the notebook)
Is there anything else that should be included?

Eventually, the GET /notebooks endpoint should have filters (especially filter by status) and pagination. 