### PR TITLE
Get notebooks as collab

### DIFF
--- a/models/Collaborator.js
+++ b/models/Collaborator.js
@@ -70,7 +70,7 @@ class Collaborator extends BaseModel {
 
   static _formatCollaborator (collaborator /*: any */) /*: any */ {
     collaborator.status = statusMap[collaborator.status]
-
+    collaborator.readerId = urlToId(collaborator.readerId)
     return collaborator
   }
 
@@ -88,9 +88,6 @@ class Collaborator extends BaseModel {
 
     this._validateCollaborator(props)
     props = this._formatCollaborator(props)
-    props.id = `${urlToId(props.readerId)}-${crypto
-      .randomBytes(5)
-      .toString('hex')}`
 
     let result
     try {

--- a/models/Collaborator.js
+++ b/models/Collaborator.js
@@ -88,6 +88,9 @@ class Collaborator extends BaseModel {
 
     this._validateCollaborator(props)
     props = this._formatCollaborator(props)
+    props.id = `${urlToId(props.readerId)}-${crypto
+      .randomBytes(5)
+      .toString('hex')}`
 
     let result
     try {

--- a/routes/notebooks/notebooks.get.js
+++ b/routes/notebooks/notebooks.get.js
@@ -46,6 +46,12 @@ module.exports = function (app) {
    *           type: string
    *         description: colour found in the settings object
    *       - in: query
+   *         name: collaboration
+   *         schema:
+   *           type: boolean
+   *         default: false
+   *         description: if true, will also return the notebooks the reader is collaborating on
+   *       - in: query
    *         name: orderBy
    *         type: string
    *         enum: ['name', 'created', 'updated']
@@ -83,7 +89,8 @@ module.exports = function (app) {
         search: req.query.search,
         colour: req.query.colour,
         orderBy: req.query.orderBy,
-        reverse: req.query.reverse
+        reverse: req.query.reverse,
+        collaboration: req.query.collaboration
       }
 
       Reader.byAuthId(req.user)

--- a/tests/integration/collaboration/collaboration-notebooks-get.test.js
+++ b/tests/integration/collaboration/collaboration-notebooks-get.test.js
@@ -1,0 +1,115 @@
+const request = require('supertest')
+const tap = require('tap')
+const {
+  getToken,
+  destroyDB,
+  createNotebook,
+  createCollaborator,
+  createReader
+} = require('../../utils/testUtils')
+
+const test = async app => {
+  // owner, collab1, collab2
+  const token = getToken()
+  // owner
+  await createReader(app, token)
+  const token2 = getToken()
+  const collab1 = await createReader(app, token2) // will be pending
+  const token3 = getToken()
+  const collab2 = await createReader(app, token3) // will be accepted
+
+  const notebook = await createNotebook(app, token, {
+    name: 'notebook123',
+    status: 'archived',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  const notebook2 = await createNotebook(app, token, {
+    name: 'notebook2',
+    status: 'active',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  // belongs to collab
+  const notebook3 = await createNotebook(app, token3, {
+    name: 'notebook3',
+    status: 'active',
+    description: 'test',
+    settings: {
+      property: 'value'
+    }
+  })
+
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab1.shortId,
+    status: 'pending',
+    permission: { read: true }
+  })
+
+  await createCollaborator(app, token, notebook.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  await createCollaborator(app, token, notebook2.shortId, {
+    readerId: collab2.shortId,
+    status: 'accepted',
+    permission: { read: true }
+  })
+
+  await tap.test(
+    'Accepted collaborator should be able to get the notebook as part of the notebooks lis',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks?collaboration=true`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.items.length, 3)
+    }
+  )
+
+  await tap.test(
+    'Accepted collaborator should be able to get the notebook as part of the notebooks list, with other filters',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks?collaboration=true&status=active`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token3}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.items.length, 2)
+    }
+  )
+
+  await tap.test(
+    'Getting notebooks as a pending collaborator should not return collaboration notebook',
+    async () => {
+      const res = await request(app)
+        .get(`/notebooks?collaboration=true`)
+        .set('Host', 'reader-api.test')
+        .set('Authorization', `Bearer ${token2}`)
+        .type('application/ld+json')
+
+      await tap.equal(res.status, 200)
+      const body = res.body
+      await tap.equal(body.items.length, 0)
+    }
+  )
+
+  await destroyDB(app)
+}
+
+module.exports = test

--- a/tests/integration/index.js
+++ b/tests/integration/index.js
@@ -129,6 +129,7 @@ const collaborationNoteContextTests = require('./collaboration/collaboration-not
 const collaborationNotebookNotePostTests = require('./collaboration/collaboration-notebook-note-post.test')
 const collaborationNoteContextNotePostTests = require('./collaboration/collaboration-noteContext-note-post.test')
 const collaborationOutlineNotePostTests = require('./collaboration/collaboration-outline-note-post.test')
+const collaborationNotebooksGetTests = require('./collaboration/collaboration-notebooks-get.test')
 
 const app = require('../../server').app
 
@@ -362,6 +363,7 @@ const allTests = async () => {
       await collaborationNotebookNotePostTests(app)
       await collaborationNoteContextNotePostTests(app)
       await collaborationOutlineNotePostTests(app)
+      await collaborationNotebooksGetTests(app)
     } catch (err) {
       console.log('collaborator integration tests error: ', err)
       throw err

--- a/tests/utils/testUtils.js
+++ b/tests/utils/testUtils.js
@@ -370,7 +370,6 @@ const createCollaborator = async (app, token, notebookId, object) => {
     .set('Host', 'reader-api.test')
     .set('Authorization', `Bearer ${token}`)
     .send(object)
-
   return res.body
 }
 


### PR DESCRIPTION
Fixing it so that the GET /notebooks endpoints can return notebooks that the user is a collaborator on. 
This is optional, and you need to use a query parameter: GET /notebooks?collaboration=true
I did it that way because I had to make a second database query to get the collaboration notebooks, and I didn't want to slow everything down for something that is not even used yet. 
I might be able to consolidate into a single query, but I am not sure. I will take another look when we start using it. If that works, I will remove the query parameter. 

