### PR TITLE
Create note as collaborator

### DIFF
--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -26,6 +26,8 @@ const test = async app => {
   const pendingCollab = await createReader(app, token4)
   const token5 = getToken()
   const noReadCollab = await createReader(app, token5)
+  const token6 = getToken()
+  const noCommentCollab = await createReader(app, token6)
 
   // create notebook and collab
   const notebook = await createNotebook(app, token, { name: 'my notebook' })
@@ -61,6 +63,15 @@ const test = async app => {
       comment: true
     }
   })
+  // no comment
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: noCommentCollab.shortId,
+    status: 'accepted',
+    permission: {
+      read: true,
+      comment: false
+    }
+  })
 
   const source = await createSource(app, token)
   await addSourceToNotebook(app, token, source.shortId, notebook.shortId)
@@ -87,6 +98,8 @@ const test = async app => {
     body: { motivation: 'test' },
     contextId: outline.shortId
   })
+
+  // ------------------- COLLABORATOR OBJECT -------------------------
 
   await tap.test(
     'Try to create a collaborator in a notebook you do not own',
@@ -180,6 +193,8 @@ const test = async app => {
     )
   })
 
+  // ----------------------------- NOTEBOOK ----------------------
+
   await tap.test('Try to get a notebook as a stranger', async () => {
     const res = await request(app)
       .get(`/notebooks/${notebook.shortId}`)
@@ -239,6 +254,8 @@ const test = async app => {
       )
     }
   )
+
+  // ----------------------------- NOTE IN NOTEBOOK ------------------
 
   await tap.test(
     'Try to get a note inside a notebook as a stranger',
@@ -303,6 +320,8 @@ const test = async app => {
     }
   )
 
