### PR TITLE
Source with read activity

### DIFF
--- a/models/library.js
+++ b/models/library.js
@@ -208,7 +208,7 @@ class Library {
 
         builder
           .withGraphFetched(
-            '[tags(selectTags, notDeleted), attributions(selectAttributions, notDeleted)]'
+            '[tags(selectTags, notDeleted), attributions(selectAttributions, notDeleted), readActivities(latestFirst)]'
           )
           .modifiers({
             selectAttributions (modifierBuilder) {
@@ -233,6 +233,9 @@ class Library {
                 'updated',
                 'Tag.json'
               )
+            },
+            latestFirst (modifierBuilder) {
+              modifierBuilder.orderBy('published', 'desc')
             }
           })
 

--- a/routes/_swagger-definitions/source-def.js
+++ b/routes/_swagger-definitions/source-def.js
@@ -183,9 +183,16 @@
  *         type: array
  *         items:
  *           $ref: '#/definitions/link'
- *       position:
+ *       lastReadActivity:
  *         type: object
  *         readOnly: true
+ *         properties:
+ *           id:
+ *             type: string
+ *           selector:
+ *             type: object
+ *           json:
+ *             type: object
  *       json:
  *         type: object
  *       readerId:
@@ -279,6 +286,16 @@
  *         type: array
  *         items:
  *           $ref: '#/definitions/link'
+ *       lastReadActivity:
+ *         type: object
+ *         readOnly: true
+ *         properties:
+ *           id:
+ *             type: string
+ *           selector:
+ *             type: object
+ *           json:
+ *             type: object
  *       published:
  *         type: string
  *         format: timestamp

--- a/routes/sources/library-get.js
+++ b/routes/sources/library-get.js
@@ -195,6 +195,9 @@ module.exports = app => {
           debug('count: ', count)
           let reader = returnedReader
           let sources = reader.sources.map(source => {
+            if (source.readActivities) {
+              source.lastReadActivity = source.readActivities[0]
+            }
             return _.pick(source.toJSON(), [
               'id',
               'name',
@@ -210,7 +213,8 @@ module.exports = app => {
               'author',
               'editor',
               'bookFormat',
-              'inLanguage'
+              'inLanguage',
+              'lastReadActivity'
             ])
           })
           debug('sources after filtering out properties: ', sources)

--- a/tests/integration/source/source-get.test.js
+++ b/tests/integration/source/source-get.test.js
@@ -11,8 +11,7 @@ const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   const token = getToken()
-  const readerCompleteUrl = await createUser(app, token)
-  const readerId = urlToId(readerCompleteUrl)
+  await createUser(app, token)
 
   const now = new Date().toISOString()
 


### PR DESCRIPTION
This adds 'lastReadActivity' to source objects retrieved with both those endpoints:
GET /sources/:id
GET /library
It only gives you one readActivity object. 