### PR TITLE
emptied notes

### DIFF
--- a/migrations/20201026104557_add_emptied_to_notes.js
+++ b/migrations/20201026104557_add_emptied_to_notes.js
@@ -1,0 +1,12 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('Note', function(table) {
+    table.timestamp('emptied')
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('Note', function(table) {
+    table.dropColumn('emptied')
+  })
+};

--- a/models/Note.js
+++ b/models/Note.js
@@ -56,7 +56,8 @@ class Note extends BaseModel {
         parentId: { type: ['string', 'null'] },
         updated: { type: 'string', format: 'date-time' },
         published: { type: 'string', format: 'date-time' },
-        deleted: { type: 'string', format: 'date-time' }
+        deleted: { type: 'string', format: 'date-time' },
+        emptied: { type: 'string', format: 'date-time' }
       },
       additionalProperties: true,
       required: ['readerId']
@@ -327,6 +328,8 @@ class Note extends BaseModel {
           builder.select('id', 'name', 'type', 'metadata')
         }
       })
+      .whereNull('deleted')
+      .whereNull('emptied')
 
     if (!note) return undefined
 
@@ -356,6 +359,15 @@ class Note extends BaseModel {
 
     return await Note.query()
       .patchAndFetchById(id, { deleted: new Date().toISOString() })
+      .whereNull('deleted')
+  }
+
+  static async empty (id /*: string */) /*: Promise<NoteType|null> */ {
+    debug('**empty**')
+    debug('id: ', id)
+
+    return await Note.query()
+      .patchAndFetchById(id, { emptied: new Date().toISOString() })
       .whereNull('deleted')
   }
 
