### PR TITLE
Fix library cache

### DIFF
--- a/models/Source.js
+++ b/models/Source.js
@@ -520,7 +520,7 @@ class Source extends BaseModel {
 
     // exceptionally, doing this instead of in the routes because of the complexity of
     // the whole file upload thing.
-    await libraryCacheUpdate(reader.id)
+    await libraryCacheUpdate(reader.authId)
 
     return createdSource
   }

--- a/routes/notebooks/notebook-delete-source.js
+++ b/routes/notebooks/notebook-delete-source.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { checkOwnership } = require('../../utils/utils')
 const { Notebook_Source } = require('../../models/Notebook_Source')
 const debug = require('debug')('ink:routes:notebook-delete-source')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -75,6 +76,8 @@ module.exports = function (app) {
                 notebookId,
                 sourceId
               )
+              await libraryCacheUpdate(reader.authId)
+
               res.status(204).end()
             } catch (err) {
               debug('error: ', err.message)

--- a/routes/notebooks/notebook-put-source.js
+++ b/routes/notebooks/notebook-put-source.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { checkOwnership } = require('../../utils/utils')
 const { Notebook_Source } = require('../../models/Notebook_Source')
 const debug = require('debug')('ink:routes:notebook-put-source')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -75,6 +76,7 @@ module.exports = function (app) {
 
           try {
             await Notebook_Source.addSourceToNotebook(notebookId, sourceId)
+            await libraryCacheUpdate(reader.authId)
             res.status(204).end()
           } catch (err) {
             debug('error', err.message)

--- a/routes/sources/readActivity-post.js
+++ b/routes/sources/readActivity-post.js
@@ -9,6 +9,7 @@ const { ValidationError } = require('objection')
 const { ReadActivity } = require('../../models/ReadActivity')
 const { checkOwnership } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:readActivity-post')
+const { libraryCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -122,6 +123,7 @@ module.exports = function (app) {
               }
             }
           }
+          await libraryCacheUpdate(reader.authId)
 
           res.setHeader('Content-Type', 'application/ld+json')
           res.status(201).end(JSON.stringify(createdReadActivity.toJSON()))

--- a/routes/sources/source-delete-tag.js
+++ b/routes/sources/source-delete-tag.js
@@ -73,7 +73,7 @@ module.exports = function (app) {
 
             Source_Tag.removeTagFromSource(sourceId, tagId)
               .then(async () => {
-                await libraryCacheUpdate(reader.id)
+                await libraryCacheUpdate(reader.authId)
                 res.status(204).end()
               })
               .catch(err => {

--- a/routes/sources/source-delete.js
+++ b/routes/sources/source-delete.js
@@ -87,7 +87,7 @@ module.exports = function (app) {
           )
         }
 
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
         res.status(204).end()
       })
       .catch(err => {

--- a/routes/sources/source-patch.js
+++ b/routes/sources/source-patch.js
@@ -153,7 +153,7 @@ module.exports = function (app) {
           )
         }
 
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
 
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(200).end(JSON.stringify(updatedSource.toJSON()))

--- a/routes/sources/source-post.js
+++ b/routes/sources/source-post.js
@@ -115,8 +115,7 @@ module.exports = function (app) {
         }
 
         const finishedSource = createdSource.toJSON()
-
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
         if (metricsQueue) {
           await metricsQueue.add({
             type: 'createSource',

--- a/routes/sources/source-put-tag.js
+++ b/routes/sources/source-put-tag.js
@@ -76,7 +76,7 @@ module.exports = function (app) {
 
           Source_Tag.addTagToSource(sourceId, tagId)
             .then(async () => {
-              await libraryCacheUpdate(reader.id)
+              await libraryCacheUpdate(reader.authId)
               res.status(204).end()
             })
             .catch(err => {

--- a/routes/tags/tag-delete.js
+++ b/routes/tags/tag-delete.js
@@ -78,7 +78,7 @@ module.exports = function (app) {
           )
         }
 
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
 
         res.status(204).end()
       })

--- a/routes/tags/tag-post.js
+++ b/routes/tags/tag-post.js
@@ -90,7 +90,7 @@ module.exports = function (app) {
           }
         }
 
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(201).end(JSON.stringify(createdTag.toJSON()))
       })

--- a/routes/tags/tag-put.js
+++ b/routes/tags/tag-put.js
@@ -121,7 +121,7 @@ module.exports = function (app) {
           }
         }
 
-        await libraryCacheUpdate(reader.id)
+        await libraryCacheUpdate(reader.authId)
 
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(200).end(JSON.stringify(updatedTag.toJSON()))

--- a/server.js
+++ b/server.js
@@ -91,8 +91,6 @@ const notebookPostSourceRoute = require('./routes/notebooks/notebook-source-post
 const hardDeleteRoute = require('./routes/hardDelete')
 
 const metricsGetRoute = require('./routes/metrics-get')
-const notebookNotePost = require('./routes/notebooks/notebook-note-post')
-const notebookSourcePost = require('./routes/notebooks/notebook-source-post')
 
 const setupKnex = async skip_migrate => {
   let config


### PR DESCRIPTION
This fixes the library cache, which uses the 'If-Modified-Since' header and returns a 304 status if the library has not been modified since that date.
The library is reset when:
- a source is created (either by itself or within a notebook), updated or deleted
- a tag is created, updated or deleted
- a source is assigned to a tag or a source is removed from a tag
- a source is assigned to a notebook, or a source is removed from a notebook
- a readActivity is created
