### PR TITLE
Notebook filters

### DIFF
--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -183,9 +183,9 @@ class Notebook extends BaseModel {
 
   static async byReader (
     id /*: string */,
-    limit /* :number */,
-    skip /*: number */,
-    filters /*: any */
+    limit /*: number */ = 10,
+    skip /*: number */ = 0,
+    filters /*: any */ = {}
   ) /*: Promise<Array<any>> */ {
     let query = Notebook.query()
       .where('readerId', '=', id)

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -196,6 +196,26 @@ class Notebook extends BaseModel {
 
     this.applyFilters(query, filters)
 
+    if (filters.orderBy === 'name') {
+      if (filters.reverse) {
+        query = query.orderByRaw('LOWER(name) desc')
+      } else {
+        query = query.orderByRaw('LOWER(name) asc')
+      }
+    } else if (filters.orderBy === 'created') {
+      if (filters.reverse) {
+        query = query.orderBy('published')
+      } else {
+        query = query.orderBy('published', 'desc')
+      }
+    } else {
+      if (filters.reverse) {
+        query = query.orderBy('updated')
+      } else {
+        query = query.orderBy('updated', 'desc')
+      }
+    }
+
     return await query
   }
 

--- a/models/Source.js
+++ b/models/Source.js
@@ -166,6 +166,7 @@ class Source extends BaseModel {
   static get relationMappings () /*: any */ {
     const { Reader } = require('./Reader')
     const { Tag } = require('./Tag.js')
+    const { Notebook } = require('./Notebook')
     return {
       reader: {
         relation: Model.BelongsToOneRelation,
@@ -201,6 +202,18 @@ class Source extends BaseModel {
             to: 'source_tag.tagId'
           },
           to: 'Tag.id'
+        }
+      },
+      notebooks: {
+        relation: Model.ManyToManyRelation,
+        modelClass: Notebook,
+        join: {
+          from: 'Source.id',
+          through: {
+            from: 'notebook_source.sourceId',
+            to: 'notebook_source.notebookId'
+          },
+          to: 'Notebook.id'
         }
       },
       readActivities: {

--- a/models/library.js
+++ b/models/library.js
@@ -51,6 +51,24 @@ class Library {
         builder.andWhere('Attribution.role', '=', filter.role)
       }
     }
+    builder.withGraphFetched('notebooks')
+    if (filter.notebook) {
+      builder.leftJoin(
+        'notebook_source',
+        'notebook_source.sourceId',
+        '=',
+        'Source.id'
+      )
+      builder.leftJoin(
+        'Notebook',
+        'notebook_source.notebookId',
+        '=',
+        'Notebook.id'
+      )
+      builder.whereNull('Notebook.deleted')
+      builder.where('Notebook.id', '=', filter.notebook)
+    }
+
     builder.withGraphFetched('[tags, attributions]')
     if (filter.collection) {
       builder.leftJoin(
@@ -182,6 +200,25 @@ class Library {
             builder.andWhere('Attribution.role', '=', filter.role)
           }
         }
+
+        builder.withGraphFetched('notebooks')
+        if (filter.notebook) {
+          builder.leftJoin(
+            'notebook_source',
+            'notebook_source.sourceId',
+            '=',
+            'Source.id'
+          )
+          builder.leftJoin(
+            'Notebook',
+            'notebook_source.notebookId',
+            '=',
+            'Notebook.id'
+          )
+          builder.whereNull('Notebook.deleted')
+          builder.where('Notebook.id', '=', filter.notebook)
+        }
+
         builder.withGraphFetched('[tags, attributions]')
         if (filter.collection) {
           builder.leftJoin(

--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -55,6 +55,14 @@ class ReaderNotes {
       )
     }
 
+    if (filters.notebook) {
+      resultQuery = resultQuery
+        .leftJoin('notebook_note', 'notebook_note.noteId', '=', 'Note.id')
+        .leftJoin('Notebook', 'notebook_note.notebookId', '=', 'Notebook.id')
+        .whereNull('Notebook.deleted')
+        .where('Notebook.id', '=', filters.notebook)
+    }
+
     if (filters.collection) {
       resultQuery = resultQuery
         .leftJoin(
@@ -175,6 +183,23 @@ class ReaderNotes {
             'ilike',
             '%' + filters.search.toLowerCase() + '%'
           )
+        }
+
+        if (filters.notebook) {
+          builder.leftJoin(
+            'notebook_note',
+            'notebook_note.noteId',
+            '=',
+            'Note.id'
+          )
+          builder.leftJoin(
+            'Notebook',
+            'notebook_note.notebookId',
+            '=',
+            'Notebook.id'
+          )
+          builder.whereNull('Notebook.deleted')
+          builder.where('Notebook.id', '=', filters.notebook)
         }
 
         if (filters.collection) {

--- a/routes/_swagger-definitions/notebook-def.js
+++ b/routes/_swagger-definitions/notebook-def.js
@@ -71,5 +71,17 @@
  *         readOnly: true
  *         description: noteContexts that belong to this notebook
  *
+ *   notebook-list:
+ *     properties:
+ *       page:
+ *         type: integer
+ *       pageSize:
+ *         type: integer
+ *       totalItems:
+ *         type: integer
+ *       items:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/notebook-ref'
  *
  */

--- a/routes/_swagger-definitions/source-def.js
+++ b/routes/_swagger-definitions/source-def.js
@@ -295,12 +295,10 @@
  *
  *   library:
  *     properties:
- *       id:
- *         type: string
- *         format: url
- *       type:
- *         type: string
- *         enum: ['Collection']
+ *       page:
+ *         type: integer
+ *       pageSize:
+ *         type: integer
  *       tags:
  *         type: array
  *         items:

--- a/routes/notebooks/notebook-delete-note.js
+++ b/routes/notebooks/notebook-delete-note.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/notes/{noteId}:
    *   delete:
    *     tags:
-   *       - notebooks
+   *       - notebook-note
    *     description: Remove assignment of Note to Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebook-delete-source.js
+++ b/routes/notebooks/notebook-delete-source.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/sources/{sourceId}:
    *   delete:
    *     tags:
-   *       - notebooks
+   *       - notebook-source
    *     description: Remove assignment of Source to Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebook-delete-tag.js
+++ b/routes/notebooks/notebook-delete-tag.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/tags/{tagId}:
    *   delete:
    *     tags:
-   *       - notebooks
+   *       - notebook-tag
    *     description: Remove assignment of Tag to Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebook-note-post.js
+++ b/routes/notebooks/notebook-note-post.js
@@ -15,7 +15,7 @@ module.exports = function (app) {
    * /notebooks/{notebookId}/notes:
    *   post:
    *     tags:
-   *       - notes
+   *       - notebook-note
    *     description: Create a note and assign it to a Notebook
    *     security:
    *       - Bearer: []

--- a/routes/notebooks/notebook-put-note.js
+++ b/routes/notebooks/notebook-put-note.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/notes/{noteId}:
    *   put:
    *     tags:
-   *       - notebooks
+   *       - notebook-note
    *     description: Assign a Note to a Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebook-put-source.js
+++ b/routes/notebooks/notebook-put-source.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/sources/{sourceId}:
    *   put:
    *     tags:
-   *       - notebooks
+   *       - notebook-source
    *     description: Assign a Source to a Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebook-put-tag.js
+++ b/routes/notebooks/notebook-put-tag.js
@@ -13,7 +13,7 @@ module.exports = function (app) {
    * notebooks/{notebookId}/tags/{tagId}:
    *   put:
    *     tags:
-   *       - notebooks
+   *       - notebook-tag
    *     description: Assign a Tag to a Notebook
    *     parameters:
    *       - in: path

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -65,9 +65,7 @@ module.exports = function (app) {
    *         content:
    *           application/json:
    *             schema:
-   *               type: array
-   *               items:
-   *                 $ref: '#/definitions/notebook-ref'
+   *               $ref: '#/definitions/notebook-list'
    *       401:
    *         description: No Authenticationd
    *       404:

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -47,7 +47,8 @@ module.exports = function (app) {
    *       - in: query
    *         name: orderBy
    *         type: string
-   *         enum: ['name', 'dateCreated', 'dateUpdated']
+   *         enum: ['name', 'created', 'updated']
+   *         default: 'updated'
    *       - in: query
    *         name: reverse
    *         schema:

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -44,6 +44,16 @@ module.exports = function (app) {
    *         schema:
    *           type: string
    *         description: colour found in the settings object
+   *       - in: query
+   *         name: orderBy
+   *         type: string
+   *         enum: ['name', 'dateCreated', 'dateUpdated']
+   *       - in: query
+   *         name: reverse
+   *         schema:
+   *           type: boolean
+   *         default: false
+   *         description: a modifier to use with orderBy to reverse the order
    *     security:
    *       - Bearer: []
    *     produces:
@@ -71,7 +81,9 @@ module.exports = function (app) {
       const filters = {
         status: req.query.status,
         search: req.query.search,
-        colour: req.query.colour
+        colour: req.query.colour,
+        orderBy: req.query.orderBy,
+        reverse: req.query.reverse
       }
 
       Reader.byAuthId(req.user)

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -5,6 +5,7 @@ const { Reader } = require('../../models/Reader')
 const boom = require('@hapi/boom')
 const { urlToId } = require('../../utils/utils')
 const { Notebook } = require('../../models/Notebook')
+const paginate = require('../_middleware/paginate')
 
 module.exports = function (app) {
   /**
@@ -14,6 +15,35 @@ module.exports = function (app) {
    *     tags:
    *       - notebooks
    *     description: Get a list of notebooks for a reader
+   *     parameters:
+   *       - in: query
+   *         name: limit
+   *           schema:
+   *             type: number
+   *             default: 10
+   *             minimum: 10
+   *             maximum: 100
+   *           description: the number of notebook items to return
+   *       - in: query
+   *         name: page
+   *         schema:
+   *           type: number
+   *           default: 1
+   *       - in: query
+   *         name: status
+   *         schema:
+   *           type: string
+   *           enum: ['active', 'archived']
+   *       - in: query
+   *         name: search
+   *         schema:
+   *           type: string
+   *         description: the string to search for in name and description of notebooks. Not case sensitive, accepts partial matches
+   *       - in : query
+   *         name: colour
+   *         schema:
+   *           type: string
+   *         description: colour found in the settings object
    *     security:
    *       - Bearer: []
    *     produces:
@@ -35,10 +65,19 @@ module.exports = function (app) {
   app.use('/', router)
   router.get(
     '/notebooks',
+    paginate,
     passport.authenticate('jwt', { session: false }),
     function (req, res, next) {
+      const filters = {
+        status: req.query.status,
+        search: req.query.search,
+        colour: req.query.colour
+      }
+
       Reader.byAuthId(req.user)
         .then(async reader => {
+          if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything
+
           if (!reader || reader.deleted) {
             return next(
               boom.notFound(`No reader found with this token`, {
@@ -46,10 +85,29 @@ module.exports = function (app) {
               })
             )
           }
-          let notebooks = await Notebook.byReader(urlToId(reader.id))
+          let notebooks = await Notebook.byReader(
+            urlToId(reader.id),
+            req.query.limit,
+            req.skip,
+            filters
+          )
+
+          let count
+          if (notebooks.length < req.query.limit && notebooks.length > 0) {
+            count = notebooks.length + req.skip
+          } else {
+            count = await Notebook.count(urlToId(reader.id), filters)
+          }
 
           res.setHeader('Content-Type', 'application/ld+json')
-          res.end(JSON.stringify(notebooks))
+          res.end(
+            JSON.stringify({
+              items: notebooks,
+              totalItems: count,
+              page: req.query.page,
+              pageSize: parseInt(req.query.limit)
+            })
+          )
         })
         .catch(next)
     }

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -18,12 +18,12 @@ module.exports = function (app) {
    *     parameters:
    *       - in: query
    *         name: limit
-   *           schema:
-   *             type: number
-   *             default: 10
-   *             minimum: 10
-   *             maximum: 100
-   *           description: the number of notebook items to return
+   *         schema:
+   *           type: number
+   *           default: 10
+   *           minimum: 10
+   *           maximum: 100
+   *         description: the number of notebook items to return
    *       - in: query
    *         name: page
    *         schema:

--- a/routes/notes/readerNotes-get.js
+++ b/routes/notes/readerNotes-get.js
@@ -49,6 +49,11 @@ module.exports = app => {
    *           type: string
    *         description: word to search for in the content of notes. Not case sensitive.
    *       - in: query
+   *         name: notebook
+   *         schema:
+   *           type: string
+   *         description: shortId of the notebook to filter by
+   *       - in: query
    *         name: stack
    *         schema:
    *           type: string
@@ -122,6 +127,7 @@ module.exports = app => {
         collection: req.query.stack,
         tag: req.query.tag,
         flag: req.query.flag,
+        notebook: req.query.notebook,
         publishedStart: req.query.publishedStart,
         publishedEnd: req.query.publishedEnd
       }

--- a/routes/search.js
+++ b/routes/search.js
@@ -6,7 +6,7 @@ const { urlToId } = require('../utils/utils')
 const { Source_Tag } = require('../models/Source_Tag')
 
 /**
- * @swagger
+ * @ swagger
  * definition:
  *   search-result:
  *     properties:
@@ -33,7 +33,7 @@ const { Source_Tag } = require('../models/Source_Tag')
  */
 module.exports = app => {
   /**
-   * @swagger
+   * @ swagger
    * /reader-{id}/search:
    *   get:
    *     tags:

--- a/routes/sources/library-get.js
+++ b/routes/sources/library-get.js
@@ -18,12 +18,6 @@ module.exports = app => {
    *       - sources
    *     description: GET a collection of sources and tags for a reader
    *     parameters:
-   *       - in: path
-   *         name: id
-   *         schema:
-   *           type: string
-   *         required: true
-   *         description: the short id of the reader
    *       - in: query
    *         name: limit
    *         schema:

--- a/routes/sources/library-get.js
+++ b/routes/sources/library-get.js
@@ -78,6 +78,11 @@ module.exports = app => {
    *            type: string
    *         description: searches in title, description, abstract, keywords and attributions
    *       - in: query
+   *         name: notebook
+   *         schema:
+   *           type: string
+   *         description: the shortId of the notebook to filter by
+   *       - in: query
    *         name: orderBy
    *         schema:
    *           type: string
@@ -132,7 +137,8 @@ module.exports = app => {
         type: req.query.type,
         keyword: req.query.keyword,
         search: req.query.search,
-        tag: req.query.tag
+        tag: req.query.tag,
+        notebook: req.query.notebook
       }
       let returnedReader
       if (req.query.limit < 10) req.query.limit = 10 // prevents people from cheating by setting limit=0 to get everything

--- a/swaggerDef.js
+++ b/swaggerDef.js
@@ -13,5 +13,5 @@ module.exports = {
     }
   },
   openapi: '3.0.0',
-  apis: ['server.js', './routes/*.js', './routes/swagger-definitions/*.js']
+  apis: ['server.js', './routes/**/*.js']
 }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -16,6 +16,7 @@ const libraryOrderByDefaultTests = require('./library/library-orderBy-default.te
 const libraryOrderByTitleTests = require('./library/library-orderBy-title.test')
 const libraryOrderByDatePublishedTests = require('./library/library-orderBy-datePublished.test')
 const libraryOrderByTypeTest = require('./library/library-orderBy-type.test')
+const libraryFilterNotebookTests = require('./library/library-filter-notebook.test')
 
 const noteGetTests = require('./note/note-get.test')
 const notePostTests = require('./note/note-post.test')
@@ -140,6 +141,7 @@ const allTests = async () => {
       await libraryOrderByDatePublishedTests(app)
       await libraryFilterKeyword(app)
       await libraryFilterSearch(app)
+      await libraryFilterNotebookTests(app)
     } catch (err) {
       console.log('library integration test error: ', err)
     }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -91,6 +91,9 @@ const notebooksGetFilterStatus = require('./notebook/notebooks-get-filter-status
 const notebooksGetFilterSearchTests = require('./notebook/notebooks-get-filter-search.test')
 const notebooksGetFilterCombinedTests = require('./notebook/notebooks-get-filter-combined.test')
 const notebooksGetFilterColourTests = require('./notebook/notebooks-get-filter-colour.test')
+const notebooksGetOrderByNameTests = require('./notebook/notebooks-get-orderBy-name.test')
+const notebooksGetOrderByCreated = require('./notebook/notebooks-get-orderBy-created.test')
+const notebooksGetOrderByDefaultTests = require('./notebook/notebooks-get-orderBy-default.test')
 
 const hardDeletePubTests = require('./hardDelete/deletePub.test')
 const hardDeleteNoteTests = require('./hardDelete/deleteNote.test')
@@ -267,6 +270,9 @@ const allTests = async () => {
       await notebooksGetFilterSearchTests(app)
       await notebooksGetFilterCombinedTests(app)
       await notebooksGetFilterColourTests(app)
+      await notebooksGetOrderByNameTests(app)
+      await notebooksGetOrderByCreated(app)
+      await notebooksGetOrderByDefaultTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -47,6 +47,7 @@ const readerNotesFilterCombinedTests = require('./readerNotes/readerNotes-filter
 const readerNotesFilterDateRange = require('./readerNotes/readerNotes-filter-dateRange.test')
 const readerNotesFilterFlagTests = require('./readerNotes/readerNotes-filter-flag.test')
 const readerNotesFilterDocumentTests = require('./readerNotes/readerNotes-filter-document.test')
+const readerNotesFilterNotebookTests = require('./readerNotes/readerNotes-filter-notebook.test')
 
 const sourceAddTagTests = require('./tag/source-tag-put.test')
 const sourceRemoveTagTests = require('./tag/source-tag-delete.test')
@@ -212,6 +213,7 @@ const allTests = async () => {
       await readerNotesFilterDateRange(app)
       await readerNotesFilterFlagTests(app)
       await readerNotesFilterDocumentTests(app)
+      await readerNotesFilterNotebookTests(app)
     } catch (err) {
       console.log('readerNotes integration tests error: ', err)
     }

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -86,6 +86,11 @@ const notebookNoteDeleteTests = require('./notebook/notebook-note-delete.test')
 const notebookNotePostTests = require('./notebook/notebook-note-post.test')
 const notebookTagPutTests = require('./notebook/notebook-tag-put.test')
 const notebookTagDeleteTests = require('./notebook/notebook-tag-delete.test')
+const notebooksGetPaginateTests = require('./notebook/notebooks-get-paginate.test')
+const notebooksGetFilterStatus = require('./notebook/notebooks-get-filter-status.test')
+const notebooksGetFilterSearchTests = require('./notebook/notebooks-get-filter-search.test')
+const notebooksGetFilterCombinedTests = require('./notebook/notebooks-get-filter-combined.test')
+const notebooksGetFilterColourTests = require('./notebook/notebooks-get-filter-colour.test')
 
 const hardDeletePubTests = require('./hardDelete/deletePub.test')
 const hardDeleteNoteTests = require('./hardDelete/deleteNote.test')
@@ -257,6 +262,11 @@ const allTests = async () => {
       await notebookNotePostTests(app)
       await notebookTagPutTests(app)
       await notebookTagDeleteTests(app)
+      await notebooksGetPaginateTests(app)
+      await notebooksGetFilterStatus(app)
+      await notebooksGetFilterSearchTests(app)
+      await notebooksGetFilterCombinedTests(app)
+      await notebooksGetFilterColourTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
     }

--- a/tests/integration/library/library-filter-combined.test.js
+++ b/tests/integration/library/library-filter-combined.test.js
@@ -88,7 +88,8 @@ const test = async () => {
     name: 'Source 6',
     inLanguage: ['km']
   })
-  const source7 = await createSourceSimplified({ name: 'Source 7 test' })
+  // 7
+  await createSourceSimplified({ name: 'Source 7 test' })
   const source8 = await createSourceSimplified({ name: 'Source 8' })
   const source9 = await createSourceSimplified({ name: 'Source 9' })
   const source10 = await createSourceSimplified({

--- a/tests/integration/library/library-filter-notebook.test.js
+++ b/tests/integration/library/library-filter-notebook.test.js
@@ -1,0 +1,129 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createSource,
+  createNotebook,
+  addSourceToNotebook
+} = require('../../utils/testUtils')
+const app = require('../../../server').app
+
+const test = async () => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const createSourceSimplified = async object => {
+    return await createSource(app, token, object)
+  }
+
+  const source1 = await createSourceSimplified({
+    name: 'Source 1'
+  })
+
+  const source2 = await createSourceSimplified({
+    name: 'Source 2'
+  })
+
+  await createSourceSimplified({ name: 'Source 3' })
+
+  const notebook = await createNotebook(app, token, { name: 'notebook1' })
+  const notebookId = notebook.shortId
+
+  await tap.test('Filter Library by notebook with empty notebook', async () => {
+    const res = await request(app)
+      .get(`/library?notebook=${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.equal(body.totalItems, 0)
+    await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 0)
+  })
+
+  await addSourceToNotebook(app, token, source1.shortId, notebookId)
+  await addSourceToNotebook(app, token, source2.shortId, notebookId)
+
+  await tap.test('Filter Library by notebook', async () => {
+    const res = await request(app)
+      .get(`/library?notebook=${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.equal(body.totalItems, 2)
+    await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 2)
+  })
+
+  await tap.test('should work with pagination', async () => {
+    const source4 = await createSourceSimplified({ name: 'Source 4 test' })
+    const source5 = await createSourceSimplified({ name: 'Source 5' })
+    const source6 = await createSourceSimplified({ name: 'Source 6' })
+    await createSourceSimplified({ name: 'Source 7 test' })
+    const source8 = await createSourceSimplified({ name: 'Source 8' })
+    const source9 = await createSourceSimplified({ name: 'Source 9' })
+    const source10 = await createSourceSimplified({
+      name: 'Source 10'
+    })
+    const source11 = await createSourceSimplified({
+      name: 'Source 11'
+    })
+    const source12 = await createSourceSimplified({ name: 'Source 12' })
+    const source13 = await createSourceSimplified({
+      name: 'Source 13'
+    })
+
+    await addSourceToNotebook(app, token, source4.shortId, notebookId)
+    await addSourceToNotebook(app, token, source5.shortId, notebookId)
+    await addSourceToNotebook(app, token, source6.shortId, notebookId)
+    await addSourceToNotebook(app, token, source8.shortId, notebookId)
+    await addSourceToNotebook(app, token, source9.shortId, notebookId)
+    await addSourceToNotebook(app, token, source10.shortId, notebookId)
+    await addSourceToNotebook(app, token, source11.shortId, notebookId)
+    await addSourceToNotebook(app, token, source12.shortId, notebookId)
+    await addSourceToNotebook(app, token, source13.shortId, notebookId)
+
+    // get library with filter for notebook with pagination
+    const res = await request(app)
+      .get(`/library?notebook=${notebookId}&limit=10`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.equal(body.totalItems, 11)
+    await tap.equal(body.items.length, 10)
+  })
+
+  await tap.test('Filter Library with a non-existing notebook', async () => {
+    const res = await request(app)
+      .get(`/library?notebook=${notebookId}abc`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.equal(body.totalItems, 0)
+    await tap.ok(Array.isArray(body.items))
+    await tap.equal(body.items.length, 0)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-filter-colour.test.js
+++ b/tests/integration/notebook/notebooks-get-filter-colour.test.js
@@ -1,0 +1,155 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  // colour: blue - 14
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'blue'
+    }
+  })
+
+  // colour 'red' - 3
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'red'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'red'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: {
+      colour: 'red'
+    }
+  })
+
+  // no settings - should not break things
+  await createNotebook(app, token, {
+    name: 'notebookabc'
+  })
+
+  await tap.test('Get Notebooks - filter by colour', async () => {
+    const res = await request(app)
+      .get('/notebooks?colour=red')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.totalItems, 3)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by colour with pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?colour=blue&limit=11&page=2')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 3)
+      await tap.equal(res.body.totalItems, 14)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-filter-combined.test.js
+++ b/tests/integration/notebook/notebooks-get-filter-combined.test.js
@@ -1,0 +1,236 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  // serach 'abc' + colour 'blue' - 11
+
+  // contains 'abc' - 18
+  await createNotebook(app, token, {
+    name: 'abc',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookabc',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'ABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1abc',
+    description: 'descriptionabc',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'descriptionabc',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'descriptionabc',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+
+  // contains 'xyz' - 5
+  await createNotebook(app, token, {
+    name: 'notebookXYZ',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'description goes here xyz',
+    settings: { colour: 'blue' }
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here',
+    status: 'archived',
+    settings: {
+      colour: 'blue'
+    }
+  })
+
+  // contains 'abc' but is archived - 3
+
+  await createNotebook(app, token, {
+    name: 'notebookABC',
+    status: 'archived',
+    settings: {
+      colour: 'blue'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABCD',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABCDEF',
+    status: 'archived'
+  })
+
+  await tap.test('Get Notebooks - filter by search & status', async () => {
+    const res = await request(app)
+      .get('/notebooks?search=abc&status=archived')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.totalItems, 3)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by search & status with pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?search=abc&status=active&limit=11&page=2')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 7)
+      await tap.equal(res.body.totalItems, 18)
+    }
+  )
+
+  // SEARCH + COLOUR
+  await tap.test('Get Notebooks - filter by search & colour', async () => {
+    const res = await request(app)
+      .get('/notebooks?search=xyz&colour=blue')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.totalItems, 3)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by search & colour with pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?search=abc&colour=blue')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 10)
+      await tap.equal(res.body.totalItems, 12)
+    }
+  )
+
+  // STATUS + COLOUR
+  await tap.test('Get Notebooks - filter by status & colour', async () => {
+    const res = await request(app)
+      .get('/notebooks?status=archived&colour=blue')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 2)
+    await tap.equal(res.body.totalItems, 2)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by status & colour with pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?status=active&colour=blue')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 10)
+      await tap.equal(res.body.totalItems, 13)
+    }
+  )
+
+  // STATUS + SEARCH + COLOUR
+
+  await tap.test('Get Notebooks - filter by status & colour', async () => {
+    const res = await request(app)
+      .get('/notebooks?status=active&search=xyz&colour=blue')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 2)
+    await tap.equal(res.body.totalItems, 2)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-filter-search.test.js
+++ b/tests/integration/notebook/notebooks-get-filter-search.test.js
@@ -1,0 +1,124 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  // contains 'abc' - 13
+  await createNotebook(app, token, {
+    name: 'abc'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookabc'
+  })
+  await createNotebook(app, token, {
+    name: 'ABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'descriptionabc'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'descriptionabc'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'descriptionabc'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+  await createNotebook(app, token, {
+    name: 'notebookABC'
+  })
+
+  // contains 'xyz' - 5
+  await createNotebook(app, token, {
+    name: 'notebookXYZ'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'description goes here xyz'
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+  await createNotebook(app, token, {
+    name: 'xyz',
+    description: 'description goes here'
+  })
+
+  await tap.test('Get Notebooks - filter by search', async () => {
+    const res = await request(app)
+      .get('/notebooks?search=xyz')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 5)
+    await tap.equal(res.body.totalItems, 5)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by search with default pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?search=abc')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 10)
+      await tap.equal(res.body.totalItems, 13)
+    }
+  )
+
+  await tap.test(
+    'Get Notebooks - filter by search with pagination',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?search=abc&limit=11&page=2')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 2)
+      await tap.equal(res.body.totalItems, 13)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-filter-status.test.js
+++ b/tests/integration/notebook/notebooks-get-filter-status.test.js
@@ -1,0 +1,123 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  // active (by default) - 5
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+
+  // archived - 12
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived'
+  })
+
+  await tap.test('Get Notebooks - filter by status', async () => {
+    const res = await request(app)
+      .get('/notebooks?status=active')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 5)
+    await tap.equal(res.body.totalItems, 5)
+  })
+
+  await tap.test(
+    'Get Notebooks - filter by status, paginate by default',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?status=archived')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 10)
+      await tap.equal(res.body.totalItems, 12)
+    }
+  )
+
+  await tap.test('Get Notebooks - filter by status, paginated', async () => {
+    const res = await request(app)
+      .get('/notebooks?status=archived&limit=11&page=2')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 1)
+    await tap.equal(res.body.totalItems, 12)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-orderBy-created.test.js
+++ b/tests/integration/notebook/notebooks-get-orderBy-created.test.js
@@ -1,0 +1,63 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  const notebook3 = await createNotebook(app, token, {
+    name: 'notebook3'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook2'
+  })
+
+  // updating should not change the order
+  await request(app)
+    .put(`/notebooks/${notebook3.shortId}`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+    .send(JSON.stringify({ name: 'notebookNew' }))
+
+  await tap.test('Get Notebooks - orderBy created', async () => {
+    const res = await request(app)
+      .get('/notebooks?orderBy=created')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'notebook2')
+    await tap.equal(res.body.items[1].name, 'notebookNew')
+    await tap.equal(res.body.items[2].name, 'notebook1')
+  })
+
+  await tap.test('Get Notebooks - orderBy name, reversed', async () => {
+    const res = await request(app)
+      .get('/notebooks?orderBy=created&reverse=true')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'notebook1')
+    await tap.equal(res.body.items[1].name, 'notebookNew')
+    await tap.equal(res.body.items[2].name, 'notebook2')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-orderBy-default.test.js
+++ b/tests/integration/notebook/notebooks-get-orderBy-default.test.js
@@ -1,0 +1,62 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  await createNotebook(app, token, {
+    name: 'notebook1'
+  })
+  const notebook3 = await createNotebook(app, token, {
+    name: 'notebook3'
+  })
+  await createNotebook(app, token, {
+    name: 'notebook2'
+  })
+
+  await request(app)
+    .put(`/notebooks/${notebook3.shortId}`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+    .send(JSON.stringify({ name: 'notebookNew' }))
+
+  await tap.test('Get Notebooks - default order by updated', async () => {
+    const res = await request(app)
+      .get('/notebooks')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'notebookNew')
+    await tap.equal(res.body.items[1].name, 'notebook2')
+    await tap.equal(res.body.items[2].name, 'notebook1')
+  })
+
+  await tap.test('Get Notebooks - orderBy name, reversed', async () => {
+    const res = await request(app)
+      .get('/notebooks?reverse=true')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'notebook1')
+    await tap.equal(res.body.items[1].name, 'notebook2')
+    await tap.equal(res.body.items[2].name, 'notebookNew')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-orderBy-name.test.js
+++ b/tests/integration/notebook/notebooks-get-orderBy-name.test.js
@@ -1,0 +1,55 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  await createNotebook(app, token, {
+    name: 'xyz'
+  })
+  await createNotebook(app, token, {
+    name: 'abc'
+  })
+  await createNotebook(app, token, {
+    name: 'AAAAAA'
+  })
+
+  await tap.test('Get Notebooks - orderBy name', async () => {
+    const res = await request(app)
+      .get('/notebooks?orderBy=name')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'AAAAAA')
+    await tap.equal(res.body.items[1].name, 'abc')
+    await tap.equal(res.body.items[2].name, 'xyz')
+  })
+
+  await tap.test('Get Notebooks - orderBy name, reversed', async () => {
+    const res = await request(app)
+      .get('/notebooks?orderBy=name&reverse=true')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].name, 'xyz')
+    await tap.equal(res.body.items[1].name, 'abc')
+    await tap.equal(res.body.items[2].name, 'AAAAAA')
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get-paginate.test.js
+++ b/tests/integration/notebook/notebooks-get-paginate.test.js
@@ -6,7 +6,6 @@ const {
   destroyDB,
   createNotebook
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   const token = getToken()

--- a/tests/integration/notebook/notebooks-get-paginate.test.js
+++ b/tests/integration/notebook/notebooks-get-paginate.test.js
@@ -1,0 +1,182 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  await createNotebook(app, token, {
+    name: 'notebook1',
+    description: 'description1',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook2',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook3',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook4',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook5',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook6',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook7',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook8',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook9',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook10',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook11',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook12',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook13',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+  await createNotebook(app, token, {
+    name: 'notebook14',
+    description: 'description2',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  // paginate
+
+  await tap.test('Get Notebooks - default paginate to 10', async () => {
+    const res = await request(app)
+      .get('/notebooks')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 10)
+    await tap.equal(res.body.totalItems, 14)
+  })
+
+  await tap.test(
+    'Get Notebooks - set limit to less than 10, will still default to 10',
+    async () => {
+      const res = await request(app)
+        .get('/notebooks?limit=3')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      await tap.equal(res.body.items.length, 10)
+      await tap.equal(res.body.totalItems, 14)
+    }
+  )
+
+  await tap.test('Get Notebooks - set limit', async () => {
+    const res = await request(app)
+      .get('/notebooks?limit=12')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 12)
+    await tap.equal(res.body.totalItems, 14)
+  })
+
+  await tap.test('Get Notebooks - set page', async () => {
+    const res = await request(app)
+      .get('/notebooks?page=2')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 4)
+    await tap.equal(res.body.totalItems, 14)
+  })
+
+  await tap.test('Get Notebooks - set page and limit', async () => {
+    const res = await request(app)
+      .get('/notebooks?limit=11&page=2')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.totalItems, 14)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/notebook/notebooks-get.test.js
+++ b/tests/integration/notebook/notebooks-get.test.js
@@ -20,7 +20,10 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.length, 0)
+    await tap.equal(res.body.items.length, 0)
+    await tap.equal(res.body.totalItems, 0)
+    await tap.equal(res.body.page, 1)
+    await tap.equal(res.body.pageSize, 10)
   })
 
   await createNotebook(app, token, {
@@ -46,9 +49,10 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.length, 2)
+    await tap.equal(res.body.items.length, 2)
+    await tap.equal(res.body.totalItems, 2)
 
-    const body = res.body[0]
+    const body = res.body.items[0]
     await tap.ok(body.id)
     await tap.equal(body.shortId, urlToId(body.id))
     await tap.ok(body.name)

--- a/tests/integration/readerNotes/readerNotes-filter-notebook.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-notebook.test.js
@@ -1,0 +1,91 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote,
+  createNotebook,
+  addNoteToNotebook
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const createNoteSimplified = async object => {
+    const noteObj = Object.assign(
+      {
+        body: { motivation: 'test' }
+      },
+      object
+    )
+    return await createNote(app, token, noteObj)
+  }
+
+  const note1 = await createNoteSimplified() // 1
+  const note2 = await createNoteSimplified() // 2
+  const note3 = await createNoteSimplified() // 3
+  const note4 = await createNoteSimplified() // 4
+  const note5 = await createNoteSimplified() // 5
+  const note6 = await createNoteSimplified() // 6
+  const note7 = await createNoteSimplified() // 7
+  const note8 = await createNoteSimplified() // 8
+  const note9 = await createNoteSimplified() // 9
+  const note10 = await createNoteSimplified() // 10
+  const note11 = await createNoteSimplified() // 11
+  const note12 = await createNoteSimplified() // 12
+  const note13 = await createNoteSimplified() // 13
+  await createNoteSimplified()
+  await createNoteSimplified()
+  await createNoteSimplified()
+
+  const notebook = await createNotebook(app, token, { name: 'notebook1' })
+  const notebookId = notebook.shortId
+  // add 13 notes to this collection
+  await addNoteToNotebook(app, token, urlToId(note1.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note2.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note3.id), notebookId)
+
+  await tap.test('Get Notes by notebook', async () => {
+    const res = await request(app)
+      .get(`/notes?notebook=${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 3)
+    await tap.equal(res.body.items.length, 3)
+  })
+
+  await addNoteToNotebook(app, token, urlToId(note4.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note5.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note6.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note7.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note8.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note9.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note10.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note11.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note12.id), notebookId)
+  await addNoteToNotebook(app, token, urlToId(note13.id), notebookId)
+
+  await tap.test('Get Notes by Collection with pagination', async () => {
+    const res = await request(app)
+      .get(`/notes?notebook=${notebookId}&limit=12&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 13)
+    await tap.equal(res.body.items.length, 1)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/models/Notebook.test.js
+++ b/tests/models/Notebook.test.js
@@ -102,7 +102,7 @@ const test = async app => {
   })
 
   await tap.test('Get notebooks for a reader', async () => {
-    let notebooks = await Notebook.byReader(urlToId(createdReader.id))
+    let notebooks = await Notebook.byReader(urlToId(createdReader.id), 10, 0)
 
     await tap.equal(notebooks.length, 2)
     await tap.ok(notebooks[0].tags)


### PR DESCRIPTION
Filters to the GET /notebooks endpoint:
- search (searches in name and description)
- status (archived or active)
- colour (which is stored in settings.colour as a simple string)
Also:
orderBy either 'created' or 'name'
with optional 'reverse=true' query
By default orders by updated date
Also with pagination (min 10, max 100 per page)

For the GET /library endpoint:
filter by notebook: 
/library?notebook=notebookId
Same thing for the GET /notes endpoint

Also fixed the documentation and cleaned up some of my tests for combined filters. 