### PR TITLE
notebook notes with source and tags, notebook sources with tags

### DIFF
--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -159,7 +159,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[body], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced)]'
+        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags]]'
       )
       .modifiers({
         notDeleted (builder) {


### PR DESCRIPTION
So when you are fetching an individual notebook with GET /notebooks/{notebookId}
You will now get more information:
notebook.notes -> each note will have a .tags array and a .source property, if relevant.
notebook.sources -> each source will have a .tags array property

@cesarCSM was that everything?