### PR TITLE
Delete notebook bug

### DIFF
--- a/models/Note.js
+++ b/models/Note.js
@@ -364,7 +364,7 @@ class Note extends BaseModel {
   static async delete (id /*: string */) /*: Promise<NoteType|null> */ {
     // Delete all Note_Tag associated with the note
     await Note_Tag.deleteNoteTagsOfNote(id)
-
+    await Notebook_Note.deleteNotebooksOfNote(id)
     await NoteBody.softDeleteBodiesOfNote(id)
 
     return await Note.query()

--- a/models/Notebook.js
+++ b/models/Notebook.js
@@ -2,6 +2,9 @@
 'use strict'
 const Model = require('objection').Model
 const { BaseModel } = require('./BaseModel.js')
+const { Notebook_Note } = require('./Notebook_Note')
+const { Notebook_Source } = require('./Notebook_Source')
+const { Notebook_Tag } = require('./Notebook_Tag')
 const _ = require('lodash')
 const { urlToId } = require('../utils/utils')
 const crypto = require('crypto')
@@ -318,6 +321,9 @@ class Notebook extends BaseModel {
   static async delete (id /*: string */) /*: Promise<any> */ {
     id = urlToId(id)
     const date = new Date().toISOString()
+    await Notebook_Note.deleteNoteOfNotebooks(id)
+    await Notebook_Source.deleteSourceOfNotebooks(id)
+    await Notebook_Tag.deleteTagOfNotebooks(id)
     return await Notebook.query()
       .patch({ deleted: date })
       .whereNull('deleted')

--- a/models/Notebook_Note.js
+++ b/models/Notebook_Note.js
@@ -64,6 +64,16 @@ class Notebook_Note extends BaseModel {
       .where({ noteId: urlToId(noteId) })
   }
 
+  static async deleteNoteOfNotebooks (
+    notebookId /*: string */
+  ) /*: Promise<number|Error> */ {
+    if (!notebookId) return new Error('no notebook')
+
+    return await Notebook_Note.query()
+      .delete()
+      .where({ notebookId: urlToId(notebookId) })
+  }
+
   /**
    * warning: does not throw errors
    */

--- a/models/Notebook_Source.js
+++ b/models/Notebook_Source.js
@@ -115,6 +115,16 @@ class Notebook_Source extends BaseModel {
     }
   }
 
+  static async deleteSourceOfNotebooks (
+    notebookId /*: string */
+  ) /*: Promise<number|Error> */ {
+    if (!notebookId) return new Error('no notebook')
+
+    return await Notebook_Source.query()
+      .delete()
+      .where({ notebookId: urlToId(notebookId) })
+  }
+
   $beforeInsert (queryOptions /*: any */, context /*: any */) /*: any */ {
     const parent = super.$beforeInsert(queryOptions, context)
     let doc = this

--- a/models/Notebook_Tag.js
+++ b/models/Notebook_Tag.js
@@ -66,6 +66,16 @@ class Notebook_Tag extends BaseModel {
     }
   }
 
+  static async deleteTagOfNotebooks (
+    notebookId /*: string */
+  ) /*: Promise<number|Error> */ {
+    if (!notebookId) return new Error('no notebook')
+
+    return await Notebook_Tag.query()
+      .delete()
+      .where({ notebookId: urlToId(notebookId) })
+  }
+
   $beforeInsert (queryOptions /*: any */, context /*: any */) /*: any */ {
     const parent = super.$beforeInsert(queryOptions, context)
     let doc = this

--- a/routes/outlines/outline-patchNote.js
+++ b/routes/outlines/outline-patchNote.js
@@ -206,17 +206,17 @@ module.exports = function (app) {
           // if updatedNote.previous
           if (updatedNote.previous) {
             const previousNote = await Note.byId(updatedNote.previous)
-            await Note.update(
-              Object.assign(previousNote, { next: urlToId(updatedNote.id) })
-            )
+            const changes = { next: urlToId(updatedNote.id) }
+            if (previousNote.previous === urlToId(updatedNote.id)) { changes.previous = null }
+            await Note.update(Object.assign(previousNote, changes))
           }
 
           // if updatedNote.next
           if (updatedNote.next) {
             const nextNote = await Note.byId(updatedNote.next)
-            await Note.update(
-              Object.assign(nextNote, { previous: urlToId(updatedNote.id) })
-            )
+            const changes = { previous: urlToId(updatedNote.id) }
+            if (nextNote.next === urlToId(updatedNote.id)) changes.next = null
+            await Note.update(Object.assign(nextNote, changes))
           }
 
           res.setHeader('Content-Type', 'application/ld+json')

--- a/server.js
+++ b/server.js
@@ -322,7 +322,9 @@ canvasGetByIdRoute(app)
 canvasGetAllRoute(app)
 
 app.use(errorHandling)
-
+app.use((req, res) => {
+  res.sendStatus(404)
+})
 app.start = port => {
   app.listen(port, () => console.log('Listening'))
 }


### PR DESCRIPTION
Fixing: 
- the bugs related with deleting notebooks (when deleting a notebook, it will also delete any related notebook_note, notebook_source and notebook_tag relation)
- fix it so that when trying to access a route that does not exist, user will get a 404 error object instead of an html page
- fix problem of switching notes in an outline that is one list of two notes
