### PR TITLE
Create and update note with notebooks

### DIFF
--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -172,6 +172,32 @@ class Notebook extends BaseModel {
       .whereNull('deleted')
   }
 
+  static async createMultipleNotebooks (
+    readerId /*: string */,
+    notebooks /*: Array<any> */
+  ) /*: Promise<any> */ {
+    const notebookArray = notebooks.map(notebook => {
+      return this._formatNotebook(notebook, readerId)
+    })
+
+    try {
+      return await Notebook.query().insert(notebookArray)
+    } catch (err) {
+      // if inserting all the notebooks at once failed, do one at a time, ignoring errors
+      let createdNotebooks = []
+      notebookArray.forEach(async notebook => {
+        try {
+          let createdNotebook = await this.createNotebook(readerId, notebook)
+          createdNotebooks.push(createdNotebook)
+        } catch (err2) {
+          // eslint-disable-next-line
+          return
+        }
+      })
+      return createdNotebooks
+    }
+  }
+
   static async applyFilters (query /*: any */, filters /*: any */) {
     debug('**applyFilters**')
     debug('filters: ', filters)

--- a/models/Notebook_Note.js
+++ b/models/Notebook_Note.js
@@ -50,6 +50,24 @@ class Notebook_Note extends BaseModel {
     }
   }
 
+  static async replaceNotebooksForNote (
+    noteId /*: string */,
+    notebooks /*: Array<string> */
+  ) /*: Promise<any> */ {
+    await this.deleteNotebooksOfNote(noteId)
+    return await this.addMultipleNotebooksToNote(noteId, notebooks)
+  }
+
+  static async deleteNotebooksOfNote (
+    noteId /*: string */
+  ) /*: Promise<number|Error> */ {
+    if (!noteId) return new Error('no note')
+
+    return await Notebook_Note.query()
+      .delete()
+      .where({ noteId: urlToId(noteId) })
+  }
+
   /**
    * warning: does not throw errors
    */

--- a/models/Notebook_Note.js
+++ b/models/Notebook_Note.js
@@ -50,6 +50,33 @@ class Notebook_Note extends BaseModel {
     }
   }
 
+  /**
+   * warning: does not throw errors
+   */
+  static async addMultipleNotebooksToNote (
+    noteId /*: string */,
+    notebooks /*: Array<string> */
+  ) {
+    const list = notebooks.map(notebook => {
+      return { noteId, notebookId: urlToId(notebook) }
+    })
+
+    // ignores errors - if errors encountered with first insert, insert one by one
+    try {
+      await Notebook_Note.query().insert(list)
+    } catch (err) {
+      // if inserting all at once failed, insert one at a time and ignore errors
+      list.forEach(async item => {
+        try {
+          await Notebook_Note.query().insert(item)
+        } catch (err2) {
+          // eslint-disable-next-line
+          return
+        }
+      })
+    }
+  }
+
   static async removeNoteFromNotebook (
     notebookId /*: string */,
     noteId /*: string */

--- a/routes/notes/note-put.js
+++ b/routes/notes/note-put.js
@@ -146,6 +146,7 @@ module.exports = function (app) {
             urlToId(updatedNote.id),
             notebookIds
           )
+          // todo: add notebooks cache update
         }
 
         await notesCacheUpdate(reader.authId)

--- a/tests/integration/note/note-put.test.js
+++ b/tests/integration/note/note-put.test.js
@@ -338,6 +338,36 @@ const test = async app => {
   )
 
   await tap.test(
+    'Update notebooks for a note - if no notebooks property, should not update notebooks',
+    async () => {
+      const newNote = Object.assign(note, {
+        json: { property: 'something' }
+      })
+
+      const res = await request(app)
+        .put(`/notes/${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(JSON.stringify(newNote))
+
+      await tap.equal(res.statusCode, 200)
+      const body = res.body
+      await tap.notOk(body.notebooks)
+
+      const noteRes = await request(app)
+        .get(`/notes/${body.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      const noteBody = noteRes.body
+      await tap.ok(noteBody.notebooks)
+      await tap.equal(noteBody.notebooks.length, 1)
+    }
+  )
+
+  await tap.test(
     'Update notebookss for a note - empty array = delete existing tags',
     async () => {
       const newNote = Object.assign(note, {


### PR DESCRIPTION
This feature works the same as creating or updating notes with tags.
So now with endpoints: `POST /notes` and `PUT /notes/:id` the notes object can have a 'notebooks' property, which will be an array of notebook objects. Any notebook objects that has an id will be assumed to already exist and will be assigned to the note. Any notebook without an id will be created and then assigned to the note.
If the note already had notebooks, the list you pass in will replace the existing notebook assignments. So if you pass in an empty array, that will remove the note from any notebooks it was in.
If you don't have a notebooks property, nothing will happen to any existing notebook assignments.
In any cases, if there are errors with the notebooks (for example if you try to create a new notebook without a name, or if you try to assign a notebook that does not exist), you will NOT get an error message. It will just quietly ignore the error. 

Makes sense? 