### PR TITLE
add author to notebook source

### DIFF
--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -159,7 +159,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags]]'
+        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags, attributions]]'
       )
       .modifiers({
         notDeleted (builder) {

--- a/tests/integration/notebook/notebook-get.test.js
+++ b/tests/integration/notebook/notebook-get.test.js
@@ -100,6 +100,8 @@ const test = async app => {
     await tap.equal(body.notebookTags[0].id, notebookTag.id)
     await tap.equal(body.sources.length, 1)
     await tap.equal(body.sources[0].shortId, source.shortId)
+    await tap.ok(body.sources[0].author)
+    await tap.equal(body.sources[0].author.length, 1)
     await tap.equal(body.noteContexts.length, 1)
     await tap.equal(body.noteContexts[0].shortId, notebookNoteContext.shortId)
   })


### PR DESCRIPTION
Change to GET /notebooks/:id
the notebook object already had a .sources array. Those sources now include their attributions, including an author array. 