### PR TITLE
Handling invalid tags better when creating them with notes or sources

### DIFF
--- a/models/Tag.js
+++ b/models/Tag.js
@@ -83,7 +83,22 @@ class Tag extends BaseModel {
       return tag
     })
 
-    return await Tag.query().insert(tagArray)
+    try {
+      return await Tag.query().insert(tagArray)
+    } catch (err) {
+      // if inserting all the tags at once failed, do one at a time, ignoring errors
+      let createdTags = []
+      tagArray.forEach(async tag => {
+        try {
+          let createdTag = await this.createTag(readerId, tag)
+          createdTags.push(createdTag)
+        } catch (err2) {
+          // eslint-disable-next-line
+          return
+        }
+      })
+      return createdTags
+    }
   }
 
   async delete () /*: Promise<number> */ {

--- a/tests/integration/note/note-post.test.js
+++ b/tests/integration/note/note-post.test.js
@@ -207,6 +207,39 @@ const test = async app => {
     await tap.equal(note.tags.length, 3)
   })
 
+  await tap.test(
+    'Create Note with existing and tag with invalid id',
+    async () => {
+      const res = await request(app)
+        .post('/notes')
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: {
+              content: 'this is the content of the note',
+              motivation: 'test'
+            },
+            tags: [tag1, { name: 'invalidTag' }]
+          })
+        )
+
+      const body = res.body
+      await tap.notOk(body.tags)
+
+      const noteRes = await request(app)
+        .get(`/notes/${body.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const note = noteRes.body
+      await tap.ok(note.tags)
+      await tap.equal(note.tags.length, 1)
+    }
+  )
+
   await tap.test('Create Note with existing and invalid tags', async () => {
     const res = await request(app)
       .post('/notes')
@@ -306,7 +339,7 @@ const test = async app => {
       .set('Host', 'reader-api.test')
       .set('Authorization', `Bearer ${token}`)
       .type('application/ld+json')
-    await tap.equal(res.body.totalItems, 6)
+    await tap.equal(res.body.totalItems, 7)
   })
 
   await tap.test('Try to create a Note with an invalid json', async () => {
@@ -408,7 +441,7 @@ const test = async app => {
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token}`)
         .type('application/ld+json')
-      await tap.equal(res.body.totalItems, 6)
+      await tap.equal(res.body.totalItems, 7)
     }
   )
 

--- a/tests/integration/notebook/notebook-source-post.test.js
+++ b/tests/integration/notebook/notebook-source-post.test.js
@@ -114,6 +114,38 @@ const test = async app => {
     await tap.equal(body.tags.length, 2)
   })
 
+  await tap.test(
+    'Create a source with existing tags and tags with invalid ids',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebookId}/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'Source Keyword',
+            type: 'Book',
+            tags: [tag1, { id: tag2.id + 'abc', name: 'tag3', type: 'stack' }]
+          })
+        )
+
+      await tap.equal(res.status, 201)
+      await tap.ok(res.body)
+      await tap.ok(res.body.shortId)
+
+      const resSource = await request(app)
+        .get(`/sources/${res.body.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const body = resSource.body
+      await tap.ok(body.tags)
+      await tap.equal(body.tags.length, 1)
+    }
+  )
+
   await tap.test('Create a source with existing and invalid tags', async () => {
     const res = await request(app)
       .post(`/notebooks/${notebookId}/sources`)
@@ -124,7 +156,7 @@ const test = async app => {
         JSON.stringify({
           name: 'Source Keyword',
           type: 'Book',
-          tags: [tag1, { id: tag2.id + 'abc', name: 'tag3', type: 'stack' }]
+          tags: [tag1, { name: 'tagA', type: 'test' }]
         })
       )
 

--- a/tests/integration/source/source-post.test.js
+++ b/tests/integration/source/source-post.test.js
@@ -386,34 +386,69 @@ const test = async app => {
     await tap.equal(body.tags.length, 2)
   })
 
-  await tap.test('Create a source with existing and invalid tags', async () => {
-    const res = await request(app)
-      .post(`/sources`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type('application/ld+json')
-      .send(
-        JSON.stringify({
-          name: 'Source Keyword',
-          type: 'Book',
-          tags: [tag1, { id: tag2.id + 'abc', name: 'tag3', type: 'stack' }]
-        })
-      )
+  await tap.test(
+    'Create a source with existing and tags with invalid ids',
+    async () => {
+      const res = await request(app)
+        .post(`/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'Source Keyword',
+            type: 'Book',
+            tags: [tag1, { id: tag2.id + 'abc', name: 'tag3', type: 'stack' }]
+          })
+        )
 
-    await tap.equal(res.status, 201)
-    await tap.ok(res.body)
-    await tap.ok(res.body.shortId)
+      await tap.equal(res.status, 201)
+      await tap.ok(res.body)
+      await tap.ok(res.body.shortId)
 
-    const resSource = await request(app)
-      .get(`/sources/${res.body.shortId}`)
-      .set('Host', 'reader-api.test')
-      .set('Authorization', `Bearer ${token}`)
-      .type('application/ld+json')
+      const resSource = await request(app)
+        .get(`/sources/${res.body.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
 
-    const body = resSource.body
-    await tap.ok(body.tags)
-    await tap.equal(body.tags.length, 1)
-  })
+      const body = resSource.body
+      await tap.ok(body.tags)
+      await tap.equal(body.tags.length, 1)
+    }
+  )
+
+  await tap.test(
+    'Try to Create a source with existing and invalid tags',
+    async () => {
+      const res = await request(app)
+        .post(`/sources`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            name: 'Source Keyword',
+            type: 'Book',
+            tags: [tag1, { type: 'stack' }]
+          })
+        )
+
+      await tap.equal(res.status, 201)
+      await tap.ok(res.body)
+      await tap.ok(res.body.shortId)
+
+      const resSource = await request(app)
+        .get(`/sources/${res.body.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const body = resSource.body
+      await tap.ok(body.tags)
+      await tap.equal(body.tags.length, 1)
+    }
+  )
 
   // ------------------------------------- ERRORS ---------------------------
 


### PR DESCRIPTION
For the following endpoints, used to create sources and notes:
POST /sources
POST /notes
POST /notebooks/:notebookId/sources
POST /notebooks/:notebookId/notes
You can create your sources or notes with tags. This was already working. What I am clarifying here is what happens when the tags you are giving your sources or notes are invalid.
In summary: invalid tags are ignored. They will not be created or assigned to the Source or Note. You will not get an error because the Source or Note is still created. 

More detailed explanation: for each tag in a .tags array:
If it has an id, I assume it exists and try to assign it to the Note/Source. If it doesn't exist, I ignore it.
If it doesn't have an id, I assume it doesn't exist and try to create it. If I get an error trying to create (for example, if it is missing a 'type', or if there is a duplicate error), I will ignore it. 

Makes sense?

