### PR TITLE
Notebook pub

### DIFF
--- a/models/Notebook_Pub.js
+++ b/models/Notebook_Pub.js
@@ -64,7 +64,7 @@ class Notebook_Pub extends BaseModel {
 
     if (result === 0) {
       throw new Error(
-        `Remove Publication from Notebook Error: No Relation found between Publication ${publicationId} and Notebook ${notebookId}`
+        `Remove Publication from Notebook Error: No Relation found between Notebook ${notebookId} and Publication ${publicationId}`
       )
     } else {
       return result

--- a/routes/notebooks/notebook-delete-pub.js
+++ b/routes/notebooks/notebook-delete-pub.js
@@ -1,0 +1,89 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const { libraryCacheUpdate } = require('../../utils/cache')
+const { Publication_Tag } = require('../../models/Publications_Tags')
+const { checkOwnership } = require('../../utils/utils')
+const { Notebook_Pub } = require('../../models/Notebook_Pub')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * notebooks/{notebookId}/publications/{pubId}:
+   *   delete:
+   *     tags:
+   *       - notebooks
+   *     description: Remove assignment of Publication to Notebook
+   *     parameters:
+   *       - in: path
+   *         name: pubId
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: path
+   *         name: notebookId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     responses:
+   *       204:
+   *         description: Successfully removed Publication from Notebook
+   *       401:
+   *         description: No Authentication
+   *       403:
+   *         description: 'Access to notebook or publication disallowed'
+   *       404:
+   *         description: publication, notebook or pub-notebook relation not found
+   */
+  app.use('/', router)
+  router
+    .route('/notebooks/:notebookId/publications/:pubId')
+    .delete(jwtAuth, function (req, res, next) {
+      const pubId = req.params.pubId
+      const notebookId = req.params.notebookId
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          } else {
+            if (!checkOwnership(reader.id, pubId)) {
+              return next(
+                boom.forbidden(`Access to Publication ${pubId} disallowed`, {
+                  requestUrl: req.originalUrl
+                })
+              )
+            }
+            if (!checkOwnership(reader.id, notebookId)) {
+              return next(
+                boom.forbidden(`Access to Notebook ${notebookId} disallowed`, {
+                  requestUrl: req.originalUrl
+                })
+              )
+            }
+
+            try {
+              await Notebook_Pub.removePubFromNotebook(notebookId, pubId)
+              res.status(204).end()
+            } catch (err) {
+              return next(
+                boom.notFound(err.message, {
+                  requestUrl: req.originalUrl
+                })
+              )
+            }
+          }
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/routes/notebooks/notebook-put-pub.js
+++ b/routes/notebooks/notebook-put-pub.js
@@ -1,0 +1,109 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const { checkOwnership } = require('../../utils/utils')
+const { Notebook_Pub } = require('../../models/Notebook_Pub')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * notebooks/{notebookId}/publications/{pubId}:
+   *   put:
+   *     tags:
+   *       - notebooks
+   *     description: Assign a Publication to a Notebook
+   *     parameters:
+   *       - in: path
+   *         name: notebookId
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: path
+   *         name: pubId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     responses:
+   *       204:
+   *         description: Successfully added Publication to Notebook
+   *       400:
+   *         description: Cannot assign the same publication twice
+   *       401:
+   *         description: No Authentication
+   *       403:
+   *         description: 'Access to notebook or publication disallowed'
+   *       404:
+   *         description:  publication or notebook not found
+   */
+  app.use('/', router)
+  router
+    .route('/notebooks/:notebookId/publications/:pubId')
+    .put(jwtAuth, function (req, res, next) {
+      const pubId = req.params.pubId
+      const notebookId = req.params.notebookId
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+
+          if (!checkOwnership(reader.id, pubId)) {
+            return next(
+              boom.forbidden(`Access to Publication ${pubId} disallowed`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+          if (!checkOwnership(reader.id, notebookId)) {
+            return next(
+              boom.forbidden(`Access to Notebook ${notebookId} disallowed`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+
+          try {
+            await Notebook_Pub.addPubToNotebook(notebookId, pubId)
+            res.status(204).end()
+          } catch (err) {
+            if (err.message === 'no publication') {
+              return next(
+                boom.notFound(
+                  `Add Publication to Notebook Error: No Publication found with id ${pubId}`,
+                  {
+                    requestUrl: req.originalUrl
+                  }
+                )
+              )
+            } else if (err.message === 'no notebook') {
+              return next(
+                boom.notFound(
+                  `Add Publication to Notebook Error: No Notebook found with id ${notebookId}`,
+                  {
+                    requestUrl: req.originalUrl
+                  }
+                )
+              )
+            } else {
+              return next(
+                boom.badRequest(err.message, {
+                  requestUrl: req.originalUrl
+                })
+              )
+            }
+          }
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/server.js
+++ b/server.js
@@ -87,6 +87,7 @@ const notebookGetRoute = require('./routes/notebooks/notebook-get') // GET /note
 const notebooksGetRoute = require('./routes/notebooks/notebooks.get') // GET /notebooks
 const notebookPutRoute = require('./routes/notebooks/notebook-put') // PUT /notebooks/:id
 const notebookDeleteRoute = require('./routes/notebooks/notebook-delete') // DELETE /notebooks/:id
+const notebookPutPubRoute = require('./routes/notebooks/notebook-put-pub') // PUT /notebooks/:id/publications/:pubId
 
 const setupKnex = async skip_migrate => {
   let config
@@ -279,6 +280,7 @@ notebookGetRoute(app)
 notebooksGetRoute(app)
 notebookPutRoute(app)
 notebookDeleteRoute(app)
+notebookPutPubRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ const notebooksGetRoute = require('./routes/notebooks/notebooks.get') // GET /no
 const notebookPutRoute = require('./routes/notebooks/notebook-put') // PUT /notebooks/:id
 const notebookDeleteRoute = require('./routes/notebooks/notebook-delete') // DELETE /notebooks/:id
 const notebookPutPubRoute = require('./routes/notebooks/notebook-put-pub') // PUT /notebooks/:id/publications/:pubId
+const notebookDeletePubRoute = require('./routes/notebooks/notebook-delete-pub') // DELETE /notebooks/:id/publications/:pubId
 
 const setupKnex = async skip_migrate => {
   let config
@@ -281,6 +282,7 @@ notebooksGetRoute(app)
 notebookPutRoute(app)
 notebookDeleteRoute(app)
 notebookPutPubRoute(app)
+notebookDeletePubRoute(app)
 
 app.use(errorHandling)
 

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -1093,6 +1093,56 @@ const test = async app => {
     }
   )
 
+  await tap.test(
+    'Try to remove a publication belonging to another user from a notebook',
+    async () => {
+      const res = await request(app)
+        .delete(`/notebooks/${notebook2.shortId}/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Publication ${publicationId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook2.shortId}/publications/${publicationId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to remove a publication to a notebook belongint from another user',
+    async () => {
+      const res = await request(app)
+        .delete(
+          `/notebooks/${notebook1.shortId}/publications/${publicationId2}`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook1.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook1.shortId}/publications/${publicationId2}`
+      )
+    }
+  )
+
   // ---------------------------------------- READER --------------------------
 
   await tap.test(

--- a/tests/integration/auth/forbidden.test.js
+++ b/tests/integration/auth/forbidden.test.js
@@ -82,6 +82,7 @@ const test = async app => {
   const outline2 = await createNoteContext(app, token2, { type: 'outline' })
 
   const notebook1 = await createNotebook(app, token)
+  const notebook2 = await createNotebook(app, token2)
 
   // ------------------------ PUBLICATION -------------------------------------
   await tap.test(
@@ -1040,6 +1041,54 @@ const test = async app => {
       await tap.equal(
         error.details.requestUrl,
         `/notebooks/${notebook1.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to assign a publication belonging to another user to a notebook',
+    async () => {
+      const res = await request(app)
+        .put(`/notebooks/${notebook2.shortId}/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Publication ${publicationId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook2.shortId}/publications/${publicationId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to assign a publication to a notebook belongint to another user',
+    async () => {
+      const res = await request(app)
+        .put(`/notebooks/${notebook1.shortId}/publications/${publicationId2}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook1.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook1.shortId}/publications/${publicationId2}`
       )
     }
   )

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -466,6 +466,17 @@ const test = async app => {
     }
   )
 
+  await tap.test(
+    'DELETE publication to notebook without authentication',
+    async () => {
+      const res = await request(app)
+        .delete('/notebooks/abc/publications/abc')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/auth/unauthorized.test.js
+++ b/tests/integration/auth/unauthorized.test.js
@@ -455,6 +455,17 @@ const test = async app => {
     await tap.equal(res.statusCode, 401)
   })
 
+  await tap.test(
+    'PUT publication to notebook without authentication',
+    async () => {
+      const res = await request(app)
+        .put('/notebooks/abc/publications/abc')
+        .set('Host', 'reader-api.test')
+        .type('application/ld+json')
+      await tap.equal(res.statusCode, 401)
+    }
+  )
+
   // ------------------------------------- UPLOAD ---------------------------
 
   await tap.test('Upload without authentication', async () => {

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -81,6 +81,7 @@ const notebookGetTests = require('./notebook/notebook-get.test')
 const notebooksGetTests = require('./notebook/notebooks-get.test')
 const notebookPutTests = require('./notebook/notebook-put.test')
 const notebookDeleteTests = require('./notebook/notebook-delete.test')
+const notebookPubPutTests = require('./notebook/notebook-pub-put.test')
 
 const app = require('../../server').app
 
@@ -247,6 +248,7 @@ const allTests = async () => {
       await notebooksGetTests(app)
       await notebookPutTests(app)
       await notebookDeleteTests(app)
+      await notebookPubPutTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -82,6 +82,7 @@ const notebooksGetTests = require('./notebook/notebooks-get.test')
 const notebookPutTests = require('./notebook/notebook-put.test')
 const notebookDeleteTests = require('./notebook/notebook-delete.test')
 const notebookPubPutTests = require('./notebook/notebook-pub-put.test')
+const notebookPubDeleteTests = require('./notebook/notebook-pub-delete.test')
 
 const app = require('../../server').app
 
@@ -249,6 +250,7 @@ const allTests = async () => {
       await notebookPutTests(app)
       await notebookDeleteTests(app)
       await notebookPubPutTests(app)
+      await notebookPubDeleteTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/notebook/notebook-pub-delete.test.js
+++ b/tests/integration/notebook/notebook-pub-delete.test.js
@@ -1,0 +1,93 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createNotebook,
+  addPubToNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const publication = await createPublication(app, token)
+  const publicationId = publication.shortId
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  await addPubToNotebook(app, token, publicationId, notebookId)
+
+  await tap.test('Remove publication from Notebook', async () => {
+    const res = await request(app)
+      .delete(`/notebooks/${notebookId}/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+
+    // make sure the publication is no longer attached to the notebook
+    const pubres = await request(app)
+      .get(`/notebooks/${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(pubres.status, 200)
+    const body = pubres.body
+    await tap.ok(Array.isArray(body.publications))
+    await tap.equal(body.publications.length, 0)
+  })
+
+  await tap.test(
+    'Try to remove pub from notebook with invalid notebook',
+    async () => {
+      const res = await request(app)
+        .delete(`/notebooks/${notebookId}abc/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Remove Publication from Notebook Error: No Relation found between Notebook ${notebookId}abc and Publication ${publicationId}`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}abc/publications/${publicationId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to remove pub from notebook with invalid pub',
+    async () => {
+      const res = await request(app)
+        .delete(`/notebooks/${notebookId}/publications/${publicationId}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Remove Publication from Notebook Error: No Relation found between Notebook ${notebookId} and Publication ${publicationId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}/publications/${publicationId}abc`
+      )
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebook-pub-put.test.js
+++ b/tests/integration/notebook/notebook-pub-put.test.js
@@ -1,0 +1,110 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createPublication,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const publication = await createPublication(app, token)
+  const publicationId = publication.shortId
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  await tap.test('Assign Publication to Notebook', async () => {
+    const res = await request(app)
+      .put(`/notebooks/${notebookId}/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 204)
+
+    // make sure the publication is really attached to the notebook
+    const pubres = await request(app)
+      .get(`/notebooks/${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(pubres.status, 200)
+    const body = pubres.body
+    await tap.ok(Array.isArray(body.publications))
+    await tap.equal(body.publications.length, 1)
+    await tap.equal(body.publications[0].shortId, publicationId)
+  })
+
+  await tap.test(
+    'Try to assign Publication to an invalid Notebook',
+    async () => {
+      const res = await request(app)
+        .put(`/notebooks/${notebookId}abc/publications/${publicationId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Add Publication to Notebook Error: No Notebook found with id ${notebookId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}abc/publications/${publicationId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to assign an invalid Publication to a Notebook',
+    async () => {
+      const res = await request(app)
+        .put(`/notebooks/${notebookId}/publications/${publicationId}abc`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Add Publication to Notebook Error: No Publication found with id ${publicationId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}/publications/${publicationId}abc`
+      )
+    }
+  )
+
+  await tap.test('Try to assign Publication to Notebook twice', async () => {
+    const res = await request(app)
+      .put(`/notebooks/${notebookId}/publications/${publicationId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(
+      error.message,
+      `Add Publication to Notebook Error: Relationship already exists between Notebook ${notebookId} and Publication ${publicationId}`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebookId}/publications/${publicationId}`
+    )
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/Notebook_Pub.test.js
+++ b/tests/models/Notebook_Pub.test.js
@@ -108,7 +108,7 @@ const test = async app => {
       await tap.ok(error)
       await tap.equal(
         error.message,
-        `Remove Publication from Notebook Error: No Relation found between Publication ${pubId} and Notebook ${notebookId}`
+        `Remove Publication from Notebook Error: No Relation found between Notebook ${notebookId} and Publication ${pubId}`
       )
     }
   )

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -294,6 +294,17 @@ const addPubToCollection = async (app, token, pubId, tagId) => {
   return res
 }
 
+const addPubToNotebook = async (app, token, pubId, notebookId) => {
+  pubId = urlToId(pubId)
+  notebookId = urlToId(notebookId)
+  const res = await request(app)
+    .put(`/notebooks/${notebookId}/publications/${pubId}`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+  return res
+}
+
 const addNoteToCollection = async (app, token, noteId, tagId) => {
   tagId = urlToId(tagId)
   return await request(app)
@@ -336,5 +347,6 @@ module.exports = {
   addNoteToOutline,
   createReader,
   createOutline,
-  createNotebook
+  createNotebook,
+  addPubToNotebook
 }


### PR DESCRIPTION
Two new endpoints:

PUT /notebooks/:id/publications/:pubId
DELETE /notebooks/:id/publications/:pubId

To add or remove a notebook-pub relation (which is a many-to-many relation)

Both endpoints take no body and return a 204 status.