@@ -391,6 +403,7 @@ class Note extends BaseModel {
     let updatedNote = await Note.query()
       .updateAndFetchById(urlToId(note.id), modifications)
       .whereNull('deleted')
+      .whereNull('emptied')
     debug('updated note: ', updatedNote)
 
     // if note not found:

--- a/models/NoteContext.js
+++ b/models/NoteContext.js
@@ -89,6 +89,7 @@ class NoteContext extends BaseModel {
         notDeleted (builder) {
           builder.whereNull('deleted')
         }
+        // should return emptied notes
       })
 
     if (noteContext) {

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -159,7 +159,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags, attributions]]'
+        '[reader, notes(notDeleted, notEmptied).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags, attributions]]'
       )
       .modifiers({
         notDeleted (builder) {
@@ -167,6 +167,9 @@ class Notebook extends BaseModel {
         },
         notReferenced (builder) {
           builder.whereNull('referenced')
+        },
+        notEmptied (builder) {
+          builder.whereNull('emptied')
         }
       })
       .whereNull('deleted')

--- a/models/Source.js
+++ b/models/Source.js
@@ -575,6 +575,9 @@ class Source extends BaseModel {
         notDeleted (builder) {
           builder.whereNull('deleted')
         },
+        notEmptied (builder) {
+          builder.whereNull('emptied')
+        },
         latestFirst (builder) {
           builder.orderBy('published', 'desc')
         }

--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -166,6 +166,7 @@ class ReaderNotes {
     let resultQuery = Note.query(Note.knex())
       .count()
       .whereNull('Note.deleted')
+      .whereNull('Note.emptied')
       .whereNull('Note.contextId')
       .andWhere('Note.readerId', '=', readerId)
       .leftJoin('NoteBody', 'NoteBody.noteId', '=', 'Note.id')
@@ -257,6 +258,7 @@ class ReaderNotes {
           )
         })
         builder.whereNull('Note.deleted')
+        builder.whereNull('Note.emptied')
         builder.whereNull('Note.contextId')
         builder.leftJoin('NoteBody', 'NoteBody.noteId', '=', 'Note.id')
 

--- a/routes/notes/note-delete.js
+++ b/routes/notes/note-delete.js
@@ -23,6 +23,11 @@ module.exports = function (app) {
    *         schema:
    *           type: string
    *         required: true
+   *       - in: query
+   *         name: empty
+   *         schema:
+   *           type: boolean
+   *         description: flag a note as emptied. It will be replaced by an empty note
    *     security:
    *       - Bearer: []
    *     responses:
@@ -56,7 +61,13 @@ module.exports = function (app) {
           )
         }
 
-        const result = await Note.delete(noteId)
+        let result
+        if (req.query.empty) {
+          result = await Note.empty(noteId)
+        } else {
+          result = await Note.delete(noteId)
+        }
+
         debug('delete result: ', result)
         if (!result) {
           return next(

--- a/tests/integration/hardDelete/deleteNote.test.js
+++ b/tests/integration/hardDelete/deleteNote.test.js
@@ -195,6 +195,74 @@ const test = async () => {
     await tap.equal(relations[0].id, urlToId(relation2.id))
   })
 
+  const note6 = await Note.query().insertAndFetch({
+    readerId,
+    stylesheet: { property: 'value' },
+    canonical: 'something',
+    target: { property: 'value' },
+    document: 'document1',
+    json: { property: 'value' },
+    emptied: timestamp25
+  })
+
+  const note7 = await Note.query().insertAndFetch({
+    readerId,
+    stylesheet: { property: 'value' },
+    canonical: 'something',
+    target: { property: 'value' },
+    document: 'document1',
+    json: { property: 'value' },
+    emptied: timestampNow
+  })
+
+  await NoteBody.query().insert({
+    noteId: urlToId(note6.id),
+    motivation: 'test',
+    content: 'something...',
+    readerId
+  })
+
+  await NoteBody.query().insert({
+    noteId: urlToId(note7.id),
+    motivation: 'test',
+    content: 'something...',
+    readerId
+  })
+
+  await tap.test('Hard Delete of emptied notes', async () => {
+    const res = await request(app)
+      .delete('/hardDelete')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.status, 204)
+
+    const notes = await Note.query()
+    await tap.equal(notes.length, 4)
+    await tap.ok(_.find(notes, { id: note6.id }))
+    const note6Index = _.findIndex(notes, { id: note6.id })
+    await tap.ok(notes[note6Index])
+    await tap.notOk(notes[note6Index].stylesheet)
+    await tap.notOk(notes[note6Index].canonical)
+    await tap.notOk(notes[note6Index].target)
+    await tap.notOk(notes[note6Index].document)
+    await tap.notOk(notes[note6Index].json)
+
+    await tap.ok(_.find(notes, { id: note7.id }))
+    const note7Index = _.findIndex(notes, { id: note7.id })
+    await tap.ok(notes[note7Index])
+    await tap.ok(notes[note7Index].stylesheet)
+    await tap.ok(notes[note7Index].canonical)
+    await tap.ok(notes[note7Index].target)
+    await tap.ok(notes[note7Index].document)
+    await tap.ok(notes[note7Index].json)
+
+    const noteBodies = await NoteBody.query()
+    await tap.equal(noteBodies.length, 3)
+    await tap.notOk(_.find(noteBodies, { noteId: note6.id }))
+    await tap.ok(_.find(noteBodies, { noteId: note7.id }))
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/models/Note.test.js
+++ b/tests/models/Note.test.js
@@ -226,14 +226,21 @@ const test = async app => {
 
     // make sure that the NoteBodies are deleted:
     const newNote = await Note.byId(urlToId(note2.id))
-    await tap.ok(newNote.body)
-    await tap.ok(newNote.body[0].deleted)
-    await tap.ok(newNote.body[1].deleted)
+    await tap.notOk(newNote)
   })
 
   await tap.test('Try to delete a note that does not exist', async () => {
     const res = await Note.delete('123')
     await tap.notOk(res)
+  })
+
+  await tap.test('Mark Note as emptied', async () => {
+    const res = await Note.empty(urlToId(noteWithSource.id))
+    await tap.ok(res.emptied)
+
+    // make sure that the NoteBodies are deleted:
+    const newNote = await Note.byId(urlToId(note2.id))
+    await tap.notOk(newNote)
   })
 
   // --------------------------------------------------------------------------------

--- a/tests/models/Source.test.js
+++ b/tests/models/Source.test.js
@@ -525,10 +525,10 @@ const test = async app => {
     await tap.equal(res, 2)
 
     const note1 = await Note.byId(urlToId(createdNote1.id))
-    await tap.ok(note1.deleted)
+    await tap.notOk(note1)
 
     const note2 = await Note.byId(urlToId(createdNote2.id))
-    await tap.ok(note2.deleted)
+    await tap.notOk(note2)
   })
 
   await tap.test('Turn a Source into a reference', async () => {


### PR DESCRIPTION
Added a parameter to the delete note endpoint
DELETE /notes/:id?empty=true

Emptied notes will not be returned on those endpoints:
GET /notes/:id
GET /notes
It will also not show up when getting an individual source or notebook.
It is only returned when getting an individual NoteContext

When we run the hard delete, we will delete the Note's:
- json
- stylesheet
- canonical
- target
- document
- body (which contains both the motivation and content)
I do not delete the:
sourceId
contextId
and all the outline information.
The contextId and outline information are still needed to know where to put the empty note card.
The sourceId could be deleted, but knex/objection have this weird bug/feature where you can't update a foreign key to null. 