### PR TITLE
Collaborator routes

### DIFF
--- a/models/Collaborator.js
+++ b/models/Collaborator.js
@@ -3,6 +3,7 @@
 const { BaseModel } = require('./BaseModel.js')
 const _ = require('lodash')
 const { urlToId } = require('../utils/utils')
+const crypto = require('crypto')
 
 const statusMap = {
   pending: 1,
@@ -71,6 +72,9 @@ class Collaborator extends BaseModel {
 
     this._validateCollaborator(props)
     props = this._formatCollaborator(props)
+    props.id = `${urlToId(props.readerId)}-${crypto
+      .randomBytes(5)
+      .toString('hex')}`
 
     let result
     try {
@@ -108,7 +112,6 @@ class Collaborator extends BaseModel {
 
     this._validateCollaborator(props)
     props = this._formatCollaborator(props)
-
     return await Collaborator.query().updateAndFetchById(object.id, props)
   }
 

--- a/models/Collaborator.js
+++ b/models/Collaborator.js
@@ -112,7 +112,9 @@ class Collaborator extends BaseModel {
 
     this._validateCollaborator(props)
     props = this._formatCollaborator(props)
-    return await Collaborator.query().updateAndFetchById(object.id, props)
+    return await Collaborator.query()
+      .updateAndFetchById(object.id, props)
+      .whereNull('deleted')
   }
 
   static async delete (id /*: string */) /*: Promise<any> */ {

--- a/routes/_swagger-definitions/collaborator-def.js
+++ b/routes/_swagger-definitions/collaborator-def.js
@@ -1,0 +1,45 @@
+// DEFINITIONS for
+// collaborator
+
+/**
+ * @swagger
+ * definition:
+ *   collaborator-input:
+ *     properties:
+ *       readerId:
+ *         type: string
+ *       status:
+ *         type: string
+ *       permission:
+ *         type: object
+ *     required:
+ *       - readerId
+ *       - status
+ *       - permission
+ *   collaborator:
+ *     allOf:
+ *       - $ref: '#/definitions/collaborator-input'
+ *     properties:
+ *       id:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       notebookId:
+ *         type: string
+ *         format: url
+ *         readOnly: true
+ *       published:
+ *         type: string
+ *         format: timestamp
+ *         readOnly: true
+ *       updated:
+ *         type: string
+ *         format: timestamp
+ *         readOnly: true
+ *     required:
+ *       - id
+ *       - notebookId
+ *       - published
+ *
+ *
+ */

--- a/routes/collaborator/collaborator-delete.js
+++ b/routes/collaborator/collaborator-delete.js
@@ -1,0 +1,93 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const { checkOwnership } = require('../../utils/utils')
+const { Collaborator } = require('../../models/Collaborator')
+const { metricsQueue } = require('../../utils/metrics')
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /notebooks/{notebookId}/collaborators/{collaboratorId}:
+   *   delete:
+   *     tags:
+   *       - collaborators
+   *     description: Delete a collaborator by id
+   *     parameters:
+   *       - in: path
+   *         name: collaboratorId
+   *         schema:
+   *           type: string
+   *         required: true
+   *       - in: path
+   *         name: notebookId
+   *         schema:
+   *           type: string
+   *         required: true
+   *     security:
+   *       - Bearer: []
+   *     responses:
+   *       204:
+   *         description: Successfully deleted Collaborator
+   *       401:
+   *         description: 'No Authentication'
+   *       404:
+   *         description: Collaborator not found
+   *       403:
+   *         description: 'Access to Collaborator {collaboratorId} disallowed'
+   */
+  app.use('/', router)
+  router
+    .route('/notebooks/:notebookId/collaborators/:collaboratorId')
+    .delete(jwtAuth, function (req, res, next) {
+      const collaboratorId = req.params.collaboratorId
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound('No reader found with this token', {
+                requestUrl: req.originalUrl
+              })
+            )
+          }
+          // assume that collaborator deletes their own collaborator object
+          if (!checkOwnership(reader.id, collaboratorId)) {
+            return next(
+              boom.forbidden(
+                `Access to Collaborator ${collaboratorId} disallowed`,
+                {
+                  requestUrl: req.originalUrl
+                }
+              )
+            )
+          }
+
+          const result = await Collaborator.delete(collaboratorId)
+          if (!result) {
+            return next(
+              boom.notFound(
+                `Collaborator Delete Error: No Collaborator found with id ${collaboratorId}`,
+                {
+                  requestUrl: req.originalUrl
+                }
+              )
+            )
+          }
+
+          if (metricsQueue) {
+            await metricsQueue.add({
+              type: 'deleteCollaborator',
+              readerId: urlToId(reader.id)
+            })
+          }
+
+          res.status(204).end()
+        })
+
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/routes/collaborator/collaborator-post.js
+++ b/routes/collaborator/collaborator-post.js
@@ -8,6 +8,7 @@ const _ = require('lodash')
 const { ValidationError } = require('objection')
 const { metricsQueue } = require('../../utils/metrics')
 const { Collaborator } = require('../../models/Collaborator')
+const { checkOwnership } = require('../../utils/utils')
 
 module.exports = function (app) {
   /**
@@ -53,6 +54,16 @@ module.exports = function (app) {
           if (!reader || reader.deleted) {
             return next(
               boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          // for now, assume only owner of notebook can create collaborators
+          if (!checkOwnership(reader.id, notebookId)) {
+            return next(
+              boom.forbidden(`Access to notebook ${notebookId} disallowed`, {
                 requestUrl: req.originalUrl,
                 requestBody: req.body
               })

--- a/routes/collaborator/collaborator-post.js
+++ b/routes/collaborator/collaborator-post.js
@@ -1,0 +1,108 @@
+const express = require('express')
+const router = express.Router()
+const passport = require('passport')
+const { Reader } = require('../../models/Reader')
+const jwtAuth = passport.authenticate('jwt', { session: false })
+const boom = require('@hapi/boom')
+const _ = require('lodash')
+const { ValidationError } = require('objection')
+const { metricsQueue } = require('../../utils/metrics')
+const { Collaborator } = require('../../models/Collaborator')
+
+module.exports = function (app) {
+  /**
+   * @swagger
+   * /notebooks/{notebookId}/collaborators:
+   *   post:
+   *     tags:
+   *       - collaborators
+   *     description: Create a Collaborator
+   *     security:
+   *       - Bearer: []
+   *     requestBody:
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/definitions/collaborator-input'
+   *     responses:
+   *       201:
+   *         description: Successfully created Collaborator
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/definitions/collaborator'
+   *       400:
+   *         description: Validation error
+   *       401:
+   *         description: No Authentication
+   *       403:
+   *         description: 'Access to reader disallowed'
+   */
+  app.use('/', router)
+  router
+    .route('/notebooks/:notebookId/collaborators')
+    .post(jwtAuth, function (req, res, next) {
+      const notebookId = req.params.notebookId
+      Reader.byAuthId(req.user)
+        .then(async reader => {
+          if (!reader || reader.deleted) {
+            return next(
+              boom.notFound(`No reader found with this token`, {
+                requestUrl: req.originalUrl,
+                requestBody: req.body
+              })
+            )
+          }
+
+          const body = req.body
+          if (typeof body !== 'object' || _.isEmpty(body)) {
+            return next(
+              boom.badRequest(
+                'Create Collaborator Error: Request body must be a JSON object',
+                {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                }
+              )
+            )
+          }
+          let createdCollaborator
+          try {
+            createdCollaborator = await Collaborator.create(body, notebookId)
+          } catch (err) {
+            if (err instanceof ValidationError) {
+              return next(
+                boom.badRequest(
+                  `Validation Error on Create Collaborator: ${err.message}`,
+                  {
+                    validation: err.data,
+                    requestUrl: req.originalUrl,
+                    requestBody: req.body
+                  }
+                )
+              )
+            } else {
+              return next(
+                boom.badRequest(err.message, {
+                  requestUrl: req.originalUrl,
+                  requestBody: req.body
+                })
+              )
+            }
+          }
+
+          if (metricsQueue) {
+            await metricsQueue.add({
+              type: 'createCollaborator',
+              readerId: createdCollaborator.readerId
+            })
+          }
+
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.status(201).end(JSON.stringify(createdCollaborator))
+        })
+        .catch(err => {
+          next(err)
+        })
+    })
+}

--- a/routes/collaborator/collaborator-put.js
+++ b/routes/collaborator/collaborator-put.js
@@ -11,7 +11,7 @@ const { Collaborator } = require('../../models/Collaborator')
 module.exports = function (app) {
   /**
    * @swagger
-   * /notebooks/{notebookId}/collaborators/{collaboratorId}
+   * /notebooks/{notebookId}/collaborators/{collaboratorId}:
    *   put:
    *     tags:
    *       - collaborators

--- a/server.js
+++ b/server.js
@@ -97,6 +97,7 @@ const notebookPostSourceRoute = require('./routes/notebooks/notebook-source-post
 
 // collaborators
 const collaboratorPostRoute = require('./routes/collaborator/collaborator-post')
+const collaboratorPutRoute = require('./routes/collaborator/collaborator-put')
 
 const hardDeleteRoute = require('./routes/hardDelete')
 
@@ -295,6 +296,8 @@ outlineDeleteNoteRoute(app)
 outlinePatchNoteRoute(app)
 readerPutRoute(app)
 readerDeleteRoute(app)
+collaboratorPostRoute(app)
+collaboratorPutRoute(app)
 notebookPostRoute(app)
 notebookGetRoute(app)
 notebooksGetRoute(app)
@@ -315,7 +318,6 @@ canvasPutRoute(app)
 canvasDeleteRoute(app)
 canvasGetByIdRoute(app)
 canvasGetAllRoute(app)
-collaboratorPostRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -98,10 +98,12 @@ const notebookPostSourceRoute = require('./routes/notebooks/notebook-source-post
 // collaborators
 const collaboratorPostRoute = require('./routes/collaborator/collaborator-post')
 const collaboratorPutRoute = require('./routes/collaborator/collaborator-put')
+const collaboratorDeleteRoute = require('./routes/collaborator/collaborator-delete')
 
 const hardDeleteRoute = require('./routes/hardDelete')
 
 const metricsGetRoute = require('./routes/metrics-get')
+const collaboratorDelete = require('./routes/collaborator/collaborator-delete')
 
 const setupKnex = async skip_migrate => {
   let config
@@ -298,6 +300,7 @@ readerPutRoute(app)
 readerDeleteRoute(app)
 collaboratorPostRoute(app)
 collaboratorPutRoute(app)
+collaboratorDeleteRoute(app)
 notebookPostRoute(app)
 notebookGetRoute(app)
 notebooksGetRoute(app)

--- a/server.js
+++ b/server.js
@@ -95,6 +95,9 @@ const notebookPutTagRoute = require('./routes/notebooks/notebook-put-tag') // PU
 const notebookDeleteTagRoute = require('./routes/notebooks/notebook-delete-tag') // DELETE /notebooks/:id/tags/:tagId
 const notebookPostSourceRoute = require('./routes/notebooks/notebook-source-post')
 
+// collaborators
+const collaboratorPostRoute = require('./routes/collaborator/collaborator-post')
+
 const hardDeleteRoute = require('./routes/hardDelete')
 
 const metricsGetRoute = require('./routes/metrics-get')
@@ -312,6 +315,7 @@ canvasPutRoute(app)
 canvasDeleteRoute(app)
 canvasGetByIdRoute(app)
 canvasGetAllRoute(app)
+collaboratorPostRoute(app)
 
 app.use(errorHandling)
 

--- a/server.js
+++ b/server.js
@@ -103,7 +103,6 @@ const collaboratorDeleteRoute = require('./routes/collaborator/collaborator-dele
 const hardDeleteRoute = require('./routes/hardDelete')
 
 const metricsGetRoute = require('./routes/metrics-get')
-const collaboratorDelete = require('./routes/collaborator/collaborator-delete')
 
 const setupKnex = async skip_migrate => {
   let config

--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -1,0 +1,141 @@
+const request = require('supertest')
+const tap = require('tap')
+const urlparse = require('url').parse
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createReader,
+  createCollaborator,
+  createSource,
+  createNote,
+  createTag,
+  createNoteRelation,
+  createNoteContext,
+  createNotebook,
+  createCanvas
+} = require('../../utils/testUtils')
+const { Reader } = require('../../../models/Reader')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  // Create owner, collaborator and stranger
+  const token = getToken()
+  const owner = await createReader(app, token)
+  const token2 = getToken()
+  const collab = await createReader(app, token2)
+  const token3 = getToken()
+  const stranger = await createReader(app, token3)
+
+  // create notebook and collab
+  const notebook = await createNotebook(app, token, { name: 'my notebook' })
+  const collaboratorObject = await createCollaborator(
+    app,
+    token,
+    notebook.shortId,
+    {
+      readerId: collab.shortId,
+      status: 'accepted',
+      permission: {
+        read: 'true',
+        comment: 'true'
+      }
+    }
+  )
+
+  await tap.test(
+    'Try to create a collaborator in a notebook you do not own',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: stranger.shortId,
+            status: 'accepted',
+            permission: { read: true }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to notebook ${notebook.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/collaborators`
+      )
+    }
+  )
+
+  await tap.test('Try to update a collaborator by a stranger', async () => {
+    const res = await request(app)
+      .put(
+        `/notebooks/${notebook.shortId}/collaborators/${
+          collaboratorObject.shortId
+        }`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token3}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          readerId: collab.shortId,
+          status: 'accepted',
+          permission: { read: true }
+        })
+      )
+
+    await tap.equal(res.statusCode, 403)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 403)
+    await tap.equal(error.error, 'Forbidden')
+    await tap.equal(
+      error.message,
+      `Access to Collaborator ${collaboratorObject.shortId} disallowed`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebook.shortId}/collaborators/${
+        collaboratorObject.shortId
+      }`
+    )
+  })
+
+  await tap.test('Try to delete a collaborator by a stranger', async () => {
+    const res = await request(app)
+      .delete(
+        `/notebooks/${notebook.shortId}/collaborators/${
+          collaboratorObject.shortId
+        }`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token3}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 403)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 403)
+    await tap.equal(error.error, 'Forbidden')
+    await tap.equal(
+      error.message,
+      `Access to Collaborator ${collaboratorObject.shortId} disallowed`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebook.shortId}/collaborators/${
+        collaboratorObject.shortId
+      }`
+    )
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -1,9 +1,7 @@
 const request = require('supertest')
 const tap = require('tap')
-const urlparse = require('url').parse
 const {
   getToken,
-  createUser,
   destroyDB,
   createReader,
   createCollaborator,
@@ -15,8 +13,6 @@ const {
   createNotebook,
   createCanvas
 } = require('../../utils/testUtils')
-const { Reader } = require('../../../models/Reader')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   // Create owner, collaborator and stranger

--- a/tests/integration/collaborator/collaborator-delete.test.js
+++ b/tests/integration/collaborator/collaborator-delete.test.js
@@ -1,0 +1,137 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+  const token2 = getToken()
+  const reader2 = await createReader(app, token2)
+
+  const notebook = await createNotebook(app, token, { name: 'notebook' })
+  const collaborator = await createCollaborator(app, token, notebook.shortId, {
+    readerId: reader2.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  await tap.test('Delete Collaborator by collaborator himself', async () => {
+    const res = await request(app)
+      .delete(
+        `/notebooks/${notebook.shortId}/collaborators/${collaborator.shortId}`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 204)
+
+    // TODO: will have to test that the collaborator does not exist
+  })
+
+  await tap.test(
+    'Try to delete a Collaborator that was already deleted',
+    async () => {
+      const res = await request(app)
+        .delete(
+          `/notebooks/${notebook.shortId}/collaborators/${collaborator.shortId}`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Collaborator Delete Error: No Collaborator found with id ${
+          collaborator.shortId
+        }`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/collaborators/${collaborator.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to update Collaborator that was already deleted',
+    async () => {
+      const res = await request(app)
+        .put(
+          `/notebooks/${notebook.shortId}/collaborators/${collaborator.shortId}`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: reader2.shortId,
+            status: 'pending',
+            permission: { read: true, comment: true }
+          })
+        )
+
+      await tap.equal(res.statusCode, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Put Collaborator Error: No Collaborator found with id ${
+          collaborator.shortId
+        }`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/collaborators/${collaborator.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to delete a Collaborator that does not exist',
+    async () => {
+      const res1 = await request(app)
+        .delete(
+          `/notebooks/${notebook.shortId}/collaborators/${
+            collaborator.shortId
+          }abc`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res1.statusCode, 404)
+      const error1 = JSON.parse(res1.text)
+      await tap.equal(error1.statusCode, 404)
+      await tap.equal(error1.error, 'Not Found')
+      await tap.equal(
+        error1.message,
+        `Collaborator Delete Error: No Collaborator found with id ${
+          collaborator.shortId
+        }abc`
+      )
+      await tap.equal(
+        error1.details.requestUrl,
+        `/notebooks/${notebook.shortId}/collaborators/${
+          collaborator.shortId
+        }abc`
+      )
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaborator/collaborator-post.test.js
+++ b/tests/integration/collaborator/collaborator-post.test.js
@@ -1,0 +1,285 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  createReader
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const token2 = getToken()
+  const reader2 = await createReader(app, token2)
+
+  const notebook = await createNotebook(app, token, { name: 'notebook1' })
+  const notebook2 = await createNotebook(app, token, { name: 'notebook2' })
+  const notebook3 = await createNotebook(app, token, { name: 'notebook3' })
+
+  await tap.test('Create a collaborator', async () => {
+    const res = await request(app)
+      .post(`/notebooks/${notebook.shortId}/collaborators`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          readerId: reader2.shortId,
+          status: 'pending',
+          permission: { read: true, comment: true }
+        })
+      )
+    await tap.equal(res.status, 201)
+
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.ok(body.shortId)
+    await tap.ok(body.notebookId)
+    await tap.ok(body.readerId)
+    await tap.equal(body.notebookId, notebook.shortId)
+    await tap.equal(body.status, 'pending')
+    await tap.equal(body.permission.read, true)
+    await tap.equal(body.permission.comment, true)
+    await tap.ok(body.published)
+    await tap.ok(body.updated)
+  })
+
+  await tap.test('invalid properties should be ignored', async () => {
+    const res = await request(app)
+      .post(`/notebooks/${notebook2.shortId}/collaborators`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          readerId: reader2.shortId,
+          status: 'pending',
+          permission: { read: true, comment: true },
+          invalidProp: 'jwoerijeosnco'
+        })
+      )
+
+    await tap.equal(res.status, 201)
+
+    const body = res.body
+    await tap.equal(body.status, 'pending')
+    await tap.notOk(body.invalidProp)
+  })
+
+  // await tap.test('Try to create a duplicate collaborator', async () => {
+  //   const res = await request(app)
+  //     .post(`/notebooks/${notebook.shortId}/collaborators`)
+  //     .set('Host', 'reader-api.test')
+  //     .set('Authorization', `Bearer ${token}`)
+  //     .type('application/ld+json')
+  //     .send(
+  //       JSON.stringify({
+  //         readerId: reader2.shortId,
+  //         status: 'pending',
+  //         permission: {read: true, comment: true}
+  //       })
+  //     )
+
+  //   await tap.equal(res.status, 400)
+  //   const error = JSON.parse(res.text)
+  //   await tap.equal(error.statusCode, 400)
+  //   await tap.equal(error.error, 'Bad Request')
+  //   await tap.equal(
+  //     error.message,
+  //     ''
+  //   )
+  //   await tap.equal(error.details.requestUrl, '/collaborators')
+  //   await tap.type(error.details.requestBody, 'object')
+  //   await tap.equal(error.details.requestBody.status, 'pending')
+
+  // })
+
+  await tap.test(
+    'trying to create a Collaborator without a readerId',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook3.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            // readerId: reader2.shortId,
+            status: 'pending',
+            permission: { read: true, comment: true }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create Collaborator: readerId: is a required property'
+      )
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(error.details.validation.readerId[0].keyword, 'required')
+      await tap.equal(
+        error.details.validation.readerId[0].params.missingProperty,
+        'readerId'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook3.shortId}/collaborators`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.status, 'pending')
+    }
+  )
+
+  await tap.test(
+    'trying to create a Collaborator without a status',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook3.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: reader2.shortId,
+            // status: 'pending',
+            permission: { read: true, comment: true }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Collaborator validation error: status is a required property'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook3.shortId}/collaborators`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.permission.read, true)
+    }
+  )
+
+  await tap.test(
+    'trying to create a Collaborator without a permission object',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook3.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: reader2.shortId,
+            status: 'pending'
+            // permission: {read: true, comment: true}
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create Collaborator: permission: is a required property'
+      )
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(
+        error.details.validation.permission[0].keyword,
+        'required'
+      )
+      await tap.equal(
+        error.details.validation.permission[0].params.missingProperty,
+        'permission'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook3.shortId}/collaborators`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.status, 'pending')
+    }
+  )
+
+  await tap.test(
+    'trying to create a Collaborator with an invalid status',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook3.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: reader2.shortId,
+            status: 'pending!!', // not valid
+            permission: { read: true, comment: true }
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Collaborator validation error: pending!! is not a valid status'
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook3.shortId}/collaborators`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.status, 'pending!!')
+    }
+  )
+
+  await tap.test(
+    'trying to create a Collaborator with invalid data',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook3.shortId}/collaborators`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            readerId: reader2.shortId,
+            status: 'pending',
+            permission: 'should not be a string'
+          })
+        )
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        'Validation Error on Create Collaborator: permission: should be object'
+      )
+      await tap.type(error.details.validation, 'object')
+      await tap.equal(error.details.validation.permission[0].keyword, 'type')
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook3.shortId}/collaborators`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.status, 'pending')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaborator/collaborator-put.test.js
+++ b/tests/integration/collaborator/collaborator-put.test.js
@@ -1,0 +1,221 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  createReader,
+  destroyDB,
+  createCollaborator,
+  createNotebook
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createUser(app, token)
+
+  const notebook1 = await createNotebook(app, token, { name: 'notebook1' })
+
+  const token2 = getToken()
+  const reader2 = await createReader(app, token2)
+
+  const collaborator = await createCollaborator(app, token, notebook1.shortId, {
+    readerId: reader2.shortId,
+    status: 'pending',
+    permission: {
+      read: true,
+      comment: true
+    }
+  })
+
+  await tap.test('Update the status of a collaborator', async () => {
+    const newCollab = Object.assign(collaborator, { status: 'accepted' })
+
+    const res = await request(app)
+      .put(
+        `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newCollab))
+
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.id, 'string')
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(body.status, 'accepted')
+    await tap.notEqual(body.published, body.updated)
+    // check that old properties are still there
+    await tap.type(body.notebookId, 'string')
+    await tap.equal(body.permission.read, true)
+    await tap.equal(urlToId(body.readerId), reader2.shortId)
+
+    canvas = body
+  })
+
+  await tap.test('Update the permission of a collaborator', async () => {
+    const newCollab = Object.assign(collaborator, {
+      permission: { read: true, comment: false }
+    })
+
+    const res = await request(app)
+      .put(
+        `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newCollab))
+
+    await tap.equal(res.statusCode, 200)
+    const body = res.body
+    await tap.type(body, 'object')
+    await tap.type(body.id, 'string')
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.notEqual(body.published, body.updated)
+    await tap.equal(body.permission.comment, false)
+    // check that old properties are still there
+    await tap.type(body.notebookId, 'string')
+    await tap.equal(body.permission.read, true)
+    await tap.equal(body.status, 'accepted')
+    await tap.equal(urlToId(body.readerId), reader2.shortId)
+
+    canvas = body
+  })
+
+  // // ----------------------------------- VALIDATION ERRORS --------------
+
+  await tap.test('Try to update the permission to a wrong type', async () => {
+    const newCollab = Object.assign(collaborator, { permission: 'string' })
+
+    const res = await request(app)
+      .put(
+        `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newCollab))
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      `Validation Error on Update Collaborator: permission: should be object`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+    )
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.permission, 'string')
+  })
+
+  await tap.test('Try to update by removing the status', async () => {
+    const newCollab = Object.assign(collaborator, { status: null })
+
+    const res = await request(app)
+      .put(
+        `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+      )
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(JSON.stringify(newCollab))
+
+    await tap.equal(res.status, 400)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 400)
+    await tap.equal(error.error, 'Bad Request')
+    await tap.equal(
+      error.message,
+      `Collaborator validation error: status is a required property`
+    )
+    await tap.equal(
+      error.details.requestUrl,
+      `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+    )
+    await tap.type(error.details.requestBody, 'object')
+    await tap.equal(error.details.requestBody.status, null)
+  })
+
+  await tap.test(
+    'Try to update by updating the status to an invalid value',
+    async () => {
+      const newCollab = Object.assign(collaborator, {
+        status: 'invalid',
+        permission: { read: true }
+      })
+
+      const res = await request(app)
+        .put(
+          `/notebooks/${notebook1.shortId}/collaborators/${
+            collaborator.shortId
+          }`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify(newCollab))
+
+      await tap.equal(res.status, 400)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 400)
+      await tap.equal(error.error, 'Bad Request')
+      await tap.equal(
+        error.message,
+        `Collaborator validation error: invalid is not a valid status`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook1.shortId}/collaborators/${collaborator.shortId}`
+      )
+      await tap.type(error.details.requestBody, 'object')
+      await tap.equal(error.details.requestBody.status, 'invalid')
+    }
+  )
+
+  await tap.test(
+    'Try to update a Collaborator that does not exist',
+    async () => {
+      const newCollab = Object.assign(collaborator, { status: 'pending' })
+
+      const res = await request(app)
+        .put(
+          `/notebooks/${notebook1.shortId}/collaborators/${
+            collaborator.shortId
+          }abc`
+        )
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+        .send(JSON.stringify(newCollab))
+
+      await tap.equal(res.statusCode, 404)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 404)
+      await tap.equal(error.error, 'Not Found')
+      await tap.equal(
+        error.message,
+        `Put Collaborator Error: No Collaborator found with id ${
+          collaborator.shortId
+        }abc`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook1.shortId}/collaborators/${
+          collaborator.shortId
+        }abc`
+      )
+      await tap.type(error.details.requestBody, 'object')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -118,6 +118,7 @@ const hardDeleteCanvasTests = require('./hardDelete/deleteCanvas.test')
 // const metricsTest = require('./metrics.test')
 
 const collaboratorPostTests = require('./collaborator/collaborator-post.test')
+const collaboratorPutTests = require('./collaborator/collaborator-put.test')
 
 const app = require('../../server').app
 
@@ -333,6 +334,7 @@ const allTests = async () => {
   if (!test || test === 'collaborator') {
     try {
       await collaboratorPostTests(app)
+      await collaboratorPutTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -119,6 +119,7 @@ const hardDeleteCanvasTests = require('./hardDelete/deleteCanvas.test')
 
 const collaboratorPostTests = require('./collaborator/collaborator-post.test')
 const collaboratorPutTests = require('./collaborator/collaborator-put.test')
+const collaboratorDeleteTests = require('./collaborator/collaborator-delete.test')
 
 const app = require('../../server').app
 
@@ -335,6 +336,7 @@ const allTests = async () => {
     try {
       await collaboratorPostTests(app)
       await collaboratorPutTests(app)
+      await collaboratorDeleteTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -1,5 +1,6 @@
 const forbiddedTests = require('./auth/forbidden.test')
 const unauthorizedTests = require('./auth/unauthorized.test')
+const collaborationAuthTests = require('./auth/collaboration-auth.test')
 
 const libraryGetTests = require('./library/library-get.test')
 const libraryPaginateTests = require('./library/library-paginate.test')
@@ -140,6 +141,7 @@ const allTests = async () => {
     try {
       await forbiddedTests(app)
       await unauthorizedTests(app)
+      await collaborationAuthTests(app)
     } catch (err) {
       console.log('authentication integration test error: ', err)
       throw err

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -117,6 +117,8 @@ const hardDeleteReaderTests = require('./hardDelete/deleteReader.test')
 const hardDeleteCanvasTests = require('./hardDelete/deleteCanvas.test')
 // const metricsTest = require('./metrics.test')
 
+const collaboratorPostTests = require('./collaborator/collaborator-post.test')
+
 const app = require('../../server').app
 
 require('dotenv').config()
@@ -324,6 +326,15 @@ const allTests = async () => {
       await canvasFilterByNotebookTests(app)
     } catch (err) {
       console.log('outline integration tests error: ', err)
+      throw err
+    }
+  }
+
+  if (!test || test === 'collaborator') {
+    try {
+      await collaboratorPostTests(app)
+    } catch (err) {
+      console.log('collaborator integration tests error: ', err)
       throw err
     }
   }

--- a/tests/models/Collaborator.test.js
+++ b/tests/models/Collaborator.test.js
@@ -67,7 +67,6 @@ const test = async app => {
         urlToId(notebookId)
       )
     } catch (err) {
-      console.log(err)
       error = err
     }
     await tap.notOk(error)

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -364,6 +364,16 @@ const createCanvas = async (app, token, object) => {
   return res.body
 }
 
+const createCollaborator = async (app, token, notebookId, object) => {
+  const res = await request(app)
+    .post(`/notebooks/${notebookId}/collaborators`)
+    .set('Host', 'reader-api.test')
+    .set('Authorization', `Bearer ${token}`)
+    .send(object)
+
+  return res.body
+}
+
 module.exports = {
   getToken,
   createUser,
@@ -385,5 +395,6 @@ module.exports = {
   addSourceToNotebook,
   addNoteToNotebook,
   addTagToNotebook,
-  createCanvas
+  createCanvas,
+  createCollaborator
 }


### PR DESCRIPTION
Creating three routes:
POST /notebooks/:notebookId/collaborators
PUT /notebooks/:notebookId/collaborators/:collaboratorId
DELETE /notebooks/:notebookId/collaborators/:collaboratorId

For now:
- only the owner of the notebook can create a collaborator. Eventually, some collaborators might be able to as well (that might depend on their level of permission)
- the collaborator can update or delete the collaborator object. Eventually the owner will too. Maybe other collaborators too, depending on permission level?

Aside from that, it is all pretty straightforward. 
