### PR TITLE
Dashboard changes

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -278,7 +278,7 @@ class Note extends BaseModel {
     debug('noteId: ', noteId, 'contextId: ', contextId)
     const originalNote = await Note.query()
       .findById(noteId)
-      .withGraphFetched('[body, reader]')
+      .withGraphFetched('[body, reader, tags]')
     if (!originalNote) throw new Error('no note')
     originalNote.contextId = contextId
     originalNote.original = urlToId(originalNote.id)

--- a/models/Note.js
+++ b/models/Note.js
@@ -69,6 +69,7 @@ class Note extends BaseModel {
     const { Tag } = require('./Tag.js')
     const { NoteRelation } = require('./NoteRelation')
     const { NoteContext } = require('./NoteContext')
+    const { Notebook } = require('./Notebook')
     return {
       reader: {
         relation: Model.BelongsToOneRelation,
@@ -128,6 +129,18 @@ class Note extends BaseModel {
             to: 'note_tag.tagId'
           },
           to: 'Tag.id'
+        }
+      },
+      notebooks: {
+        relation: Model.ManyToManyRelation,
+        modelClass: Notebook,
+        join: {
+          from: 'Note.id',
+          through: {
+            from: 'notebook_note.noteId',
+            to: 'notebook_note.notebookId'
+          },
+          to: 'Notebook.id'
         }
       }
     }
@@ -304,7 +317,7 @@ class Note extends BaseModel {
     const note = await Note.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, tags(notDeleted), body, relationsFrom.toNote(notDeleted).body, relationsTo.fromNote(notDeleted).body]'
+        '[reader, tags(notDeleted), body, relationsFrom.toNote(notDeleted).body, relationsTo.fromNote(notDeleted).body, notebooks]'
       )
       .modifiers({
         notDeleted (builder) {

--- a/models/ReadActivity.js
+++ b/models/ReadActivity.js
@@ -110,6 +110,23 @@ class ReadActivity extends BaseModel {
 
     return readActivities[0]
   }
+
+  static async getLatestReadActivitiesForReader (
+    readerId /*: string */,
+    number /*: number */ = 1
+  ) /*: Promise<ReadActivityType|Error> */ {
+    debug('**getLatestReadActivitiesForReader**')
+
+    if (!readerId) return new Error('missing sourceId')
+
+    const readActivities = await ReadActivity.query()
+      .where('readerId', '=', readerId)
+      .orderBy('published', 'desc')
+      .limit(number)
+      .withGraphFetched('[source.[tags, notebooks]]')
+
+    return readActivities
+  }
 }
 
 module.exports = { ReadActivity }

--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -141,7 +141,9 @@ class ReaderNotes {
     }
 
     const readers = await qb
-      .withGraphFetched('replies.[source.[attributions], body, tags]')
+      .withGraphFetched(
+        'replies.[source.[attributions], body, tags, notebooks]'
+      )
       .modifyGraph('replies', builder => {
         builder.modifyGraph('body', bodyBuilder => {
           bodyBuilder.select('content', 'language', 'motivation')

--- a/routes/_swagger-definitions/note-def.js
+++ b/routes/_swagger-definitions/note-def.js
@@ -38,6 +38,10 @@
  *         type: array
  *         items:
  *           $ref: '#/definitions/noteBody'
+ *       tags:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/tag'
  *       published:
  *         type: string
  *         format: date-time

--- a/routes/_swagger-definitions/note-def.js
+++ b/routes/_swagger-definitions/note-def.js
@@ -42,6 +42,10 @@
  *         type: array
  *         items:
  *           $ref: '#/definitions/tag'
+ *       notebooks:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/notebook'
  *       published:
  *         type: string
  *         format: date-time

--- a/routes/_swagger-definitions/source-def.js
+++ b/routes/_swagger-definitions/source-def.js
@@ -309,5 +309,9 @@
  *         type: array
  *         items:
  *           $ref: '#/definitions/source-ref'
+ *       lastRead:
+ *         type: array
+ *         items:
+ *           $ref: '#/definitions/source'
  *
  */

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -17,6 +17,7 @@ const libraryOrderByTitleTests = require('./library/library-orderBy-title.test')
 const libraryOrderByDatePublishedTests = require('./library/library-orderBy-datePublished.test')
 const libraryOrderByTypeTest = require('./library/library-orderBy-type.test')
 const libraryFilterNotebookTests = require('./library/library-filter-notebook.test')
+const libraryLastReadTests = require('./library/library-lastRead.test')
 
 const noteGetTests = require('./note/note-get.test')
 const notePostTests = require('./note/note-post.test')
@@ -148,6 +149,7 @@ const allTests = async () => {
       await libraryFilterKeyword(app)
       await libraryFilterSearch(app)
       await libraryFilterNotebookTests(app)
+      await libraryLastReadTests(app)
     } catch (err) {
       console.log('library integration test error: ', err)
       throw err

--- a/tests/integration/library/library-lastRead.test.js
+++ b/tests/integration/library/library-lastRead.test.js
@@ -1,0 +1,83 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createSource,
+  createReadActivity
+} = require('../../utils/testUtils')
+const app = require('../../../server').app
+
+const test = async () => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const source1 = await createSource(app, token)
+  const source2 = await createSource(app, token)
+  const source3 = await createSource(app, token)
+
+  await createReadActivity(app, token, source2.shortId)
+  await createReadActivity(app, token, source3.shortId)
+
+  await tap.test('Get library with lastRead', async () => {
+    const res = await request(app)
+      .get('/library?lastRead=2')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.status, 200)
+
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.equal(body.totalItems, 3)
+    await tap.equal(body.items.length, 3)
+    await tap.equal(body.lastRead.length, 2)
+    const latest = body.lastRead[0]
+    await tap.equal(latest.shortId, source3.shortId)
+    await tap.ok(latest.tags)
+    await tap.ok(latest.notebooks)
+  })
+
+  await tap.test(
+    'Get library with lastRead number smaller than read',
+    async () => {
+      const res = await request(app)
+        .get('/library?lastRead=1')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+      await tap.equal(res.status, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.totalItems, 3)
+      await tap.equal(body.items.length, 3)
+      await tap.equal(body.lastRead.length, 1)
+      await tap.equal(body.lastRead[0].shortId, source3.shortId)
+    }
+  )
+
+  await tap.test(
+    'Get library with lastRead number larger than read',
+    async () => {
+      const res = await request(app)
+        .get('/library?lastRead=10')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+      await tap.equal(res.status, 200)
+
+      const body = res.body
+      await tap.type(body, 'object')
+      await tap.equal(body.totalItems, 3)
+      await tap.equal(body.items.length, 3)
+      await tap.equal(body.lastRead.length, 2)
+      await tap.equal(body.lastRead[0].shortId, source3.shortId)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/note/note-get.test.js
+++ b/tests/integration/note/note-get.test.js
@@ -7,7 +7,9 @@ const {
   destroyDB,
   createSource,
   createNote,
-  createNoteRelation
+  createNoteRelation,
+  addNoteToCollection,
+  createTag
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
 const _ = require('lodash')
@@ -104,6 +106,23 @@ const test = async app => {
     await tap.ok(body.relations[index2].toNote)
     await tap.equal(body.relations[index2].toNote.shortId, note3.shortId)
     await tap.ok(body.relations[index2].toNote.body)
+  })
+
+  // with tags
+  const tag = await createTag(app, token)
+  await addNoteToCollection(app, token, noteId, tag.id)
+
+  await tap.test('Get Note with Tag', async () => {
+    const res = await request(app)
+      .get(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.ok(body.relations)
+    await tap.equal(body.tags.length, 1)
   })
 
   await tap.test('Try to get Note that does not exist', async () => {

--- a/tests/integration/note/note-get.test.js
+++ b/tests/integration/note/note-get.test.js
@@ -9,6 +9,8 @@ const {
   createNote,
   createNoteRelation,
   addNoteToCollection,
+  createNotebook,
+  addNoteToNotebook,
   createTag
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
@@ -121,8 +123,23 @@ const test = async app => {
     await tap.equal(res.statusCode, 200)
 
     const body = res.body
-    await tap.ok(body.relations)
     await tap.equal(body.tags.length, 1)
+  })
+
+  // with notebook
+  const notebook = await createNotebook(app, token)
+  await addNoteToNotebook(app, token, noteId, notebook.shortId)
+
+  await tap.test('Get Note with Tag', async () => {
+    const res = await request(app)
+      .get(`/notes/${noteId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.statusCode, 200)
+
+    const body = res.body
+    await tap.equal(body.notebooks.length, 1)
   })
 
   await tap.test('Try to get Note that does not exist', async () => {

--- a/tests/integration/readerNotes/readerNotes-filter-flag.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-flag.test.js
@@ -66,6 +66,7 @@ const test = async app => {
     await tap.ok(res.body)
     await tap.equal(res.body.totalItems, 3)
     await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].tags.length, 1)
   })
 
   await addNoteToCollection(app, token, urlToId(note4.id), importantTagId)

--- a/tests/integration/readerNotes/readerNotes-filter-notebook.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-notebook.test.js
@@ -59,6 +59,8 @@ const test = async app => {
     await tap.ok(res.body)
     await tap.equal(res.body.totalItems, 3)
     await tap.equal(res.body.items.length, 3)
+    await tap.ok(res.body.items[0].notebooks)
+    await tap.equal(res.body.items[0].notebooks.length, 1)
   })
 
   await addNoteToNotebook(app, token, urlToId(note4.id), notebookId)

--- a/tests/models/ReadActivity.test.js
+++ b/tests/models/ReadActivity.test.js
@@ -130,6 +130,26 @@ const test = async app => {
     }
   )
 
+  await tap.test('Get latests ReadActivities of a reader', async () => {
+    const lastReadActivity = await ReadActivity.createReadActivity(
+      urlToId(createdReader.id),
+      urlToId(source.id),
+      selectorJsonObject
+    )
+
+    let readActivities = await ReadActivity.getLatestReadActivitiesForReader(
+      urlToId(createdReader.id),
+      2
+    )
+
+    await tap.ok(readActivities)
+    await tap.equal(readActivities.length, 2)
+    await tap.ok(readActivities[0] instanceof ReadActivity)
+    await tap.equal(readActivities[0].id, lastReadActivity.id)
+    await tap.ok(readActivities[0].source)
+    await tap.equal(readActivities[0].readerId, createdReader.id)
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -154,6 +154,26 @@ const createNote = async (app, token, object = {}) => {
   return response.body
 }
 
+const createReadActivity = async (app, token, sourceId, object = {}) => {
+  const readActivityObject = Object.assign(
+    {
+      selector: {
+        type: 'XPathSelector',
+        value: '/html/body/p[2]/table/tr[2]/td[3]/span'
+      }
+    },
+    object
+  )
+  const response = await request(app)
+    .post(`/sources/${sourceId}/readActivity`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+    .send(JSON.stringify(readActivityObject))
+
+  return response.body
+}
+
 const updateNote = async (app, token, object) => {
   const response = await request(app)
     .put(`/notes/${object.shortId}`)
@@ -344,6 +364,7 @@ module.exports = {
   addNoteToCollection,
   createNoteRelation,
   createNoteContext,
+  createReadActivity,
   addNoteToContext,
   updateNote,
   addNoteToOutline,


### PR DESCRIPTION
Changes done for the dashboard:

/notes endpoint
- notes already included tags, but that was not tested or documented. I did that. Also with the /notes/:id endpoint.
- notes now include a 'notebooks' property. This will be a list of notebooks because the API accepts multiple notebooks for a note. Also did the change with the /notes/:id endpoint

/library endpoint
new query parameter: lastRead=<number>
If used, the response object will include a second list of sources under the 'lastRead' property with the sources with the latest read activity. 