### PR TITLE
hard delete for referenced sources

### DIFF
--- a/models/Source.js
+++ b/models/Source.js
@@ -632,10 +632,7 @@ class Source extends BaseModel {
   static async toReference (id /*: string */) /*: Promise<any> */ {
     const date = new Date().toISOString()
     return await Source.query().patchAndFetchById(id, {
-      referenced: date,
-      links: null,
-      resources: null,
-      readingOrder: null
+      referenced: date
     })
   }
 

--- a/routes/hardDelete.js
+++ b/routes/hardDelete.js
@@ -47,6 +47,15 @@ module.exports = function (app) {
         .delete()
         .where('deleted', '<', timestamp)
 
+      // referenced sources
+      await Source.query()
+        .where('referenced', '<', timestamp)
+        .patch({
+          links: null,
+          readingOrder: null,
+          resources: null
+        })
+
       res.status(204).end()
     } else {
       res.status(403)

--- a/tests/integration/hardDelete/deletePub.test.js
+++ b/tests/integration/hardDelete/deletePub.test.js
@@ -178,6 +178,112 @@ const test = async () => {
     await tap.equal(source_tags[0].sourceId, source4.id)
   })
 
+  const source5 = await Source.query().insertAndFetch({
+    name: 'source5',
+    type: 'Article',
+    links: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example link'
+        }
+      ]
+    },
+    readingOrder: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example reading order object1'
+        },
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example reading order object2'
+        },
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example reading order object3'
+        }
+      ]
+    },
+    resources: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example resource'
+        }
+      ]
+    },
+    readerId: readerId,
+    referenced: timestamp25
+  })
+
+  const source6 = await Source.query().insertAndFetch({
+    name: 'source6',
+    type: 'Article',
+    readerId: readerId,
+    links: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example link'
+        }
+      ]
+    },
+    readingOrder: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example reading order object1'
+        },
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example reading order object2'
+        }
+      ]
+    },
+    resources: {
+      data: [
+        {
+          url: 'http://example.org/abc',
+          encodingFormat: 'text/html',
+          name: 'An example resource'
+        }
+      ]
+    },
+    referenced: timestampNow
+  })
+
+  await tap.test('Hard Delete', async () => {
+    const res = await request(app)
+      .delete('/hardDelete')
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+    await tap.equal(res.status, 204)
+
+    const sources = await Source.query()
+    await tap.equal(sources.length, 4)
+    const source5Index = _.findIndex(sources, { name: 'source5' })
+    await tap.ok(sources[source5Index])
+    await tap.notOk(sources[source5Index].links)
+    await tap.notOk(sources[source5Index].resources)
+    await tap.notOk(sources[source5Index].readingOrder)
+    const source6Index = _.findIndex(sources, { name: 'source6' })
+    await tap.ok(sources[source6Index])
+    await tap.ok(sources[source6Index].links)
+    await tap.ok(sources[source6Index].resources)
+    await tap.ok(sources[source6Index].readingOrder)
+    await tap.ok(_.find(sources, { name: 'source6' }))
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/models/Source.test.js
+++ b/tests/models/Source.test.js
@@ -540,9 +540,9 @@ const test = async app => {
 
     const result = await Source.toReference(sourceId2)
     await tap.ok(result.referenced)
-    await tap.notOk(result.links)
-    await tap.notOk(result.resources)
-    await tap.notOk(result.readingOrder)
+    // await tap.notOk(result.links)
+    // await tap.notOk(result.resources)
+    // await tap.notOk(result.readingOrder)
   })
 
   await tap.test('Get SourceIds By Collection', async () => {


### PR DESCRIPTION
I did that before the emptied notes thing, but somehow forgot to create a pull request.

So we already had a parameter reference=true

Now when we use that parameter, the source will be marked as 'referenced'. When the hard delete, we remove this information from the source:
- links
- resources
- readingOrder
We will probably want to delete more. TBD.