### PR TITLE
notes cache

### DIFF
--- a/routes/noteRelations/noteRelation-delete.js
+++ b/routes/noteRelations/noteRelation-delete.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { NoteRelation } = require('../../models/NoteRelation')
 const { checkOwnership } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:noteRelation-delete')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -80,6 +81,7 @@ module.exports = function (app) {
           )
         }
 
+        await notesCacheUpdate(reader.authId)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(204).end()
       })

--- a/routes/noteRelations/noteRelation-post.js
+++ b/routes/noteRelations/noteRelation-post.js
@@ -9,6 +9,7 @@ const { ValidationError } = require('objection')
 const { NoteRelation } = require('../../models/NoteRelation')
 const { checkOwnership, urlToId } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:noteRelation-post')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -140,7 +141,7 @@ module.exports = function (app) {
             )
           }
         }
-
+        await notesCacheUpdate(reader.authId)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(201).end(JSON.stringify(createdNoteRelation.toJSON()))
       })

--- a/routes/noteRelations/noteRelation-put.js
+++ b/routes/noteRelations/noteRelation-put.js
@@ -9,6 +9,7 @@ const { ValidationError } = require('objection')
 const { NoteRelation } = require('../../models/NoteRelation')
 const { urlToId, checkOwnership } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:noteRelation-put')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -197,7 +198,7 @@ module.exports = function (app) {
             })
           )
         }
-
+        await notesCacheUpdate(reader.authId)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(200).end(JSON.stringify(updatedNoteRelation.toJSON()))
       })

--- a/routes/notebooks/notebook-delete-note.js
+++ b/routes/notebooks/notebook-delete-note.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { checkOwnership } = require('../../utils/utils')
 const { Notebook_Note } = require('../../models/Notebook_Note')
 const debug = require('debug')('ink:routes:notebook-delete-note')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -72,6 +73,7 @@ module.exports = function (app) {
 
             try {
               await Notebook_Note.removeNoteFromNotebook(notebookId, noteId)
+              await notesCacheUpdate(reader.authId)
               res.status(204).end()
             } catch (err) {
               debug('error: ', err.message)

--- a/routes/notebooks/notebook-note-post.js
+++ b/routes/notebooks/notebook-note-post.js
@@ -11,6 +11,7 @@ const { checkOwnership, urlToId } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:notebook-note-post')
 const { Note_Tag } = require('../../models/Note_Tag')
 const { Tag } = require('../../models/Tag')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -156,7 +157,7 @@ module.exports = function (app) {
               )
             }
           }
-
+          await notesCacheUpdate(reader.authId)
           res.setHeader('Content-Type', 'application/ld+json')
           res.setHeader('Location', createdNote.id)
           res.status(201).end(JSON.stringify(createdNote.toJSON()))

--- a/routes/notebooks/notebook-put-note.js
+++ b/routes/notebooks/notebook-put-note.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { checkOwnership } = require('../../utils/utils')
 const { Notebook_Note } = require('../../models/Notebook_Note')
 const debug = require('debug')('ink:routes:notebook-put-note')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -75,6 +76,7 @@ module.exports = function (app) {
 
           try {
             await Notebook_Note.addNoteToNotebook(notebookId, noteId)
+            await notesCacheUpdate(reader.authId)
             res.status(204).end()
           } catch (err) {
             debug('error: ', err.message)

--- a/routes/notes/note-delete-tag.js
+++ b/routes/notes/note-delete-tag.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { Note_Tag } = require('../../models/Note_Tag')
 const { checkOwnership } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:note-delete-tag')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -71,6 +72,7 @@ module.exports = function (app) {
             }
             Note_Tag.removeTagFromNote(noteId, tagId)
               .then(async () => {
+                await notesCacheUpdate(reader.authId)
                 res.status(204).end()
               })
               .catch(err => {

--- a/routes/notes/note-delete.js
+++ b/routes/notes/note-delete.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { checkOwnership } = require('../../utils/utils')
 const { Note } = require('../../models/Note')
 const debug = require('debug')('ink:routes:note-delete')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -68,6 +69,7 @@ module.exports = function (app) {
           )
         }
 
+        await notesCacheUpdate(reader.authId)
         res.status(204).end()
       })
 

