### PR TITLE
Colour tags

### DIFF
--- a/models/Reader.js
+++ b/models/Reader.js
@@ -216,19 +216,19 @@ class Reader extends BaseModel {
         type: 'flag'
       },
       {
-        name: 'colour 1',
+        name: 'colour1',
         type: 'colour'
       },
       {
-        name: 'colour 2',
+        name: 'colour2',
         type: 'colour'
       },
       {
-        name: 'colour 3',
+        name: 'colour3',
         type: 'colour'
       },
       {
-        name: 'colour 4',
+        name: 'colour4',
         type: 'colour'
       }
     ])

--- a/models/Reader.js
+++ b/models/Reader.js
@@ -180,22 +180,6 @@ class Reader extends BaseModel {
     // create default Tags
     await Tag.createMultipleTags(newReader.id, [
       {
-        name: 'Research',
-        type: 'workspace'
-      },
-      {
-        name: 'Teaching',
-        type: 'workspace'
-      },
-      {
-        name: 'Public Scholarships',
-        type: 'workspace'
-      },
-      {
-        name: 'Personal',
-        type: 'workspace'
-      },
-      {
         name: 'important',
         type: 'flag'
       },
@@ -233,19 +217,19 @@ class Reader extends BaseModel {
       },
       {
         name: 'colour 1',
-        type: 'flag'
+        type: 'colour'
       },
       {
         name: 'colour 2',
-        type: 'flag'
+        type: 'colour'
       },
       {
         name: 'colour 3',
-        type: 'flag'
+        type: 'colour'
       },
       {
         name: 'colour 4',
-        type: 'flag'
+        type: 'colour'
       }
     ])
 

--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -9,9 +9,12 @@ class ReaderNotes {
     debug('readerId: ', readerId)
     debug('filters: ', filters)
     // note: not applied with filters.document
-    let flag
+    let flag, colour
     if (filters.flag) {
       flag = filters.flag.toLowerCase()
+    }
+    if (filters.colour) {
+      colour = filters.colour.toLowerCase()
     }
     let resultQuery = Note.query(Note.knex())
       .count()
@@ -113,6 +116,25 @@ class ReaderNotes {
         .andWhere('Tag_flag.type', '=', 'flag')
     }
 
+    if (filters.colour) {
+      resultQuery = resultQuery
+        .leftJoin(
+          'note_tag AS note_tag_colour',
+          'note_tag_colour.noteId',
+          '=',
+          'Note.id'
+        )
+        .leftJoin(
+          'Tag AS Tag_colour',
+          'note_tag_colour.tagId',
+          '=',
+          'Tag_colour.id'
+        )
+        .whereNull('Tag_colour.deleted')
+        .where('Tag_colour.name', '=', colour)
+        .andWhere('Tag_colour.type', '=', 'colour')
+    }
+
     const result = await resultQuery
 
     return result[0].count
@@ -129,10 +151,13 @@ class ReaderNotes {
     debug('filters: ', filters)
     offset = !offset ? 0 : offset
     const qb = Reader.query(Reader.knex()).where('authId', '=', readerAuthId)
-    let flag
+    let flag, colour
 
     if (filters.flag) {
       flag = filters.flag.toLowerCase()
+    }
+    if (filters.colour) {
+      colour = filters.colour.toLowerCase()
     }
     if (filters.document) {
       // no pagination for filter by document
@@ -264,6 +289,25 @@ class ReaderNotes {
           builder
             .where('Tag_flag.name', '=', flag)
             .andWhere('Tag_flag.type', '=', 'flag')
+        }
+
+        if (filters.colour) {
+          builder.leftJoin(
+            'note_tag AS note_tag_colour',
+            'note_tag_colour.noteId',
+            '=',
+            'Note.id'
+          )
+          builder.leftJoin(
+            'Tag AS Tag_colour',
+            'note_tag_colour.tagId',
+            '=',
+            'Tag_colour.id'
+          )
+          builder.whereNull('Tag_colour.deleted')
+          builder
+            .where('Tag_colour.name', '=', colour)
+            .andWhere('Tag_colour.type', '=', 'colour')
         }
 
         // orderBy

--- a/routes/notes/readerNotes-get.js
+++ b/routes/notes/readerNotes-get.js
@@ -70,7 +70,13 @@ module.exports = app => {
    *           type: string
    *         description: flag assigned to notes (tag with type 'flag')
    *         enum: ['important', 'question', 'revisit', 'to do', 'idea', 'important term', 'further reading',
-   *           'urgent', 'reference', 'colour 1', 'colour 2', 'colour 3', 'colour 4']
+   *           'urgent', 'reference']
+   *       - in: query
+   *         name: colour
+   *         schema:
+   *           type: string
+   *         description: colour assigned to notes (tag with type 'colour')
+   *         enum: ['colour1', 'colour2', 'colour3', 'colour4']
    *       - in: query
    *         name: publishedStart
    *         schema:
@@ -128,6 +134,7 @@ module.exports = app => {
         collection: req.query.stack,
         tag: req.query.tag,
         flag: req.query.flag,
+        colour: req.query.colour,
         notebook: req.query.notebook,
         publishedStart: req.query.publishedStart,
         publishedEnd: req.query.publishedEnd

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -49,6 +49,7 @@ const readerNotesFilterDateRange = require('./readerNotes/readerNotes-filter-dat
 const readerNotesFilterFlagTests = require('./readerNotes/readerNotes-filter-flag.test')
 const readerNotesFilterDocumentTests = require('./readerNotes/readerNotes-filter-document.test')
 const readerNotesFilterNotebookTests = require('./readerNotes/readerNotes-filter-notebook.test')
+const readerNotesFilterColourTests = require('./readerNotes/readerNotes-filter-colour.test')
 
 const sourceAddTagTests = require('./tag/source-tag-put.test')
 const sourceRemoveTagTests = require('./tag/source-tag-delete.test')
@@ -226,6 +227,7 @@ const allTests = async () => {
       await readerNotesFilterFlagTests(app)
       await readerNotesFilterDocumentTests(app)
       await readerNotesFilterNotebookTests(app)
+      await readerNotesFilterColourTests(app)
     } catch (err) {
       console.log('readerNotes integration tests error: ', err)
       throw err

--- a/tests/integration/library/library-lastRead.test.js
+++ b/tests/integration/library/library-lastRead.test.js
@@ -13,7 +13,8 @@ const test = async () => {
   const token = getToken()
   await createUser(app, token)
 
-  const source1 = await createSource(app, token)
+  // source1
+  await createSource(app, token)
   const source2 = await createSource(app, token)
   const source3 = await createSource(app, token)
 

--- a/tests/integration/reader/reader-post.test.js
+++ b/tests/integration/reader/reader-post.test.js
@@ -54,7 +54,11 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
-    await tap.equal(res.body.length, 17)
+    await tap.equal(res.body.length, 13)
+    const flags = res.body.filter(item => item.type === 'flag')
+    await tap.equal(flags.length, 9)
+    const colours = res.body.filter(item => item.type === 'colour')
+    await tap.equal(colours.length, 4)
   })
 
   await tap.test('Create Simple Reader', async () => {

--- a/tests/integration/readerNotes/readerNotes-filter-colour.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-colour.test.js
@@ -1,0 +1,99 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote,
+  addNoteToCollection
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+const _ = require('lodash')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  // get reader colour tags:
+  const tagsres = await request(app)
+    .get(`/tags`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .type('application/ld+json')
+
+  const colour1TagId = _.find(tagsres.body, { name: 'colour1' }).id
+
+  const createNoteSimplified = async object => {
+    const noteObj = Object.assign(
+      {
+        body: { motivation: 'test' }
+      },
+      object
+    )
+    return await createNote(app, token, noteObj)
+  }
+
+  const note1 = await createNoteSimplified() // 1
+  const note2 = await createNoteSimplified() // 2
+  const note3 = await createNoteSimplified() // 3
+  const note4 = await createNoteSimplified() // 4
+  const note5 = await createNoteSimplified() // 5
+  const note6 = await createNoteSimplified() // 6
+  const note7 = await createNoteSimplified() // 7
+  const note8 = await createNoteSimplified() // 8
+  const note9 = await createNoteSimplified() // 9
+  const note10 = await createNoteSimplified() // 10
+  const note11 = await createNoteSimplified() // 11
+  const note12 = await createNoteSimplified() // 12
+  const note13 = await createNoteSimplified() // 13
+  await createNoteSimplified()
+  await createNoteSimplified()
+  await createNoteSimplified()
+
+  // add 13 notes to colour1
+  await addNoteToCollection(app, token, urlToId(note1.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note2.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note3.id), colour1TagId)
+
+  await tap.test('Get Notes by colour', async () => {
+    const res = await request(app)
+      .get(`/notes?colour=colOUr1`) // not case sensitive
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 3)
+    await tap.equal(res.body.items.length, 3)
+    await tap.equal(res.body.items[0].tags.length, 1)
+  })
+
+  await addNoteToCollection(app, token, urlToId(note4.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note5.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note6.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note7.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note8.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note9.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note10.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note11.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note12.id), colour1TagId)
+  await addNoteToCollection(app, token, urlToId(note13.id), colour1TagId)
+
+  await tap.test('Get Notes by colour with pagination', async () => {
+    const res = await request(app)
+      .get(`/notes?colour=colour1&limit=12&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 13)
+    await tap.equal(res.body.items.length, 1)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/tag/tag-delete.test.js
+++ b/tests/integration/tag/tag-delete.test.js
@@ -69,7 +69,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
-    await tap.equal(libraryBefore.body.tags.length, 18) // 4 default modes + 13 flags + our tag
+    await tap.equal(libraryBefore.body.tags.length, 14) // 9 flags + 4 colours + our tag
 
     // get the tags list before
     const tagsBefore = await request(app)
@@ -78,7 +78,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
-    await tap.equal(tagsBefore.body.length, 18) // 4 default modes + 13 flags + our tag
+    await tap.equal(tagsBefore.body.length, 14) // 9 flags + 4 colours + our tag
 
     // Add a tag to the note and source
     await addNoteToCollection(app, token, urlToId(noteUrl), urlToId(stack.id))
@@ -124,7 +124,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
-    await tap.equal(libraryAfter.body.tags.length, 17) // default modes + flags
+    await tap.equal(libraryAfter.body.tags.length, 13) // 9 flags + 4 colours
     await tap.equal(libraryAfter.body.items[0].tags.length, 0)
 
     // get the tags list after
@@ -134,7 +134,7 @@ const test = async app => {
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
 
-    await tap.equal(tagsAfter.body.length, 17) // 4 default modes + 13 flags
+    await tap.equal(tagsAfter.body.length, 13) // 9 flags + 4 colours
 
     // Note and Source should no longer have the tag
     const resNoteAfter = await request(app)

--- a/tests/integration/tag/tag-put.test.js
+++ b/tests/integration/tag/tag-put.test.js
@@ -65,7 +65,7 @@ const test = async app => {
       noteWithTag.tags[0].name,
       libraryBefore.body.tags[tagIndexBefore].name
     )
-    await tap.equal(libraryBefore.body.tags.length, 18) // 4 modes + 13 flags + created tag
+    await tap.equal(libraryBefore.body.tags.length, 14) // 9 flags + 4 colours + created tag
     const tagIndex = _.findIndex(libraryBefore.body.tags, { name: stack.name })
     await tap.ok(tagIndex !== -1)
 
@@ -98,7 +98,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 18) // modes + flags + created
+    await tap.equal(libraryAfter.body.tags.length, 14) // 9 flags + 4 colours + created
     const tagIndex2 = _.findIndex(libraryAfter.body.tags, { name: 'newName' })
     await tap.ok(tagIndex2 !== -1)
     await tap.equal(noteWithNewTag.tags.length, 1)
@@ -134,7 +134,7 @@ const test = async app => {
 
     // Get the note after the modifications
     const noteWithNewTag = await Note.byId(urlToId(noteUrl))
-    await tap.equal(libraryAfter.body.tags.length, 18) // modes + tags + 1 created
+    await tap.equal(libraryAfter.body.tags.length, 14) // 9 flags + 4 colours + 1 created
     const tagIndex = _.findIndex(libraryAfter.body.tags, { name: 'newName' })
     await tap.ok(tagIndex !== -1)
     await tap.equal(libraryAfter.body.tags[tagIndex].json.property, 'value!!')

--- a/tests/integration/tag/tags-get.test.js
+++ b/tests/integration/tag/tags-get.test.js
@@ -20,7 +20,7 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.length, 17) // 4 default modes + 13 flags
+    await tap.equal(res.body.length, 13) // 9 flags + 4 colours
   })
 
   await createTag(app, token, { name: 'tag1' })
@@ -34,7 +34,7 @@ const test = async app => {
       .type('application/ld+json')
 
     await tap.equal(res.status, 200)
-    await tap.equal(res.body.length, 19) // 4 default modes + 13 flags + 2 created tags
+    await tap.equal(res.body.length, 15) // 9 flags + 4 colours + 2 created tags
 
     const body = res.body[0]
     await tap.ok(body.id)

--- a/tests/models/Tag.test.js
+++ b/tests/models/Tag.test.js
@@ -121,7 +121,7 @@ const test = async app => {
     })
     let responseGet = await Tag.byReaderId(urlToId(createdReader.id))
 
-    await tap.equal(responseGet.length, 22) // 4 default modes, 13 flags and 2 tags we created
+    await tap.equal(responseGet.length, 18) // 9 flags + 4 colours + 5 tags we created
     await tap.ok(responseGet[0] instanceof Tag)
     await tap.ok(responseGet[1] instanceof Tag)
     await tap.ok(responseGet[2] instanceof Tag)


### PR DESCRIPTION
the colour tags have been changed from type 'flag' to type 'colour'
I also added a colour filter to the notes endpoint:
GET /notes?colour=colour1
This works just like the flag filter. Accepted values are 'colour1', 'colour2', 'colour3', 'colour4'

I also removed the workspace tags. 