### PR TITLE
fixed it so we can update foreign keys to null

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -383,7 +383,9 @@ class Note extends BaseModel {
       'document',
       'next',
       'parentId',
-      /* 'sourceId', */ 'json'
+      'sourceId',
+      'contextId',
+      'json'
     ]
     propsCanBeDeleted.forEach(prop => {
       if (note[prop] === undefined) {

--- a/models/Tag.js
+++ b/models/Tag.js
@@ -140,6 +140,10 @@ class Tag extends BaseModel {
       'type',
       'notebookId'
     ])
+
+    // only notebookId can be deleted
+    if (modifications.notebookId === undefined) modifications.notebookId = null
+
     return await Tag.query().updateAndFetchById(urlToId(this.id), modifications)
   }
 

--- a/tests/integration/note/note-delete.test.js
+++ b/tests/integration/note/note-delete.test.js
@@ -189,7 +189,7 @@ const test = async app => {
 
     // but the note is not actually deleted, only marked as 'emptied'
     const noteAfter = await Note.query().findById(note2.shortId)
-    await tap.ok(noteAter)
+    await tap.ok(noteAfter)
     await tap.ok(noteAfter.emptied)
     await tap.notOk(noteAfter.deleted)
   })

--- a/tests/integration/note/note-put.test.js
+++ b/tests/integration/note/note-put.test.js
@@ -6,6 +6,7 @@ const {
   destroyDB,
   createSource,
   createNote,
+  createNoteContext,
   createTag,
   createNotebook
 } = require('../../utils/testUtils')
@@ -19,11 +20,15 @@ const test = async app => {
 
   const sourceId = urlToId(source.id)
 
+  const context = await createNoteContext(app, token)
+  const contextId = context.shortId
+
   const note = await createNote(app, token, {
     body: { content: 'test content', motivation: 'test' },
     sourceId,
     document: 'doc123',
     json: { property: 'value' },
+    contextId,
     canonical: '123'
   })
   const noteId = urlToId(note.id)
@@ -55,6 +60,7 @@ const test = async app => {
     // check that old properties are still there
     await tap.type(body.sourceId, 'string')
     await tap.equal(body.json.property, 'value')
+    await tap.equal(body.contextId, contextId)
   })
 
   await tap.test('Update the target of a Note', async () => {
@@ -115,7 +121,9 @@ const test = async app => {
     const newNote = Object.assign(note, {
       canonical: undefined,
       document: undefined,
-      stylesheet: undefined /* sourceId: undefined */
+      stylesheet: undefined,
+      sourceId: undefined,
+      contextId: undefined
     })
 
     const res = await request(app)
@@ -132,7 +140,8 @@ const test = async app => {
     await tap.notOk(body.canonical)
     await tap.notOk(body.stylesheet)
     await tap.notOk(body.document)
-    // await tap.notOk(body.sourceId)
+    await tap.notOk(body.sourceId)
+    await tap.notOk(body.contextId)
   })
 
   // ---------------------------- TAGS ----------------

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -12,6 +12,7 @@ const checkOwnership = (readerId, resourceId) => {
 }
 
 const urlToId = url => {
+  if (url === null) return null
   if (!url) return undefined
   if (!url.startsWith('http')) return url
   let path = parseurl(url).path.substring(1) // remove first '/'


### PR DESCRIPTION
This fixes the bug that was preventing us from updating a foreign key to null.
We can now do this update on Note.contextId, Note.sourceId and Tag.notebookId
Most other foreign keys are required, so no need to update them to null. 

Let me know if there are any other cases that you can think of. Normally they should work, but I can add a test to make sure they do.