### PR TITLE
Get stuff as a collaborator

### DIFF
--- a/models/Collaborator.js
+++ b/models/Collaborator.js
@@ -1,5 +1,6 @@
 // @flow
 'use strict'
+const Model = require('objection').Model
 const { BaseModel } = require('./BaseModel.js')
 const _ = require('lodash')
 const { urlToId } = require('../utils/utils')
@@ -34,6 +35,21 @@ class Collaborator extends BaseModel {
         deleted: { type: ['string', 'null'], format: 'date-time' }
       },
       required: ['readerId', 'notebookId', 'permission', 'status']
+    }
+  }
+
+  static get relationMappings () /*: any */ {
+    const { Reader } = require('./Reader')
+
+    return {
+      reader: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Reader,
+        join: {
+          from: 'Collaborator.readerId',
+          to: 'Reader.id'
+        }
+      }
     }
   }
 

--- a/models/Note.js
+++ b/models/Note.js
@@ -323,11 +323,16 @@ class Note extends BaseModel {
     const note = await Note.query()
       .findById(id)
       .withGraphFetched(
-        `[reader, outlineData, tags(notDeleted), body, 
+        `[reader, 
+          outlineData, 
+          tags(notDeleted), 
+          body, 
           relationsFrom.toNote(notDeleted).body, 
           relationsTo.fromNote(notDeleted).body, 
           notebooks(notDeleted).collaborators, 
-          source(notDeleted, selectSource).attributions]`
+          source(notDeleted, selectSource).attributions,
+          context(notDeleted).notebook.collaborators
+        ]`
       )
       .modifiers({
         notDeleted (builder) {

--- a/models/Note.js
+++ b/models/Note.js
@@ -323,7 +323,11 @@ class Note extends BaseModel {
     const note = await Note.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, outlineData, tags(notDeleted), body, relationsFrom.toNote(notDeleted).body, relationsTo.fromNote(notDeleted).body, notebooks, source(notDeleted, selectSource).attributions]'
+        `[reader, outlineData, tags(notDeleted), body, 
+          relationsFrom.toNote(notDeleted).body, 
+          relationsTo.fromNote(notDeleted).body, 
+          notebooks(notDeleted).collaborators, 
+          source(notDeleted, selectSource).attributions]`
       )
       .modifiers({
         notDeleted (builder) {

--- a/models/NoteContext.js
+++ b/models/NoteContext.js
@@ -34,6 +34,7 @@ class NoteContext extends BaseModel {
   static get relationMappings () /*: any */ {
     const { Reader } = require('./Reader')
     const { Note } = require('./Note')
+    const { Notebook } = require('./Notebook')
 
     return {
       reader: {
@@ -42,6 +43,14 @@ class NoteContext extends BaseModel {
         join: {
           from: 'NoteContext.readerId',
           to: 'Reader.id'
+        }
+      },
+      notebook: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: Notebook,
+        join: {
+          from: 'NoteContext.notebookId',
+          to: 'Notebook.id'
         }
       },
       notes: {
@@ -76,7 +85,12 @@ class NoteContext extends BaseModel {
     const noteContext = await NoteContext.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[outlineData, relationsFrom(notDeleted).toNote(notDeleted).body, relationsTo(notDeleted).fromNote(notDeleted).body, body, tags, source(selectSource)]]'
+        `[reader, 
+          notebook(notDeleted).collaborators,
+          notes(notDeleted).[outlineData, 
+            relationsFrom(notDeleted).toNote(notDeleted).body, 
+            relationsTo(notDeleted).fromNote(notDeleted).body, 
+            body, tags, source(selectSource)]]`
       )
       .modifiers({
         notDeleted (builder) {

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -42,6 +42,7 @@ class Notebook extends BaseModel {
     const { Tag } = require('./Tag')
     const { Source } = require('./Source')
     const { Canvas } = require('./Canvas')
+    const { Collaborator } = require('./Collaborator')
 
     return {
       reader: {
@@ -111,6 +112,14 @@ class Notebook extends BaseModel {
           },
           to: 'Note.id'
         }
+      },
+      collaborators: {
+        relation: Model.HasManyRelation,
+        modelClass: Collaborator,
+        join: {
+          from: 'Notebook.id',
+          to: 'Collaborator.notebookId'
+        }
       }
     }
   }
@@ -155,7 +164,7 @@ class Notebook extends BaseModel {
     return await Notebook.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), canvas(notDeleted), tags(notDeleted), sources(notDeleted, notReferenced).[tags, attributions]]'
+        '[reader, notes(notDeleted).[body, tags(notDeleted), source(notDeleted)], notebookTags(notDeleted), noteContexts(notDeleted), canvas(notDeleted), tags(notDeleted), collaborators(notDeleted).reader, sources(notDeleted, notReferenced).[tags, attributions]]'
       )
       .modifiers({
         notDeleted (builder) {

--- a/models/Source.js
+++ b/models/Source.js
@@ -545,7 +545,7 @@ class Source extends BaseModel {
     const source = await Source.query()
       .findById(id)
       .withGraphFetched(
-        '[reader, replies(notDeleted), tags(notDeleted), attributions, readActivities(latestFirst), notebooks]'
+        '[reader, replies(notDeleted), tags(notDeleted), attributions, readActivities(latestFirst), notebooks.collaborators]'
       )
       .modifiers({
         notDeleted (builder) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "^12.0.0"
   },
   "scripts": {
-    "test-integration": "cross-env SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap --reporter=dot --no-coverage-report --timeout=200 tests/integration/index.js",
+    "test-integration": "cross-env SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap --reporter=dot --no-coverage-report --timeout=400 tests/integration/index.js",
     "test-google": "cross-env SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -c -R classic --cov tests/google-integration/index.js",
     "test-models": "cross-env SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -R classic --no-coverage tests/models/index.js",
     "test-unit": "cross-env SECRETORKEY=kick-opossum-snowiness ISSUER=auth.reader-api.test DOMAIN=https://reader-api.test NODE_ENV=test tap -R classic --no-coverage tests/unit/*.test.js",

--- a/routes/noteContexts/noteContext-get.js
+++ b/routes/noteContexts/noteContext-get.js
@@ -67,7 +67,7 @@ module.exports = app => {
             )
             if (!collaborator.read) {
               return next(
-                boom.forbidden(`Access to noteContext ${id} disallowed`, {
+                boom.forbidden(`Access to NoteContext ${id} disallowed`, {
                   requestUrl: req.originalUrl
                 })
               )

--- a/routes/notes/note-get.js
+++ b/routes/notes/note-get.js
@@ -63,11 +63,21 @@ module.exports = app => {
               note.notebooks
             )
             if (!collaborator.read) {
-              return next(
-                boom.forbidden(`Access to note ${id} disallowed`, {
-                  requestUrl: req.originalUrl
-                })
-              )
+              // check if collaborator in the noteContext
+              let collaborator2
+              if (note.context) {
+                collaborator2 = utils.checkNotebookCollaborator(
+                  reader.id,
+                  note.context.notebook
+                )
+              }
+              if (!collaborator2 || !collaborator2.read) {
+                return next(
+                  boom.forbidden(`Access to note ${id} disallowed`, {
+                    requestUrl: req.originalUrl
+                  })
+                )
+              }
             }
           }
 

--- a/routes/outlines/outline-get.js
+++ b/routes/outlines/outline-get.js
@@ -72,39 +72,38 @@ module.exports = app => {
             )
             if (!collaborator.read) {
               return next(
-                boom.forbidden(`Access to noteContext ${id} disallowed`, {
+                boom.forbidden(`Access to Outline ${id} disallowed`, {
                   requestUrl: req.originalUrl
                 })
               )
             }
-
-            let nestedNotesList
-            try {
-              nestedNotesList = notesListToTree(noteContext.notes)
-            } catch (err) {
-              if (err.message === 'circular') {
-                return next(
-                  boom.badRequest('Error: outline contains a circular list', {
-                    requestUrl: req.originalUrl
-                  })
-                )
-              } else {
-                return next(
-                  boom.badRequest(
-                    `Error: invalid outline structure: ${err.message} `,
-                    {
-                      requestUrl: req.originalUrl
-                    }
-                  )
-                )
-              }
-            }
-            const outline = Object.assign(noteContext.toJSON(), {
-              notes: nestedNotesList
-            })
-            res.setHeader('Content-Type', 'application/ld+json')
-            res.end(JSON.stringify(outline))
           }
+          let nestedNotesList
+          try {
+            nestedNotesList = notesListToTree(noteContext.notes)
+          } catch (err) {
+            if (err.message === 'circular') {
+              return next(
+                boom.badRequest('Error: outline contains a circular list', {
+                  requestUrl: req.originalUrl
+                })
+              )
+            } else {
+              return next(
+                boom.badRequest(
+                  `Error: invalid outline structure: ${err.message} `,
+                  {
+                    requestUrl: req.originalUrl
+                  }
+                )
+              )
+            }
+          }
+          const outline = Object.assign(noteContext.toJSON(), {
+            notes: nestedNotesList
+          })
+          res.setHeader('Content-Type', 'application/ld+json')
+          res.end(JSON.stringify(outline))
         })
         .catch(err => {
           next(err)

--- a/routes/outlines/outline-get.js
+++ b/routes/outlines/outline-get.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const passport = require('passport')
 const { NoteContext } = require('../../models/NoteContext')
+const { Reader } = require('../../models/Reader')
 const utils = require('../../utils/utils')
 const { notesListToTree } = require('../../utils/outline')
 const boom = require('@hapi/boom')
@@ -48,7 +49,7 @@ module.exports = app => {
     function (req, res, next) {
       const id = req.params.id
       NoteContext.byId(id)
-        .then(noteContext => {
+        .then(async noteContext => {
           if (
             !noteContext ||
             noteContext.deleted ||
@@ -63,12 +64,20 @@ module.exports = app => {
               )
             )
           } else if (!utils.checkReader(req, noteContext.reader)) {
-            return next(
-              boom.forbidden(`Access to Outline ${id} disallowed`, {
-                requestUrl: req.originalUrl
-              })
+            // if user is not owner, check if it is a collaborator
+            const reader = await Reader.byAuthId(req.user)
+            const collaborator = utils.checkNotebookCollaborator(
+              reader.id,
+              noteContext.notebook
             )
-          } else {
+            if (!collaborator.read) {
+              return next(
+                boom.forbidden(`Access to noteContext ${id} disallowed`, {
+                  requestUrl: req.originalUrl
+                })
+              )
+            }
+
             let nestedNotesList
             try {
               nestedNotesList = notesListToTree(noteContext.notes)

--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -9,17 +9,14 @@ const {
   addSourceToNotebook,
   addNoteToNotebook,
   createNote,
-  createTag,
-  createNoteRelation,
-  createNoteContext,
-  createNotebook,
-  createCanvas
+  createNotebook
 } = require('../../utils/testUtils')
 
 const test = async app => {
   // Create owner, collaborator and stranger
   const token = getToken()
-  const owner = await createReader(app, token)
+  // owner:
+  await createReader(app, token)
   const token2 = getToken()
   const collab = await createReader(app, token2)
   const token3 = getToken()

--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -9,7 +9,8 @@ const {
   addSourceToNotebook,
   addNoteToNotebook,
   createNote,
-  createNotebook
+  createNotebook,
+  createNoteContext
 } = require('../../utils/testUtils')
 
 const test = async app => {
@@ -21,6 +22,10 @@ const test = async app => {
   const collab = await createReader(app, token2)
   const token3 = getToken()
   const stranger = await createReader(app, token3)
+  const token4 = getToken()
+  const pendingCollab = await createReader(app, token4)
+  const token5 = getToken()
+  const noReadCollab = await createReader(app, token5)
 
   // create notebook and collab
   const notebook = await createNotebook(app, token, { name: 'my notebook' })
@@ -32,17 +37,56 @@ const test = async app => {
       readerId: collab.shortId,
       status: 'accepted',
       permission: {
-        read: 'true',
-        comment: 'true'
+        read: true,
+        comment: true
       }
     }
   )
+  // pending
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: pendingCollab.shortId,
+    status: 'pending',
+    permission: {
+      read: true,
+      comment: true
+    }
+  })
+
+  // no read
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: noReadCollab.shortId,
+    status: 'accepted',
+    permission: {
+      read: false,
+      comment: true
+    }
+  })
 
   const source = await createSource(app, token)
   await addSourceToNotebook(app, token, source.shortId, notebook.shortId)
 
   const note = await createNote(app, token, { body: { motivation: 'test' } })
   await addNoteToNotebook(app, token, note.shortId, notebook.shortId)
+
+  const noteContext = await createNoteContext(app, token, {
+    type: 'test',
+    notebookId: notebook.shortId
+  })
+
+  const outline = await createNoteContext(app, token, {
+    type: 'outline',
+    notebookId: notebook.shortId
+  })
+
+  const note1 = await createNote(app, token, {
+    body: { motivation: 'test' },
+    contextId: noteContext.shortId
+  })
+
+  const note2 = await createNote(app, token, {
+    body: { motivation: 'test' },
+    contextId: outline.shortId
+  })
 
   await tap.test(
     'Try to create a collaborator in a notebook you do not own',
@@ -154,6 +198,48 @@ const test = async app => {
     await tap.equal(error.details.requestUrl, `/notebooks/${notebook.shortId}`)
   })
 
+  await tap.test('Try to get a notebook as a pendingCollab', async () => {
+    const res = await request(app)
+      .get(`/notebooks/${notebook.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token4}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.statusCode, 403)
+    const error = JSON.parse(res.text)
+    await tap.equal(error.statusCode, 403)
+    await tap.equal(error.error, 'Forbidden')
+    await tap.equal(
+      error.message,
+      `Access to Notebook ${notebook.shortId} disallowed`
+    )
+    await tap.equal(error.details.requestUrl, `/notebooks/${notebook.shortId}`)
+  })
+
+  await tap.test(
+    'Try to get a notebook as a collaborator without a read permission',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks/${notebook.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}`
+      )
+    }
+  )
+
   await tap.test(
     'Try to get a note inside a notebook as a stranger',
     async () => {
@@ -161,6 +247,48 @@ const test = async app => {
         .get(`/notes/${note.shortId}`)
         .set('Host', 'reader-api.test')
         .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside a notebook as a collaborator without a read permission',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
         .type('application/ld+json')
 
       await tap.equal(res.statusCode, 403)
@@ -193,6 +321,313 @@ const test = async app => {
         `Access to source ${source.shortId} disallowed`
       )
       await tap.equal(error.details.requestUrl, `/sources/${source.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a source inside a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/sources/${source.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to source ${source.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/sources/${source.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a source inside a notebook as a collaborator without read permission',
+    async () => {
+      const res = await request(app)
+        .get(`/sources/${source.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to source ${source.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/sources/${source.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a noteContext inside a notebook as a stranger',
+    async () => {
+      const res = await request(app)
+        .get(`/noteContexts/${noteContext.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to get a noteContext inside a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/noteContexts/${noteContext.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    `Try to get a noteContext inside a notebook as a collaborator without
+     read permission`,
+    async () => {
+      const res = await request(app)
+        .get(`/noteContexts/${noteContext.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to get an outline inside a notebook as a stranger',
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get an outline inside a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+    }
+  )
+
+  await tap.test(
+    `Try to get an outline inside a notebook as a collaborator without a
+     read permission`,
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outline.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside a noteContext in a notebook as a stranger',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note1.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside a noteContext in a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note1.shortId}`)
+    }
+  )
+
+  await tap.test(
+    `Try to get a note inside a noteContext in a notebook as a collaborator 
+    without read permission`,
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note1.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note1.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside an outline in a notebook as a stranger',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note2.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note2.shortId}`)
+    }
+  )
+
+  await tap.test(
+    'Try to get a note inside an outline in a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note2.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note2.shortId}`)
+    }
+  )
+
+  await tap.test(
+    `Try to get a note inside an outline in a notebook as a collaborator without
+     read permission`,
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token5}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to note ${note2.shortId} disallowed`
+      )
+      await tap.equal(error.details.requestUrl, `/notes/${note2.shortId}`)
     }
   )
 

--- a/tests/integration/collaboration/collaboration-note-get.test.js
+++ b/tests/integration/collaboration/collaboration-note-get.test.js
@@ -2,28 +2,19 @@ const request = require('supertest')
 const tap = require('tap')
 const {
   getToken,
-  createUser,
   destroyDB,
   createNotebook,
-  addSourceToNotebook,
-  createSource,
   addNoteToNotebook,
-  addTagToNotebook,
-  createTag,
   createNote,
-  createCanvas,
-  createNoteContext,
-  addSourceToCollection,
-  addNoteToCollection,
   createCollaborator,
   createReader
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   // owner, collab1, collab2
   const token = getToken()
-  const owner = await createReader(app, token)
+  // owner
+  await createReader(app, token)
   const token2 = getToken()
   const collab1 = await createReader(app, token2) // will be pending
   const token3 = getToken()
@@ -38,13 +29,13 @@ const test = async app => {
     }
   })
 
-  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab1.shortId,
     status: 'pending',
     permission: { read: true }
   })
 
-  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab2.shortId,
     status: 'accepted',
     permission: { read: true }

--- a/tests/integration/collaboration/collaboration-note-get.test.js
+++ b/tests/integration/collaboration/collaboration-note-get.test.js
@@ -1,0 +1,77 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  addSourceToNotebook,
+  createSource,
+  addNoteToNotebook,
+  addTagToNotebook,
+  createTag,
+  createNote,
+  createCanvas,
+  createNoteContext,
+  addSourceToCollection,
+  addNoteToCollection,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  // owner, collab1, collab2
+  const token = getToken()
+  const owner = await createReader(app, token)
+  const token2 = getToken()
+  const collab1 = await createReader(app, token2) // will be pending
+  const token3 = getToken()
+  const collab2 = await createReader(app, token3) // will be accepted
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab1.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  // add sources to the notebook
+  const note1 = await createNote(app, token, {
+    body: { content: 'something', motivation: 'test' }
+  })
+  await addNoteToNotebook(app, token, note1.shortId, notebook.shortId)
+
+  await tap.test(
+    'Accepted collaborator should be able to get a note in the notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.body[0].content, 'something')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaboration/collaboration-noteContext-get.test.js
+++ b/tests/integration/collaboration/collaboration-noteContext-get.test.js
@@ -2,29 +2,18 @@ const request = require('supertest')
 const tap = require('tap')
 const {
   getToken,
-  createUser,
   destroyDB,
   createNotebook,
-  addSourceToNotebook,
-  createSource,
-  addNoteToNotebook,
-  addTagToNotebook,
-  createTag,
-  createNote,
-  createCanvas,
   createNoteContext,
-  addSourceToCollection,
-  addNoteToCollection,
   createCollaborator,
   createReader,
   addNoteToContext
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   // owner, collab1, collab2
   const token = getToken()
-  const owner = await createReader(app, token)
+  await createReader(app, token)
   const token2 = getToken()
   const collab1 = await createReader(app, token2) // will be pending
   const token3 = getToken()
@@ -39,13 +28,13 @@ const test = async app => {
     }
   })
 
-  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab1.shortId,
     status: 'pending',
     permission: { read: true }
   })
 
-  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab2.shortId,
     status: 'accepted',
     permission: { read: true }

--- a/tests/integration/collaboration/collaboration-noteContext-get.test.js
+++ b/tests/integration/collaboration/collaboration-noteContext-get.test.js
@@ -16,7 +16,8 @@ const {
   addSourceToCollection,
   addNoteToCollection,
   createCollaborator,
-  createReader
+  createReader,
+  addNoteToContext
 } = require('../../utils/testUtils')
 const { urlToId } = require('../../../utils/utils')
 
@@ -88,6 +89,44 @@ const test = async app => {
       await tap.equal(res.status, 200)
       const body = res.body
       await tap.equal(body.type, 'outline')
+    }
+  )
+
+  const note1 = await addNoteToContext(app, token, context1.shortId, {
+    body: { motivation: 'test', content: 'abc' }
+  })
+
+  await tap.test(
+    'Accepted collaborator should be able to get a note within a noteContext',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.body[0].content, 'abc')
+    }
+  )
+
+  const note2 = await addNoteToContext(app, token, outline1.shortId, {
+    body: { motivation: 'test', content: 'def' }
+  })
+
+  await tap.test(
+    'Accepted collaborator should be able to get a note within an outline',
+    async () => {
+      const res = await request(app)
+        .get(`/notes/${note2.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.body[0].content, 'def')
     }
   )
 

--- a/tests/integration/collaboration/collaboration-noteContext-get.test.js
+++ b/tests/integration/collaboration/collaboration-noteContext-get.test.js
@@ -1,0 +1,97 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  addSourceToNotebook,
+  createSource,
+  addNoteToNotebook,
+  addTagToNotebook,
+  createTag,
+  createNote,
+  createCanvas,
+  createNoteContext,
+  addSourceToCollection,
+  addNoteToCollection,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  // owner, collab1, collab2
+  const token = getToken()
+  const owner = await createReader(app, token)
+  const token2 = getToken()
+  const collab1 = await createReader(app, token2) // will be pending
+  const token3 = getToken()
+  const collab2 = await createReader(app, token3) // will be accepted
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab1.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  // add sources to the notebook
+  const context1 = await createNoteContext(app, token, {
+    type: 'test',
+    notebookId: notebook.shortId
+  })
+
+  const outline1 = await createNoteContext(app, token, {
+    type: 'outline',
+    notebookId: notebook.shortId
+  })
+
+  await tap.test(
+    'Accepted collaborator should be able to get a noteContext in the notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/noteContexts/${context1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.type, 'test')
+    }
+  )
+
+  await tap.test(
+    'Accepted collaborator should be able to get an outline in the notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/outlines/${outline1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.type, 'outline')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaboration/collaboration-notebook-get.test.js
+++ b/tests/integration/collaboration/collaboration-notebook-get.test.js
@@ -2,7 +2,6 @@ const request = require('supertest')
 const tap = require('tap')
 const {
   getToken,
-  createUser,
   destroyDB,
   createNotebook,
   addSourceToNotebook,
@@ -18,12 +17,12 @@ const {
   createCollaborator,
   createReader
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   // owner, collab1, collab2
   const token = getToken()
-  const owner = await createReader(app, token)
+  // owner
+  await createReader(app, token)
   const token2 = getToken()
   const collab1 = await createReader(app, token2) // will be pending
   const token3 = getToken()
@@ -38,13 +37,13 @@ const test = async app => {
     }
   })
 
-  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab1.shortId,
     status: 'pending',
     permission: { read: true }
   })
 
-  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab2.shortId,
     status: 'accepted',
     permission: { read: true }

--- a/tests/integration/collaboration/collaboration-notebook-get.test.js
+++ b/tests/integration/collaboration/collaboration-notebook-get.test.js
@@ -1,0 +1,198 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  addSourceToNotebook,
+  createSource,
+  addNoteToNotebook,
+  addTagToNotebook,
+  createTag,
+  createNote,
+  createCanvas,
+  createNoteContext,
+  addSourceToCollection,
+  addNoteToCollection,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  // owner, collab1, collab2
+  const token = getToken()
+  const owner = await createReader(app, token)
+  const token2 = getToken()
+  const collab1 = await createReader(app, token2) // will be pending
+  const token3 = getToken()
+  const collab2 = await createReader(app, token3) // will be accepted
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab1.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  await tap.test(
+    'Get empty notebook with collaborators - by owner',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks/${notebook.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.ok(body.id)
+      await tap.ok(body.id.startsWith('http'))
+      await tap.ok(body.shortId)
+      await tap.equal(body.name, 'notebook1')
+      await tap.equal(body.description, 'test')
+      await tap.equal(body.status, 'archived')
+      await tap.equal(body.settings.property, 'value')
+      await tap.equal(body.collaborators.length, 2)
+      await tap.ok(body.collaborators[0].reader)
+      // notes, tags, notebookTags, sources, noteContexts
+      await tap.equal(body.notes.length, 0)
+      await tap.equal(body.tags.length, 0)
+      await tap.equal(body.notebookTags.length, 0)
+      await tap.equal(body.sources.length, 0)
+      await tap.equal(body.noteContexts.length, 0)
+    }
+  )
+
+  await tap.test(
+    'Accepted collaborator should be able to get the notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks/${notebook.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.name, 'notebook1')
+      await tap.equal(body.description, 'test')
+      await tap.equal(body.status, 'archived')
+      await tap.equal(body.settings.property, 'value')
+      await tap.equal(body.collaborators.length, 2)
+      await tap.ok(body.collaborators[0].reader)
+    }
+  )
+
+  const source = await createSource(app, token)
+  await addSourceToNotebook(app, token, source.shortId, notebook.shortId)
+
+  const note = await createNote(app, token, {
+    body: { content: 'test!!', motivation: 'test' },
+    sourceId: source.shortId
+  })
+  await addNoteToNotebook(app, token, note.shortId, notebook.shortId)
+
+  const tag = await createTag(app, token)
+  await addTagToNotebook(app, token, tag.id, notebook.shortId)
+
+  const notebookTag = await createTag(app, token, {
+    name: 'testing!',
+    notebookId: notebook.shortId
+  })
+
+  const notebookNoteContext = await createNoteContext(app, token, {
+    notebookId: notebook.shortId
+  })
+
+  await tap.test('Get notebook with source, by collaborator', async () => {
+    const res = await request(app)
+      .get(`/notebooks/${notebook.shortId}`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token3}`)
+      .type('application/ld+json')
+
+    await tap.equal(res.status, 200)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.name, 'notebook1')
+    await tap.equal(body.description, 'test')
+    await tap.equal(body.status, 'archived')
+    await tap.equal(body.settings.property, 'value')
+    // notes, tags, notebookTags, sources, noteContexts
+    await tap.equal(body.notes.length, 1)
+    await tap.equal(body.notes[0].shortId, note.shortId)
+    await tap.equal(body.notes[0].body[0].content, 'test!!')
+    await tap.equal(body.tags.length, 1)
+    await tap.equal(body.tags[0].id, tag.id)
+    await tap.equal(body.notebookTags.length, 1)
+    await tap.equal(body.notebookTags[0].id, notebookTag.id)
+    await tap.equal(body.sources.length, 1)
+    await tap.equal(body.sources[0].shortId, source.shortId)
+    await tap.ok(body.sources[0].author)
+    await tap.equal(body.sources[0].author.length, 1)
+    await tap.equal(body.noteContexts.length, 1)
+    await tap.equal(body.noteContexts[0].shortId, notebookNoteContext.shortId)
+  })
+
+  await addNoteToCollection(app, token, note.shortId, tag.id)
+  await addSourceToCollection(app, token, source.shortId, tag.id)
+  await createCanvas(app, token, {
+    notebookId: notebook.shortId,
+    name: 'canvas1',
+    description: 'something'
+  })
+
+  await tap.test(
+    'Get notebook with source tags, note tags..., by collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks/${notebook.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.ok(body.id)
+      // notes, tags, notebookTags, sources, noteContexts
+      await tap.equal(body.notes.length, 1)
+      await tap.equal(body.notes[0].tags.length, 1)
+      await tap.equal(body.sources.length, 1)
+      await tap.equal(body.sources[0].tags.length, 1)
+      await tap.equal(body.canvas.length, 1)
+    }
+  )
+
+  await tap.test(
+    'Try to get a notebook by a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks/${notebook.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 403)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaboration/collaboration-source-get.test.js
+++ b/tests/integration/collaboration/collaboration-source-get.test.js
@@ -2,28 +2,19 @@ const request = require('supertest')
 const tap = require('tap')
 const {
   getToken,
-  createUser,
   destroyDB,
   createNotebook,
   addSourceToNotebook,
   createSource,
-  addNoteToNotebook,
-  addTagToNotebook,
-  createTag,
-  createNote,
-  createCanvas,
-  createNoteContext,
-  addSourceToCollection,
-  addNoteToCollection,
   createCollaborator,
   createReader
 } = require('../../utils/testUtils')
-const { urlToId } = require('../../../utils/utils')
 
 const test = async app => {
   // owner, collab1, collab2
   const token = getToken()
-  const owner = await createReader(app, token)
+  // owner
+  await createReader(app, token)
   const token2 = getToken()
   const collab1 = await createReader(app, token2) // will be pending
   const token3 = getToken()
@@ -38,13 +29,13 @@ const test = async app => {
     }
   })
 
-  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab1.shortId,
     status: 'pending',
     permission: { read: true }
   })
 
-  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+  await createCollaborator(app, token, notebook.shortId, {
     readerId: collab2.shortId,
     status: 'accepted',
     permission: { read: true }

--- a/tests/integration/collaboration/collaboration-source-get.test.js
+++ b/tests/integration/collaboration/collaboration-source-get.test.js
@@ -1,0 +1,75 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createUser,
+  destroyDB,
+  createNotebook,
+  addSourceToNotebook,
+  createSource,
+  addNoteToNotebook,
+  addTagToNotebook,
+  createTag,
+  createNote,
+  createCanvas,
+  createNoteContext,
+  addSourceToCollection,
+  addNoteToCollection,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  // owner, collab1, collab2
+  const token = getToken()
+  const owner = await createReader(app, token)
+  const token2 = getToken()
+  const collab1 = await createReader(app, token2) // will be pending
+  const token3 = getToken()
+  const collab2 = await createReader(app, token3) // will be accepted
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook1',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  const collabObject1 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab1.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  const collabObject2 = await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  // add sources to the notebook
+  const source1 = await createSource(app, token, { name: 'test source' })
+  await addSourceToNotebook(app, token, source1.shortId, notebook.shortId)
+
+  await tap.test(
+    'Accepted collaborator should be able to get a source in the notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/sources/${source1.shortId}`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.name, 'test source')
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -122,6 +122,8 @@ const collaboratorPostTests = require('./collaborator/collaborator-post.test')
 const collaboratorPutTests = require('./collaborator/collaborator-put.test')
 const collaboratorDeleteTests = require('./collaborator/collaborator-delete.test')
 
+const collaborationNotebookGetTests = require('./collaboration/collaboration-notebook-get.test')
+
 const app = require('../../server').app
 
 require('dotenv').config()
@@ -339,6 +341,15 @@ const allTests = async () => {
       await collaboratorPostTests(app)
       await collaboratorPutTests(app)
       await collaboratorDeleteTests(app)
+    } catch (err) {
+      console.log('collaborator integration tests error: ', err)
+      throw err
+    }
+  }
+
+  if (!test || test === 'collaboration') {
+    try {
+      await collaborationNotebookGetTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -123,6 +123,9 @@ const collaboratorPutTests = require('./collaborator/collaborator-put.test')
 const collaboratorDeleteTests = require('./collaborator/collaborator-delete.test')
 
 const collaborationNotebookGetTests = require('./collaboration/collaboration-notebook-get.test')
+const collaborationSourceGetTests = require('./collaboration/collaboration-source-get.test')
+const collaborationNoteGetTests = require('./collaboration/collaboration-note-get.test')
+const collaborationNoteContextTests = require('./collaboration/collaboration-noteContext-get.test')
 
 const app = require('../../server').app
 
@@ -350,6 +353,9 @@ const allTests = async () => {
   if (!test || test === 'collaboration') {
     try {
       await collaborationNotebookGetTests(app)
+      await collaborationSourceGetTests(app)
+      await collaborationNoteGetTests(app)
+      await collaborationNoteContextTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -25,6 +25,10 @@ const test = async () => {
       }
     ]
   }
+  const notebook2 = {
+    id: '123',
+    name: 'notebook2'
+  }
 
   await tap.test(
     'checkNotebookCollaboration should return the permission object',
@@ -53,5 +57,12 @@ const test = async () => {
       await tap.ok(_.isEmpty(result))
     }
   )
+
+  await tap.test('should work with an array of notebooks', async () => {
+    const result = checkNotebookCollaborator('11', [notebook, notebook2])
+    await tap.ok(result)
+    await tap.equal(result.read, true)
+    await tap.equal(result.comment, true)
+  })
 }
 test()

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,0 +1,57 @@
+const tap = require('tap')
+const { checkNotebookCollaborator } = require('../../utils/utils')
+const _ = require('lodash')
+
+const test = async () => {
+  const notebook = {
+    id: '123',
+    name: 'notebook1',
+    collaborators: [
+      {
+        id: '1',
+        status: 2, // accepted
+        permission: { read: true, comment: true },
+        notebookId: '123',
+        readerId: '11',
+        reader: { id: '11', name: 'John Doe' }
+      },
+      {
+        id: '2',
+        notebookId: '123',
+        status: 1, // pending
+        permission: { read: true },
+        readerId: '22',
+        reader: { id: '22', name: 'Jane Doe' }
+      }
+    ]
+  }
+
+  await tap.test(
+    'checkNotebookCollaboration should return the permission object',
+    async () => {
+      const result = checkNotebookCollaborator('11', notebook)
+      await tap.ok(result)
+      await tap.equal(result.read, true)
+      await tap.equal(result.comment, true)
+    }
+  )
+
+  await tap.test(
+    'checkNotebookCollaboration should return empty object if collaborator is not accepted',
+    async () => {
+      const result = checkNotebookCollaborator('22', notebook)
+      await tap.ok(result)
+      await tap.ok(_.isEmpty(result))
+    }
+  )
+
+  await tap.test(
+    'checkNotebookCollaboration should return empty object if collaborator does not exist',
+    async () => {
+      const result = checkNotebookCollaborator('33', notebook)
+      await tap.ok(result)
+      await tap.ok(_.isEmpty(result))
+    }
+  )
+}
+test()

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,4 +1,5 @@
 const parseurl = require('url').parse
+const _ = require('lodash')
 
 const checkReader = (req, reader) => {
   return req.user === reader.authId
@@ -11,6 +12,15 @@ const checkOwnership = (readerId, resourceId) => {
   return resourceId.startsWith(readerId)
 }
 
+const checkNotebookCollaborator = (readerId, notebook) => {
+  readerId = urlToId(readerId)
+  const collaborator = _.find(notebook.collaborators, collab => {
+    return urlToId(collab.readerId) === readerId
+  })
+  if (collaborator && collaborator.status === 2) return collaborator.permission
+  else return {}
+}
+
 const urlToId = url => {
   if (url === null) return null
   if (!url) return undefined
@@ -20,4 +30,9 @@ const urlToId = url => {
   return path.substring(path.indexOf('/') + 1)
 }
 
-module.exports = { checkReader, urlToId, checkOwnership }
+module.exports = {
+  checkReader,
+  urlToId,
+  checkOwnership,
+  checkNotebookCollaborator
+}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -12,13 +12,21 @@ const checkOwnership = (readerId, resourceId) => {
   return resourceId.startsWith(readerId)
 }
 
-const checkNotebookCollaborator = (readerId, notebook) => {
+const checkNotebookCollaborator = (readerId, notebooks) => {
+  if (!notebooks) return {}
+  if (!_.isArray(notebooks)) notebooks = [notebooks]
+
   readerId = urlToId(readerId)
-  const collaborator = _.find(notebook.collaborators, collab => {
-    return urlToId(collab.readerId) === readerId
+  let result = {}
+  notebooks.forEach(notebook => {
+    const collaborator = _.find(notebook.collaborators, collab => {
+      return urlToId(collab.readerId) === readerId
+    })
+    if (collaborator && collaborator.status === 2) {
+      result = collaborator.permission
+    }
   })
-  if (collaborator && collaborator.status === 2) return collaborator.permission
-  else return {}
+  return result
 }
 
 const urlToId = url => {


### PR DESCRIPTION
Collaborator access on those routes:
GET /notebooks/:id
GET /sources/:id (if source is part of a shared notebook)
GET /notes/:id (if note is part of a shared notebook, or in a noteContext or outline belonging to a shared notebook)
GET /noteContexts/:id
GET /outlines/:id
The collaborator must have a status of 'accepted' and a permission.read = true