### PR TITLE
notes filter by notMotivation

### DIFF
--- a/models/readerNotes.js
+++ b/models/readerNotes.js
@@ -42,6 +42,9 @@ class ReaderNotes {
     if (filters.motivation) {
       query.where('NoteBody.motivation', '=', filters.motivation)
     }
+    if (filters.notMotivation) {
+      query.whereNot('NoteBody.motivation', '=', filters.notMotivation)
+    }
 
     if (filters.search) {
       query.where(

--- a/routes/notes/readerNotes-get.js
+++ b/routes/notes/readerNotes-get.js
@@ -46,6 +46,12 @@ module.exports = app => {
    *           type: string
    *         enum: ['test', 'bookmarking', 'commenting', 'describing', 'editing', 'highlighting', 'replying']
    *       - in: query
+   *         name: notMotivation
+   *         schema:
+   *           type: string
+   *         enum: ['test', 'bookmarking', 'commenting', 'describing', 'editing', 'highlighting', 'replying']
+   *         description: motivation to filter out. Should not be combined with the motivation filter.
+   *       - in: query
    *         name: search
    *         schema:
    *           type: string
@@ -152,6 +158,7 @@ module.exports = app => {
         source: req.query.source,
         document: req.query.document,
         motivation: req.query.motivation,
+        notMotivation: req.query.notMotivation,
         search: req.query.search,
         orderBy: req.query.orderBy,
         reverse: req.query.reverse,

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -51,6 +51,7 @@ const readerNotesFilterDocumentTests = require('./readerNotes/readerNotes-filter
 const readerNotesFilterNotebookTests = require('./readerNotes/readerNotes-filter-notebook.test')
 const readerNotesFilterColourTests = require('./readerNotes/readerNotes-filter-colour.test')
 const readerNotesFilterDateRangeUpdatedTests = require('./readerNotes/readerNotes-filter-dateRangeUpdate.test')
+const readerNotesFilterNotMotivationTests = require('./readerNotes/readerNotes-filter-notMotivation.test')
 
 const sourceAddTagTests = require('./tag/source-tag-put.test')
 const sourceRemoveTagTests = require('./tag/source-tag-delete.test')
@@ -237,6 +238,7 @@ const allTests = async () => {
       await readerNotesFilterNotebookTests(app)
       await readerNotesFilterColourTests(app)
       await readerNotesFilterDateRangeUpdatedTests(app)
+      await readerNotesFilterNotMotivationTests(app)
     } catch (err) {
       console.log('readerNotes integration tests error: ', err)
       throw err

--- a/tests/integration/readerNotes/readerNotes-filter-combined.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-combined.test.js
@@ -516,6 +516,96 @@ const test = async app => {
     }
   )
 
+  await tap.test('Filter Notes by notebook and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?notebook=${notebook.shortId}&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 2)
+    await tap.equal(res2.body.items.length, 2)
+    await tap.ok(_.find(res2.body.items, { shortId: note5.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note14.shortId }))
+  })
+
+  await tap.test('Filter Notes by collection and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?stack=testCollection&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 2)
+    await tap.equal(res2.body.items.length, 2)
+    await tap.ok(_.find(res2.body.items, { shortId: note5.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note3.shortId }))
+  })
+
+  await tap.test('Filter Notes by document and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?document=doc1&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 3)
+    await tap.equal(res2.body.items.length, 3)
+    await tap.ok(_.find(res2.body.items, { shortId: note5.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note14.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note3.shortId }))
+  })
+
+  await tap.test('Filter Notes by source and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?source=${source2.shortId}&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 3)
+    await tap.equal(res2.body.items.length, 3)
+    await tap.ok(_.find(res2.body.items, { shortId: note14.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note3.shortId }))
+    await tap.ok(_.find(res2.body.items, { shortId: note5.shortId }))
+  })
+
+  await tap.test('Filter Notes by search and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?search=something&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 1)
+    await tap.equal(res2.body.items.length, 1)
+    await tap.ok(_.find(res2.body.items, { shortId: note14.shortId }))
+  })
+
+  await tap.test('Filter Notes by colour and notMotivation', async () => {
+    const res2 = await request(app)
+      .get(`/notes?colour=colour1&notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res2.status, 200)
+    await tap.ok(res2.body)
+    await tap.ok(res2.body.totalItems, 1)
+    await tap.equal(res2.body.items.length, 1)
+    await tap.ok(_.find(res2.body.items, { shortId: note5.shortId }))
+  })
+
   await destroyDB(app)
 }
 

--- a/tests/integration/readerNotes/readerNotes-filter-notMotivation.test.js
+++ b/tests/integration/readerNotes/readerNotes-filter-notMotivation.test.js
@@ -1,0 +1,97 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNote
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const createNoteSimplified = async object => {
+    const noteObj = Object.assign(
+      {
+        body: { motivation: 'test' }
+      },
+      object
+    )
+    return await createNote(app, token, noteObj)
+  }
+
+  await createNoteSimplified() // 1
+  await createNoteSimplified() // 2
+  await createNoteSimplified() // 3
+  await createNoteSimplified() // 4
+  await createNoteSimplified() // 5
+  await createNoteSimplified() // 6
+  await createNoteSimplified() // 7
+  await createNoteSimplified() // 8
+  await createNoteSimplified() // 9
+  await createNoteSimplified() // 10
+  await createNoteSimplified() // 11
+  await createNoteSimplified() // 12
+  await createNoteSimplified() // 13
+
+  // create more notes with another motivation (5)
+  await createNoteSimplified({
+    body: { motivation: 'highlighting' }
+  })
+  await createNoteSimplified({
+    body: { motivation: 'highlighting' }
+  })
+  await createNoteSimplified({
+    body: { motivation: 'highlighting' }
+  })
+  await createNoteSimplified({
+    body: { motivation: 'highlighting' }
+  })
+  await createNoteSimplified({
+    body: { motivation: 'highlighting' }
+  })
+
+  await tap.test('Filter Notes by NOT motivation', async () => {
+    const res = await request(app)
+      .get(`/notes?notMotivation=test`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 5)
+    await tap.equal(res.body.items.length, 5)
+  })
+
+  await tap.test('Filter Notes by NOT motivation with pagination', async () => {
+    const res = await request(app)
+      .get(`/notes?notMotivation=highlighting&limit=11&page=2`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.totalItems, 13)
+    await tap.equal(res.body.items.length, 2)
+  })
+
+  await tap.test('Filter Notes by an inexistant NOT motivation', async () => {
+    const res = await request(app)
+      .get(`/notes?notMotivation=somethingElse`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    await tap.ok(res.body)
+    await tap.equal(res.body.items.length, 10)
+    await tap.equal(res.body.totalItems, 18)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test


### PR DESCRIPTION
Adding a filter for the GET /notes endpoint: notMotivation
It works just like the motivation filter, but it excludes notes by motivation. It can be combined with pagination and other filters, except for the motivation filter, obviously.
It only takes one value. If you need it to accept more than one, let me know and I can fix that. 
