### PR TITLE
Create source in notebook

### DIFF
--- a/models/Source.js
+++ b/models/Source.js
@@ -495,7 +495,7 @@ class Source extends BaseModel {
   static async createSource (
     reader /*: any */,
     source /*: any */
-  ) /*: Promise<SourceType|Error> */ {
+  ) /*: Promise<SourceType> */ {
     debug('**createSource**')
     debug('reader: ', reader)
     debug('incoming source: ', source)

--- a/routes/notebooks/notebook-source-post.js
+++ b/routes/notebooks/notebook-source-post.js
@@ -1,0 +1,133 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const { Source } = require('../../models/Source')
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { checkOwnership } = require('../../utils/utils')
+const debug = require('debug')('ink:routes:notebook-note-post')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /notebooks/{notebookId}/sources:
+   *   post:
+   *     tags:
+   *       - notebook-source
+   *     description: Create a source and assign it to a Notebook
+   *     security:
+   *       - Bearer: []
+   *     parameters:
+   *       - in: path
+   *         name: notebookId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/source'
+   *     responses:
+   *       201:
+   *         description: Successfully created Source and assigned it to Notebook
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/source'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: 'No Authentication'
+   *       403:
+   *         description: 'Access to reader {id} disallowed'
+   *       404:
+   *         description: Notebook not found
+   */
+  app.use('/', router)
+  router
+    .route('/notebooks/:notebookId/sources')
+    .post(jwtAuth, function (req, res, next) {
+      const notebookId = req.params.notebookId
+      debug('notebookId', notebookId)
+      debug('request body: ', req.body)
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          if (!checkOwnership(reader.id, notebookId)) {
+            return next(
+              boom.forbidden(`Access to Notebook ${notebookId} disallowed`, {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+
+          const body = req.body
+          if (typeof body !== 'object' || _.isEmpty(body)) {
+            return next(
+              boom.badRequest('Body must be a JSON object', {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          let createdSource
+          try {
+            createdSource = await Source.createSourceInNotebook(
+              reader,
+              notebookId,
+              body
+            )
+          } catch (err) {
+            if (err instanceof ValidationError) {
+              return next(
+                boom.badRequest(
+                  `Validation Error on Create Source: ${err.message}`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body,
+                    validation: err.data
+                  }
+                )
+              )
+            } else if (err.message === 'no notebook') {
+              return next(
+                boom.notFound(
+                  `Create Source Error: No Notebook found with id: ${notebookId}`,
+                  {
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else {
+              return next(
+                boom.badRequest(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.setHeader('Location', createdSource.id)
+          res.status(201).end(JSON.stringify(createdSource.toJSON()))
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/server.js
+++ b/server.js
@@ -86,10 +86,13 @@ const notebookDeleteNoteRoute = require('./routes/notebooks/notebook-delete-note
 const notebookPostNoteRoute = require('./routes/notebooks/notebook-note-post') // POST /notebooks/:id/notes
 const notebookPutTagRoute = require('./routes/notebooks/notebook-put-tag') // PUT /notebooks/:id/tags/:tagId
 const notebookDeleteTagRoute = require('./routes/notebooks/notebook-delete-tag') // DELETE /notebooks/:id/tags/:tagId
+const notebookPostSourceRoute = require('./routes/notebooks/notebook-source-post')
 
 const hardDeleteRoute = require('./routes/hardDelete')
 
 const metricsGetRoute = require('./routes/metrics-get')
+const notebookNotePost = require('./routes/notebooks/notebook-note-post')
+const notebookSourcePost = require('./routes/notebooks/notebook-source-post')
 
 const setupKnex = async skip_migrate => {
   let config
@@ -290,6 +293,7 @@ notebookDeleteNoteRoute(app)
 notebookPostNoteRoute(app)
 notebookPutTagRoute(app)
 notebookDeleteTagRoute(app)
+notebookPostSourceRoute(app)
 hardDeleteRoute(app)
 metricsGetRoute(app)
 

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -89,6 +89,7 @@ const notebookPubDeleteTests = require('./notebook/notebook-source-delete.test')
 const notebookNotePutTests = require('./notebook/notebook-note-put.test')
 const notebookNoteDeleteTests = require('./notebook/notebook-note-delete.test')
 const notebookNotePostTests = require('./notebook/notebook-note-post.test')
+const notebookSourcePostTests = require('./notebook/notebook-source-post.test')
 const notebookTagPutTests = require('./notebook/notebook-tag-put.test')
 const notebookTagDeleteTests = require('./notebook/notebook-tag-delete.test')
 const notebooksGetPaginateTests = require('./notebook/notebooks-get-paginate.test')
@@ -297,6 +298,7 @@ const allTests = async () => {
       await notebooksGetOrderByNameTests(app)
       await notebooksGetOrderByCreated(app)
       await notebooksGetOrderByDefaultTests(app)
+      await notebookSourcePostTests(app)
     } catch (err) {
       console.log('notebook integration test error: ', err)
       throw err

--- a/tests/integration/notebook/notebook-source-post.test.js
+++ b/tests/integration/notebook/notebook-source-post.test.js
@@ -1,0 +1,174 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  const readerUrl = await createUser(app, token)
+  const readerId = urlToId(readerUrl)
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  await tap.test('Create Source in Notebook', async () => {
+    const res = await request(app)
+      .post(`/notebooks/${notebookId}/sources`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          name: 'source1',
+          type: 'Book',
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), readerId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.equal(body.name, 'source1')
+    await tap.equal(body.type, 'Book')
+    await tap.ok(body.published)
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location') + '/', body.id)
+
+    // source should show up in notebook
+    const resNotebook = await request(app)
+      .get(`/notebooks/${notebookId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(resNotebook.body.sources.length, 1)
+  })
+
+  await tap.test(
+    'Try to create a Source in a Notebook without a type',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebookId}/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'source1'
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create Source: type: is a required property'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}/sources`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.name, 'source1')
+    }
+  )
+
+  await tap.test(
+    'Try to create a Source in a Notebook with an invalid json',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebookId}/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'source2',
+            type: 'Book',
+            json: 'a string!'
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create Source: json: should be object,null'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}/sources`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.json, 'a string!')
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(error.details.validation.json[0].keyword, 'type')
+      await tap.equal(
+        error.details.validation.json[0].params.type,
+        'object,null'
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a Source for a Notebook that does not exist',
+    async () => {
+      const resSourcesBefore = await request(app)
+        .get(`/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const numberOfSourcesBefore = resSourcesBefore.body.items.length
+
+      const res = await request(app)
+        .post(`/notebooks/${notebookId}abc/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'source2',
+            type: 'Book'
+          })
+        )
+
+      await tap.equal(res.status, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(
+        error.message,
+        `Create Source Error: No Notebook found with id: ${notebookId}abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebookId}abc/sources`
+      )
+
+      // source should source exist
+
+      const resSourcesAfter = await request(app)
+        .get(`/library`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(resSourcesAfter.body.items.length, numberOfSourcesBefore)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test


### PR DESCRIPTION
New route:
POST /notebooks/{notebookId}/sources
to create a source inside a notebook. This creates a source and creates a notebook_source relation.

By doing this, I also noticed that this route, and the POST /notebooks/{notebookId}/notes route, it wasn't possible to create a source or note with tags, like you can do with POST /sources and POST /notes. I fixed that. 