+  // ---------------------------------- SOURCE --------------------
+
   await tap.test(
     'Try to get a source inside a notebook as a stranger',
     async () => {
@@ -365,6 +384,8 @@ const test = async app => {
       await tap.equal(error.details.requestUrl, `/sources/${source.shortId}`)
     }
   )
+
+  // ------------------------------ NOTECONTEXT ------------------
 
   await tap.test(
     'Try to get a noteContext inside a notebook as a stranger',
@@ -439,6 +460,8 @@ const test = async app => {
     }
   )
 
+  // ----------------------------- OUTLINE -------------------------
+
   await tap.test(
     'Try to get an outline inside a notebook as a stranger',
     async () => {
@@ -502,6 +525,8 @@ const test = async app => {
       await tap.equal(error.details.requestUrl, `/outlines/${outline.shortId}`)
     }
   )
+
+  // ---------------------------- NOTE IN NOTECONTEXT ----------------
 
   await tap.test(
     'Try to get a note inside a noteContext in a notebook as a stranger',
@@ -567,6 +592,8 @@ const test = async app => {
     }
   )
 
+  // -------------------------- NOTE IN OUTLINE ------------------------
+
   await tap.test(
     'Try to get a note inside an outline in a notebook as a stranger',
     async () => {
@@ -628,6 +655,95 @@ const test = async app => {
         `Access to note ${note2.shortId} disallowed`
       )
       await tap.equal(error.details.requestUrl, `/notes/${note2.shortId}`)
+    }
+  )
+
+  // --------------------------- CREATE NOTE IN NOTEBOOK --------------
+
+  await tap.test(
+    'Try to create a note inside a notebook as a stranger',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside a notebook as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside a notebook as a collaborator without comment permission',
+    async () => {
+      const res = await request(app)
+        .post(`/notebooks/${notebook.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token6}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Notebook ${notebook.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/notebooks/${notebook.shortId}/notes`
+      )
     }
   )
 

--- a/tests/integration/auth/collaboration-auth.test.js
+++ b/tests/integration/auth/collaboration-auth.test.js
@@ -747,6 +747,184 @@ const test = async app => {
     }
   )
 
+  // -------------------------- POST NOTE IN CONTEXT ------------
+
+  await tap.test(
+    'Try to create a note inside a notecontext as a stranger',
+    async () => {
+      const res = await request(app)
+        .post(`/noteContexts/${noteContext.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside a notecontext as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .post(`/noteContexts/${noteContext.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside a notecontext as a collaborator without comment permission',
+    async () => {
+      const res = await request(app)
+        .post(`/noteContexts/${noteContext.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token6}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to NoteContext ${noteContext.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/noteContexts/${noteContext.shortId}/notes`
+      )
+    }
+  )
+
+  // -------------------------- POST NOTE IN OUTLINE ------------
+
+  await tap.test(
+    'Try to create a note inside an outline as a stranger',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside an outline as a pending collaborator',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token4}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes`
+      )
+    }
+  )
+
+  await tap.test(
+    'Try to create a note inside an outline as a collaborator without a comment permission',
+    async () => {
+      const res = await request(app)
+        .post(`/outlines/${outline.shortId}/notes`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token6}`)
+        .type('application/ld+json')
+        .send(
+          JSON.stringify({
+            body: { motivation: 'test' }
+          })
+        )
+
+      await tap.equal(res.statusCode, 403)
+      const error = JSON.parse(res.text)
+      await tap.equal(error.statusCode, 403)
+      await tap.equal(error.error, 'Forbidden')
+      await tap.equal(
+        error.message,
+        `Access to Outline ${outline.shortId} disallowed`
+      )
+      await tap.equal(
+        error.details.requestUrl,
+        `/outlines/${outline.shortId}/notes`
+      )
+    }
+  )
+
   await destroyDB(app)
 }
 

--- a/tests/integration/collaboration/collaboration-noteContext-note-post.test.js
+++ b/tests/integration/collaboration/collaboration-noteContext-note-post.test.js
@@ -1,0 +1,66 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createReader,
+  destroyDB,
+  createNotebook,
+  createNoteContext,
+  createCollaborator
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createReader(app, token)
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  const token2 = getToken()
+  const collaborator = await createReader(app, token2)
+
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: collaborator.shortId,
+    status: 'accepted',
+    permission: { read: true, comment: true }
+  })
+
+  const context = await createNoteContext(app, token, {
+    notebookId
+  })
+
+  await tap.test('Create Note in Notecontext as a collaborator', async () => {
+    const res = await request(app)
+      .post(`/noteContexts/${context.shortId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), collaborator.shortId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaboration/collaboration-notebook-note-post.test.js
+++ b/tests/integration/collaboration/collaboration-notebook-note-post.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createReader,
+  destroyDB,
+  createNotebook,
+  createCollaborator
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createReader(app, token)
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  const token2 = getToken()
+  const collaborator = await createReader(app, token2)
+
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: collaborator.shortId,
+    status: 'accepted',
+    permission: { read: true, comment: true }
+  })
+
+  await tap.test('Create Note in Notebook as a collaborator', async () => {
+    const res = await request(app)
+      .post(`/notebooks/${notebookId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), collaborator.shortId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/collaboration/collaboration-outline-note-post.test.js
+++ b/tests/integration/collaboration/collaboration-outline-note-post.test.js
@@ -1,0 +1,67 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  createReader,
+  destroyDB,
+  createNotebook,
+  createNoteContext,
+  createCollaborator
+} = require('../../utils/testUtils')
+const { urlToId } = require('../../../utils/utils')
+
+const test = async app => {
+  const token = getToken()
+  await createReader(app, token)
+
+  const notebook = await createNotebook(app, token)
+  const notebookId = notebook.shortId
+
+  const token2 = getToken()
+  const collaborator = await createReader(app, token2)
+
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: collaborator.shortId,
+    status: 'accepted',
+    permission: { read: true, comment: true }
+  })
+
+  const context = await createNoteContext(app, token, {
+    notebookId,
+    type: 'outline'
+  })
+
+  await tap.test('Create Note in Outline as a collaborator', async () => {
+    const res = await request(app)
+      .post(`/outlines/${context.shortId}/notes`)
+      .set('Host', 'reader-api.test')
+      .set('Authorization', `Bearer ${token2}`)
+      .type('application/ld+json')
+      .send(
+        JSON.stringify({
+          body: {
+            content: 'this is the content of the note',
+            motivation: 'test'
+          },
+          json: { property1: 'value1' }
+        })
+      )
+    await tap.equal(res.status, 201)
+    const body = res.body
+    await tap.ok(body.id)
+    await tap.equal(body.shortId, urlToId(body.id))
+    await tap.equal(urlToId(body.readerId), collaborator.shortId)
+    await tap.equal(body.json.property1, 'value1')
+    await tap.ok(body.published)
+    await tap.ok(body.body)
+    await tap.ok(body.body[0].content)
+    await tap.equal(body.body[0].motivation, 'test')
+
+    await tap.type(res.get('Location'), 'string')
+    await tap.equal(res.get('Location'), body.id)
+  })
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -126,6 +126,7 @@ const collaborationNotebookGetTests = require('./collaboration/collaboration-not
 const collaborationSourceGetTests = require('./collaboration/collaboration-source-get.test')
 const collaborationNoteGetTests = require('./collaboration/collaboration-note-get.test')
 const collaborationNoteContextTests = require('./collaboration/collaboration-noteContext-get.test')
+const collaborationNotebookNotePostTests = require('./collaboration/collaboration-notebook-note-post.test')
 
 const app = require('../../server').app
 
@@ -356,6 +357,7 @@ const allTests = async () => {
       await collaborationSourceGetTests(app)
       await collaborationNoteGetTests(app)
       await collaborationNoteContextTests(app)
+      await collaborationNotebookNotePostTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -127,6 +127,8 @@ const collaborationSourceGetTests = require('./collaboration/collaboration-sourc
 const collaborationNoteGetTests = require('./collaboration/collaboration-note-get.test')
 const collaborationNoteContextTests = require('./collaboration/collaboration-noteContext-get.test')
 const collaborationNotebookNotePostTests = require('./collaboration/collaboration-notebook-note-post.test')
+const collaborationNoteContextNotePostTests = require('./collaboration/collaboration-noteContext-note-post.test')
+const collaborationOutlineNotePostTests = require('./collaboration/collaboration-outline-note-post.test')
 
 const app = require('../../server').app
 
@@ -358,6 +360,8 @@ const allTests = async () => {
       await collaborationNoteGetTests(app)
       await collaborationNoteContextTests(app)
       await collaborationNotebookNotePostTests(app)
+      await collaborationNoteContextNotePostTests(app)
+      await collaborationOutlineNotePostTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/unit/outline-utils.test.js
+++ b/tests/unit/outline-utils.test.js
@@ -136,6 +136,121 @@ const test = async () => {
     await tap.equal(result[0].children[1].children[2].shortId, '8')
   })
 
+  // list with some free floating notes
+  /*
+  note1
+    note4
+    note2
+      note3
+  note5
+  ... note6, note7 not in tree
+  */
+  const listOfNotes2 = [
+    {
+      id: 'https://reader-api.test/notes/1',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      documentUrl:
+        'https://reader-api.test/sources/q3WCuzFju4zaw3AAr3KBoU-2cf84b9e55/path/1',
+      sourceId:
+        'https://reader-api.test/sources/q3WCuzFju4zaw3AAr3KBoU-2cf84b9e55',
+      published: '2020-02-28T13:55:40.345Z',
+      updated: '2020-02-28T13:55:40.345Z',
+      body: [{ content: 'note content 1', motivation: 'test' }],
+      shortId: '1',
+      next: '5'
+    },
+    {
+      id: 'https://reader-api.test/notes/2',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      published: '2020-02-28T13:55:40.334Z',
+      updated: '2020-02-28T13:55:40.334Z',
+      body: [{ content: 'note content 2', motivation: 'test' }],
+      type: 'Note',
+      shortId: '2',
+      parentId: '1',
+      previous: '4'
+    },
+    {
+      id: 'https://reader-api.test/notes/3',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      published: '2020-02-28T13:55:40.318Z',
+      updated: '2020-02-28T13:55:40.318Z',
+      body: [{ content: 'note content 3', motivation: 'test' }],
+      type: 'Note',
+      shortId: '3',
+      parentId: '2'
+    },
+    {
+      id: 'https://reader-api.test/notes/4',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      published: '2020-02-28T13:55:40.382Z',
+      updated: '2020-02-28T13:55:40.382Z',
+      body: [{ content: 'note content 4', motivation: 'test' }],
+      type: 'Note',
+      shortId: '4',
+      parentId: '1',
+      next: '2'
+    },
+    {
+      id: 'https://reader-api.test/notes/5',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      published: '2020-02-28T13:55:40.382Z',
+      updated: '2020-02-28T13:55:40.382Z',
+      body: [{ content: 'note content 5', motivation: 'test' }],
+      type: 'Note',
+      shortId: '5',
+      previous: '1'
+    },
+    {
+      id: 'https://reader-api.test/notes/6',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      published: '2020-02-28T13:55:40.382Z',
+      updated: '2020-02-28T13:55:40.382Z',
+      body: [{ content: 'note content 6', motivation: 'test' }],
+      type: 'Note',
+      shortId: '6'
+    },
+    {
+      id: 'https://reader-api.test/notes/7',
+      readerId: 'https://reader-api.test/readers/q3WCuzFju4zaw3AAr3KBoU',
+      target: { property: 'something' },
+      published: '2020-02-28T13:55:40.382Z',
+      updated: '2020-02-28T13:55:40.382Z',
+      body: [{ content: 'note content 7', motivation: 'test' }],
+      type: 'Note',
+      shortId: '7'
+    }
+  ]
+
+  await tap.test('should still work with free floating notes', async () => {
+    const result = notesListToTree(listOfNotes2)
+
+    // first level: 1, 5, 6, 7
+    await tap.equal(result.length, 4)
+    await tap.equal(result[0].shortId, '1')
+    await tap.equal(result[1].shortId, '5')
+    await tap.equal(result[2].shortId, '6')
+    await tap.equal(result[3].shortId, '7')
+    // 5, 6, 7 have no children
+    await tap.equal(result[1].children.length, 0)
+    await tap.equal(result[2].children.length, 0)
+    await tap.equal(result[3].children.length, 0)
+    // children of 1: 4, 2
+    await tap.equal(result[0].children.length, 2)
+    await tap.equal(result[0].children[0].shortId, '4')
+    await tap.equal(result[0].children[1].shortId, '2')
+    // children of 4: none
+    await tap.equal(result[0].children[0].children.length, 0)
+    // children of 2: 3
+    await tap.equal(result[0].children[1].children.length, 1)
+    await tap.equal(result[0].children[1].children[0].shortId, '3')
+  })
+
   const badList = [
     {
       id: 'https://reader-api.test/notes/2',


### PR DESCRIPTION
Allows collaborators to create notes using those routes:
POST /notebooks/:id/notes
POST /noteContexts/:id/notes
POST /outlines/:id/notes
In all cases, the collaborator must have a status of 'accepted' and a permission.comment = true
In the case of outlines, I assume comments will not be part of the hierarchy of the outline, but they will just be in the same list, at the top level, with no children notes. People in the front-end might want to think about using a specific motivation type for the comments to differentiate them from the notes that are in the outline. 