### PR TITLE
Turning a source into a reference

### DIFF
--- a/migrations/20200901101934_add_referenced_to_sources.js
+++ b/migrations/20200901101934_add_referenced_to_sources.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('Source', function(table) {
+    table.timestamp('referenced')
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('Source', function(table) {
+    table.dropColumn('referenced')
+  })
+};

--- a/models/Note.js
+++ b/models/Note.js
@@ -317,11 +317,14 @@ class Note extends BaseModel {
     const note = await Note.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, tags(notDeleted), body, relationsFrom.toNote(notDeleted).body, relationsTo.fromNote(notDeleted).body, notebooks]'
+        '[reader, tags(notDeleted), body, relationsFrom.toNote(notDeleted).body, relationsTo.fromNote(notDeleted).body, notebooks, source(notDeleted, selectSource).attributions]'
       )
       .modifiers({
         notDeleted (builder) {
           builder.whereNull('deleted')
+        },
+        selectSource (builder) {
+          builder.select('id', 'name', 'type', 'metadata')
         }
       })
 
@@ -333,7 +336,6 @@ class Note extends BaseModel {
       note.relationsTo = null
     }
     debug('note: ', note)
-
     return note
   }
 

--- a/models/Note.js
+++ b/models/Note.js
@@ -335,6 +335,7 @@ class Note extends BaseModel {
       note.relationsFrom = null
       note.relationsTo = null
     }
+    note.sourceId = null
     debug('note: ', note)
     return note
   }

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -159,11 +159,14 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[body], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted)]'
+        '[reader, notes(notDeleted).[body], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced)]'
       )
       .modifiers({
         notDeleted (builder) {
           builder.whereNull('deleted')
+        },
+        notReferenced (builder) {
+          builder.whereNull('referenced')
         }
       })
       .whereNull('deleted')

--- a/models/Source.js
+++ b/models/Source.js
@@ -563,11 +563,6 @@ class Source extends BaseModel {
   static async delete (id /*: string */) /*: Promise<number|null> */ {
     debug('**delete**')
     debug('id: ', id)
-    let source = await Source.query().findById(id)
-
-    if (!source || source.deleted) {
-      return null
-    }
 
     // Delete Source_Tag associated with source
     await Source_Tag.deleteSourceTagsOfSource(id)
@@ -576,9 +571,10 @@ class Source extends BaseModel {
     // if (elasticsearchQueue) {
     //   await elasticsearchQueue.add({ type: 'delete', sourceId: id })
     // }
-
     const date = new Date().toISOString()
-    return await Source.query().patchAndFetchById(id, { deleted: date })
+    return await Source.query()
+      .patchAndFetchById(id, { deleted: date })
+      .whereNull('deleted')
   }
 
   static async deleteNotes (id /*: string */) /*: Promise<number|null> */ {

--- a/models/Source.js
+++ b/models/Source.js
@@ -159,7 +159,8 @@ class Source extends BaseModel {
         json: { type: ['object', 'null'] },
         updated: { type: 'string', format: 'date-time' },
         published: { type: 'string', format: 'date-time' },
-        deleted: { type: 'string', format: 'date-time' }
+        deleted: { type: 'string', format: 'date-time' },
+        referenced: { type: 'string', format: 'date-time' }
       },
       required: ['name', 'readerId', 'type']
     }
@@ -536,7 +537,7 @@ class Source extends BaseModel {
         }
       })
     debug('retrieved source: ', source)
-    if (!source || source.deleted) return null
+    if (!source || source.deleted || source.referenced) return null
 
     const latestReadActivity = await ReadActivity.getLatestReadActivity(id)
     debug('latest readActivity: ', latestReadActivity)