--- a/routes/notes/note-post.js
+++ b/routes/notes/note-post.js
@@ -12,6 +12,7 @@ const { metricsQueue } = require('../../utils/metrics')
 const { Tag } = require('../../models/Tag')
 const { Note_Tag } = require('../../models/Note_Tag')
 const { urlToId } = require('../../utils/utils')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -126,6 +127,8 @@ module.exports = function (app) {
             readerId: createdNote.readerId
           })
         }
+
+        await notesCacheUpdate(reader.authId)
 
         res.setHeader('Content-Type', 'application/ld+json')
         res.setHeader('Location', createdNote.id)

--- a/routes/notes/note-put-tag.js
+++ b/routes/notes/note-put-tag.js
@@ -7,6 +7,7 @@ const boom = require('@hapi/boom')
 const { Note_Tag } = require('../../models/Note_Tag')
 const { checkOwnership } = require('../../utils/utils')
 const debug = require('debug')('ink:routes:note-put-tag')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -75,6 +76,7 @@ module.exports = function (app) {
 
           Note_Tag.addTagToNote(noteId, tagId)
             .then(async () => {
+              await notesCacheUpdate(reader.authId)
               res.status(204).end()
             })
             .catch(err => {

--- a/routes/notes/note-put.js
+++ b/routes/notes/note-put.js
@@ -10,6 +10,7 @@ const { Tag } = require('../../models/Tag')
 const { Note_Tag } = require('../../models/Note_Tag')
 const { ValidationError } = require('objection')
 const debug = require('debug')('ink:routes:note-put')
+const { notesCacheUpdate } = require('../../utils/cache')
 
 module.exports = function (app) {
   /**
@@ -125,6 +126,7 @@ module.exports = function (app) {
           await Note_Tag.replaceTagsForNote(urlToId(updatedNote.id), tagIds)
         }
 
+        await notesCacheUpdate(reader.authId)
         res.setHeader('Content-Type', 'application/ld+json')
         res.status(200).end(JSON.stringify(updatedNote.toJSON()))
       })

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -5,6 +5,8 @@ const { urlToId } = require('./utils')
 // the cache is not used in pull requests because travis does not have access to the redis password
 let libraryCacheGet = async () => Promise.resolve()
 let libraryCacheUpdate = () => undefined
+let notesCacheGet = async () => Promise.resolve()
+let notesCacheUpdate = () => undefined
 let quitCache = () => undefined
 
 if (process.env.REDIS_PASSWORD) {
@@ -34,9 +36,26 @@ if (process.env.REDIS_PASSWORD) {
     return await getAsync(`${readerId}-library`)
   }
 
+  notesCacheUpdate = async readerId => {
+    readerId = urlToId(readerId)
+    return await setASync(`${readerId}-notes`, new Date().getTime(), 'EX', 3600)
+  }
+
+  notesCacheGet = async (readerId, check) => {
+    if (!check) return undefined // so we can skip when the 'if-modified-since' header is not used'
+    readerId = urlToId(readerId)
+    return await getAsync(`${readerId}-notes`)
+  }
+
   quitCache = () => {
     client.quit()
   }
 }
 
-module.exports = { libraryCacheUpdate, libraryCacheGet, quitCache }
+module.exports = {
+  libraryCacheUpdate,
+  libraryCacheGet,
+  quitCache,
+  notesCacheGet,
+  notesCacheUpdate
+}


### PR DESCRIPTION
Added a cache for the GET /notes endpoint. 
The cache is reset when we:
- create, update or delete a note
- add / remove a tag from a note
- add / remove a note from a notebook
- create a note inside a notebook
- create, update or delete a NoteRelation