### PR TITLE
cleanup return objects

### DIFF
--- a/models/Note_Tag.js
+++ b/models/Note_Tag.js
@@ -65,8 +65,14 @@ class Note_Tag extends Model {
     try {
       await Note_Tag.query().insert(list)
     } catch (err) {
+      // if inserting all at once failed, insert one at a time and ignore errors
       list.forEach(async item => {
-        await Note_Tag.query().insert(item)
+        try {
+          await Note_Tag.query().insert(item)
+        } catch (err2) {
+          // eslint-disable-next-line
+          return
+        }
       })
     }
   }

--- a/tests/integration/library/library-filter-collection.test.js
+++ b/tests/integration/library/library-filter-collection.test.js
@@ -61,7 +61,8 @@ const test = async () => {
   const source11 = await createSourceSimplified({
     name: 'Source 11'
   })
-  const source12 = await createSourceSimplified({ name: 'Source 12' })
+  // source12
+  await createSourceSimplified({ name: 'Source 12' })
   const source13 = await createSourceSimplified({
     name: 'Source 13'
   })

--- a/tests/integration/reader/reader-delete.test.js
+++ b/tests/integration/reader/reader-delete.test.js
@@ -255,7 +255,7 @@ const test = async app => {
 
       // PUT /sources/:sourceId/tags/:tagId
       const res4 = await request(app)
-        .put(`/sources/${source.shortId}/tags/${tag.shortId}`)
+        .put(`/sources/${source.shortId}/tags/${tag.id}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
@@ -267,7 +267,7 @@ const test = async app => {
 
       // DELETE /sources/:sourceId/tags/:tagId
       const res5 = await request(app)
-        .delete(`/sources/${source.shortId}/tags/${tag.shortId}`)
+        .delete(`/sources/${source.shortId}/tags/${tag.id}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')

--- a/tests/integration/readerNotes/readerNotes-filter-source.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-source.test.js
@@ -68,7 +68,6 @@ const test = async app => {
 
     await tap.equal(res.status, 200)
     const body = res.body
-
     await tap.equal(body.totalItems, 2)
     await tap.equal(body.items.length, 2)
     await tap.equal(body.items[0].type, 'Note')

--- a/tests/integration/tag/tag-post.test.js
+++ b/tests/integration/tag/tag-post.test.js
@@ -114,7 +114,7 @@ const test = async app => {
     await tap.ok(Array.isArray(body.tags))
     await tap.type(body.tags[0].name, 'string')
     await tap.ok(
-      urlToId(body.tags[0].id).startsWith(urlToId(body.tags[0].readerId))
+      urlToId(body.tags[0].id).startsWith(urlToId(readerCompleteUrl))
     ) // check that id contains readerId
     const tagIndex = _.findIndex(body.tags, { type: 'newTagType!' })
     await tap.ok(tagIndex !== -1)

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -330,11 +330,12 @@ const addTagToNotebook = async (app, token, tagId, notebookId) => {
 
 const addNoteToCollection = async (app, token, noteId, tagId) => {
   tagId = urlToId(tagId)
-  return await request(app)
+  const res = await request(app)
     .put(`/notes/${noteId}/tags/${tagId}`)
     .set('Host', 'reader-api.test')
     .set('Authorization', `Bearer ${token}`)
     .type('application/ld+json')
+  return res
 }
 
 const createNotebook = async (app, token, object) => {


### PR DESCRIPTION
This cleans up the objects returned by the GET /library and GET /notes endpoints.
For example, the library returns the tags, as well as tags for each source. Those will no longer include a readerId, 'deleted' timestamp, etc. It shouldn't change anything for the front-end. If you worry that it does, I can clarify what exactly has been removed.

there is probably more that can be removed, but I will look at that more closely when I look at the overall design of the API 