@@ -554,7 +555,7 @@ class Source extends BaseModel {
     debug('**checkIfExists**')
     debug('id: ', id)
     const source = await Source.query().findById(id)
-    if (!source || source.deleted) {
+    if (!source || source.deleted || source.referenced) {
       return false
     } else return true
   }
@@ -587,6 +588,16 @@ class Source extends BaseModel {
     return await Note.query()
       .patch({ deleted: time })
       .where('sourceId', '=', id)
+  }
+
+  static async toReference (id /*: string */) /*: Promise<any> */ {
+    const date = new Date().toISOString()
+    return await Source.query().patchAndFetchById(id, {
+      referenced: date,
+      links: null,
+      resources: null,
+      readingOrder: null
+    })
   }
 
   static async batchUpdate (body /*: any */) /*: Promise<any> */ {

--- a/models/library.js
+++ b/models/library.js
@@ -145,6 +145,7 @@ class Library {
       .from('Source')
     builder.distinct('Source.id')
     builder.whereNull('Source.deleted')
+    builder.whereNull('Source.referenced')
     builder.where('Source.readerId', '=', readerId)
 
     this.applyFilters(builder, filters)
@@ -201,6 +202,7 @@ class Library {
           .from('Source')
         builder.distinct('Source.id')
         builder.whereNull('Source.deleted')
+        builder.whereNull('Source.referenced')
 
         this.applyFilters(builder, filters)
 

--- a/routes/sources/source-delete.js
+++ b/routes/sources/source-delete.js
@@ -23,6 +23,11 @@ module.exports = function (app) {
    *         schema:
    *           type: string
    *         required: true
+   *       - in: query
+   *         name: reference
+   *         schema:
+   *           type: boolean
+   *         description: flag a source that you want to keep as a reference for notes. The source will no longer be in the library.
    *     security:
    *       - Bearer: []
    *     responses:
@@ -66,7 +71,13 @@ module.exports = function (app) {
           )
         }
 
-        const result = await Source.delete(sourceId)
+        let result
+        if (req.query.reference) {
+          result = await Source.toReference(sourceId)
+        } else {
+          result = await Source.delete(sourceId)
+        }
+
         debug('result: ', result)
         if (!result) {
           return next(

--- a/routes/sources/source-get.js
+++ b/routes/sources/source-get.js
@@ -68,9 +68,7 @@ module.exports = function (app) {
               JSON.stringify(
                 Object.assign(sourceJson, {
                   replies: source.replies
-                    ? source.replies
-                      .filter(note => !note.deleted)
-                      .map(note => note.asRef())
+                    ? source.replies.map(note => note.asRef())
                     : []
                 })
               )

--- a/tests/integration/note/note-get.test.js
+++ b/tests/integration/note/note-get.test.js
@@ -50,7 +50,6 @@ const test = async app => {
     await tap.equal(body.body[0].motivation, 'test')
     await tap.equal(body.body[0].content, 'content goes here')
     await tap.equal(body.target.property1, 'target information')
-    await tap.equal(urlToId(body.sourceId), sourceId)
     await tap.equal(body.document, 'doc123')
     await tap.ok(body.published)
     await tap.ok(body.updated)
@@ -79,7 +78,7 @@ const test = async app => {
     await tap.equal(body.body[0].motivation, 'test')
     await tap.equal(body.body[0].content, 'content goes here')
     await tap.equal(body.target.property1, 'target information')
-    await tap.equal(urlToId(body.sourceId), sourceId)
+    await tap.ok(body.source)
     await tap.ok(body.published)
     await tap.ok(body.updated)
   })
@@ -203,8 +202,7 @@ const test = async app => {
     const body = res.body
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
-    await tap.ok(body.sourceId)
-    await tap.equal(urlToId(body.sourceId), sourceId)
+    await tap.ok(body.source)
 
     // should still include source information
     await tap.ok(body.source)
@@ -236,7 +234,7 @@ const test = async app => {
     const body = res.body
     await tap.type(body, 'object')
     await tap.type(body.id, 'string')
-    // await tap.notOk(body.sourceId) not working: for some reason, cannot update a foreign key to null
+    await tap.notOk(body.sourceId)
     await tap.notOk(body.source)
   })
 

--- a/tests/integration/note/note-get.test.js
+++ b/tests/integration/note/note-get.test.js
@@ -15,7 +15,6 @@ const {
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
 const _ = require('lodash')
-const { toPairs } = require('lodash')
 
 const test = async app => {
   const token = getToken()

--- a/tests/models/Source.test.js
+++ b/tests/models/Source.test.js
@@ -531,6 +531,20 @@ const test = async app => {
     await tap.ok(note2.deleted)
   })
 
+  await tap.test('Turn a Source into a reference', async () => {
+    // before
+    const source2 = await Source.byId(sourceId2)
+    await tap.ok(source2.links)
+    await tap.ok(source2.resources)
+    await tap.ok(source2.readingOrder)
+
+    const result = await Source.toReference(sourceId2)
+    await tap.ok(result.referenced)
+    await tap.notOk(result.links)
+    await tap.notOk(result.resources)
+    await tap.notOk(result.readingOrder)
+  })
+
   await tap.test('Get SourceIds By Collection', async () => {
     // create a third source:
     let response = await Source.createSource(createdReader, simpleSource)


### PR DESCRIPTION
This adds an optional query parameter to the delete source route:
DELETE /sources/:id?reference=true

This will modify the source to add a 'referenced' timestamp and remove data that is stored in 'links', 'resources', 'readingOrder'
Eventually we should probably make it delete the actual content files (for normal deletes too, of course)

When you are getting the library,  'referenced' sources will not show up. You also cannot fetch them individually. However, when you get the notes (either individually or in the /notes endpoint), it will include the source information. 

In doing that, I noticed that we were not actually getting the source information when fetching the notes individually. That is fixed.

I also noticed that when a source is soft-deleted, its id will still show up in the Note.sourceId I tried to fix this, but there seems to be a weird bug with knex or objection (either that, or something I don't understand about sql) and I am not able to update a foreign key to null. The sourceId will disappear once we run the hardDelete. My suggestion to fix this would be to remove the sourceId. It is not necessary at all, since we are actually loading the source object before returning the note. In fact, any time we have are eager loading something from a foreign key, we can probably remove the foreign key before returning the object. Makes sense?

Anothe rimportant note: this pull request contains the first ever proper migration that does not involve resetting the database. Hopefully it wont break everything. :crossed_fingers: 