### PR TITLE
fix outline bug and keep tags on copied notes

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -9,6 +9,7 @@ const { NoteBody } = require('./NoteBody')
 const { Notebook_Note } = require('./Notebook_Note')
 const debug = require('debug')('ink:models:Note')
 const { OutlineData } = require('./OutlineData')
+const { Note_Tag } = require('./Note_Tag')
 
 /*::
 type NoteType = {
@@ -334,6 +335,10 @@ class Note extends BaseModel {
       _.omit(originalNote, ['published', 'updated', 'id'])
     )
     debug('new note: ', newNote)
+
+    // copy tag relations
+    if (newNote && newNote.id) { await Note_Tag.copyTagsFromAnotherNote(noteId, urlToId(newNote.id)) }
+
     return newNote
   }
 

--- a/models/Note_Tag.js
+++ b/models/Note_Tag.js
@@ -132,6 +132,23 @@ class Note_Tag extends Model {
       .delete()
       .where({ tagId: urlToId(tagId) })
   }
+
+  static async copyTagsFromAnotherNote (
+    originalNoteId /*: string */,
+    newNoteId /*: string */
+  ) {
+    const listOfNote_Tags = await Note_Tag.query().where(
+      'noteId',
+      '=',
+      originalNoteId
+    )
+    if (listOfNote_Tags.length > 0) {
+      let list = listOfNote_Tags.map(note_tag => {
+        return { tagId: note_tag.tagId, noteId: newNoteId }
+      })
+      await Note_Tag.query().insert(list)
+    }
+  }
 }
 
 module.exports = { Note_Tag }


### PR DESCRIPTION
fixing it so that when you copy a note and give it a previous or next property, it will make the adjustments to surrounding notes in the outline.

Also, fixing it so that the copied note will have the same tags as the original. 

Note: will merge this shortly so that I can deploy. 