### PR TITLE
add note to outline with modifications

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -302,7 +302,8 @@ class Note extends BaseModel {
 
   static async copyToContext (
     noteId /*: string */,
-    contextId /*: string */
+    contextId /*: string */,
+    changes /*: any */
   ) /*: Promise<any> */ {
     debug('**copyToContext**')
     debug('noteId: ', noteId, 'contextId: ', contextId)
@@ -325,6 +326,8 @@ class Note extends BaseModel {
         language: body.language
       }
     })
+
+    Object.assign(originalNote, changes)
 
     const newNote = await Note.createNote(
       originalNote.reader,

--- a/routes/outlines/outline-addNote.js
+++ b/routes/outlines/outline-addNote.js
@@ -89,7 +89,8 @@ module.exports = function (app) {
           try {
             copiedNote = await Note.copyToContext(
               req.query.source,
-              req.params.id
+              req.params.id,
+              req.body
             )
             debug('copied note: ', copiedNote)
           } catch (err) {

--- a/tests/integration/outline/outline-addNote.test.js
+++ b/tests/integration/outline/outline-addNote.test.js
@@ -401,6 +401,40 @@ const test = async app => {
   })
 
   await tap.test(
+    'Copy an existing note to the context with changes',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outlineId}/notes?source=${noteId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            previous: note2.shortId
+          })
+        )
+
+      await tap.equal(res.status, 201)
+      const body = res.body
+      await tap.ok(body.id)
+      await tap.equal(body.shortId, urlToId(body.id))
+      await tap.notEqual(body.shortId, noteId)
+      await tap.equal(urlToId(body.readerId), readerId)
+      await tap.equal(body.contextId, outlineId)
+      await tap.ok(body.published)
+      await tap.ok(body.body)
+      await tap.ok(body.body[0].content)
+      await tap.equal(body.body[0].content, 'to be copied')
+      await tap.equal(body.body[0].motivation, 'test')
+      await tap.equal(body.previous, note2.shortId)
+
+      await tap.type(res.get('Location'), 'string')
+      await tap.equal(res.get('Location'), body.id)
+      noteCopy = res.body
+    }
+  )
+
+  await tap.test(
     'Updating the copied Note should not affect the original',
     async () => {
       const res = await request(app)


### PR DESCRIPTION
With this change, when we copy an existing note to an outline, we can also pass in a body with modifications to the note.

for example:
POST /outlines/:id/notes?source=noteId
with body { next: note2, previous: note3 }


