### PR TITLE
make search ignore html tags

### DIFF
--- a/migrations/20200925095735_add-noteBody-formattedContent.js
+++ b/migrations/20200925095735_add-noteBody-formattedContent.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('NoteBody', (table) => {
+    table.text('formattedContent')
+  })
+}
+
+exports.down = function(knex) {
+  return knex.schema.table('NoteBody', table => {
+    table.dropColumn('formattedContent')
+  })
+}

--- a/models/Note.js
+++ b/models/Note.js
@@ -257,7 +257,6 @@ class Note extends BaseModel {
           reader.id
         )
         createdNote.body = note.body
-        debug('added multiple bodies: ', createdNote.body)
       } else {
         await NoteBody.createNoteBody(
           note.body,
@@ -298,6 +297,7 @@ class Note extends BaseModel {
     originalNote.body = originalNote.body.map(body => {
       return {
         content: body.content,
+        formattedContent: body.formattedContent,
         motivation: body.motivation,
         language: body.language
       }

--- a/models/NoteBody.js
+++ b/models/NoteBody.js
@@ -5,6 +5,7 @@ const { BaseModel } = require('./BaseModel.js')
 const _ = require('lodash')
 const { Note } = require('./Note')
 const debug = require('debug')('ink:models:NoteBody')
+const striptags = require('striptags')
 
 /*::
 type NoteBodyType = {
@@ -41,6 +42,7 @@ class NoteBody extends BaseModel {
         id: { type: 'string' },
         noteId: { type: 'string' },
         content: { type: ['string', 'null'] },
+        formattedContent: { type: ['string', 'null'] },
         language: { type: ['string', 'null'] },
         motivation: { type: 'string' },
         readerId: { type: 'string' },
@@ -106,6 +108,7 @@ class NoteBody extends BaseModel {
       props.motivation = props.motivation.toLowerCase()
       props.noteId = noteId
       props.readerId = readerId
+      props.formattedContent = striptags(props.content)
       return props
     })
     debug('bodies to be inserted: ', bodies)
@@ -121,6 +124,7 @@ class NoteBody extends BaseModel {
     debug('**createNoteBody**')
     debug('noteBody: ', noteBody)
     debug('noteId: ', noteId, 'readerId: ', readerId)
+
     return await NoteBody.createMultipleNoteBodies([noteBody], noteId, readerId)
   }
 

--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -45,7 +45,7 @@ class ReaderNotes {
 
     if (filters.search) {
       query.where(
-        'NoteBody.content',
+        'NoteBody.formattedContent',
         'ilike',
         '%' + filters.search.toLowerCase() + '%'
       )

--- a/package-lock.json
+++ b/package-lock.json
@@ -15293,6 +15293,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "striptags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
+      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "redis": "^2.8.0",
     "request": "^2.88.0",
     "short-uuid": "^3.1.1",
+    "striptags": "^3.1.1",
     "swagger-jsdoc": "^3.2.9"
   },
   "standard": {


### PR DESCRIPTION
This fixes the notes search so that it ignores the html tags. To do this, I had to add an extra column in the notebody table, which stores the cleaned up content. This html-free content will not be returned by the API anywhere, it is only there for searching purposes.

That also means another new migration. Fun! 
The migration does not modify any of the existing notes, so any notes that are currently in the database will not be returned when we do a search. 
