### PR TITLE
Article metadata

### DIFF
--- a/models/Source.js
+++ b/models/Source.js
@@ -24,7 +24,9 @@ const metadataProps = [
   'copyrightYear',
   'genre',
   'license',
-  'inDirection'
+  'inDirection',
+  'pagination',
+  'isPartOf'
 ]
 
 const linkProperties = [
@@ -343,6 +345,37 @@ class Source extends BaseModel {
           }
         })
       }
+
+      // check pagination
+      if (source.pagination && !_.isString(source.pagination)) {
+        throw new Error(
+          'Source validation error: pagination should be a string'
+        )
+      }
+
+      if (source.isPartOf) {
+        if (source.isPartOf.title && !_.isString(source.isPartOf.title)) {
+          throw new Error(
+            'Source validation error: isPartOf.title should be a string'
+          )
+        }
+        if (
+          source.isPartOf.issueNumber &&
+          !_.isString(source.isPartOf.issueNumber)
+        ) {
+          throw new Error(
+            'Source validation error: isPartOf.issueNumber should be a string'
+          )
+        }
+        if (
+          source.isPartOf.volumeNumber &&
+          !_.isString(source.isPartOf.volumeNumber)
+        ) {
+          throw new Error(
+            'Source validation error: isPartOf.volumeNumber should be a string'
+          )
+        }
+      }
     }
 
     // check resources objects
@@ -477,6 +510,14 @@ class Source extends BaseModel {
     if (source.status) {
       source.status = statusMap[source.status]
     }
+
+    if (source.isPartOf && source.isPartOf.volumeNumber) {
+      source.isPartOf.volumeNumber = source.isPartOf.volumeNumber.toString()
+    }
+    if (source.isPartOf && source.isPartOf.issueNumber) {
+      source.isPartOf.issueNumber = source.isPartOf.issueNumber.toString()
+    }
+
     return source
   }
 

--- a/routes/sources/library-get.js
+++ b/routes/sources/library-get.js
@@ -211,7 +211,9 @@ module.exports = app => {
               'bookFormat',
               'inLanguage',
               'lastReadActivity',
-              'citation'
+              'citation',
+              'isPartOf',
+              'pagination'
             ])
           })
 

--- a/tests/integration/library/library-get.test.js
+++ b/tests/integration/library/library-get.test.js
@@ -59,7 +59,13 @@ const test = async () => {
       readingOrder: [{ url: 'one' }, { url: 'two' }, { url: 'three' }],
       resources: [{ url: 'value' }],
       json: { property: 'value' },
-      citation: { default: '123' }
+      citation: { default: '123' },
+      pagination: '100-101',
+      isPartOf: {
+        title: 'journal of something',
+        issueNumber: '1',
+        volumeNumber: '2'
+      }
     })
 
     const activity1 = await request(app)
@@ -151,6 +157,11 @@ const test = async () => {
     await tap.notOk(source.license)
     await tap.ok(source.citation)
     await tap.equal(source.citation.default, '123')
+    await tap.equal(source.pagination, '100-101')
+    await tap.ok(source.isPartOf)
+    await tap.equal(source.isPartOf.title, 'journal of something')
+    await tap.equal(source.isPartOf.issueNumber, '1')
+    await tap.equal(source.isPartOf.volumeNumber, '2')
   })
 
   if (process.env.REDIS_PASSWORD) {

--- a/tests/integration/source/source-get.test.js
+++ b/tests/integration/source/source-get.test.js
@@ -70,7 +70,14 @@ const test = async app => {
       }
     ],
     json: { property: 'value' },
-    citation: { default: '123' }
+    citation: { default: '123' },
+    pagination: '100-101',
+    isPartOf: {
+      title: 'journal of something',
+      datePublished: now,
+      issueNumber: '1',
+      volumeNumber: '2'
+    }
   }
 
   const resCreateSource = await createSource(app, token, sourceObject)
@@ -127,6 +134,12 @@ const test = async app => {
     await tap.equal(body.license, 'http://www.mylicense.com')
     await tap.ok(body.citation)
     await tap.equal(body.citation.default, '123')
+    await tap.equal(body.pagination, '100-101')
+    await tap.ok(body.isPartOf)
+    await tap.equal(body.isPartOf.title, 'journal of something')
+    await tap.equal(body.isPartOf.issueNumber, '1')
+    await tap.equal(body.isPartOf.volumeNumber, '2')
+    await tap.ok(body.isPartOf.datePublished)
   })
 
   await tap.test('Get Source with a readActivity', async () => {

--- a/tests/integration/source/source-patch.test.js
+++ b/tests/integration/source/source-patch.test.js
@@ -71,7 +71,14 @@ const test = async app => {
         name: 'An example resource'
       }
     ],
-    json: { property: 'value' }
+    json: { property: 'value' },
+    pagination: '100-101',
+    isPartOf: {
+      title: 'journal of something',
+      datePublished: now,
+      issueNumber: '1',
+      volumeNumber: '2'
+    }
   }
 
   const resCreateSource = await createSource(app, token, sourceObject)
@@ -124,7 +131,13 @@ const test = async app => {
           illustrator: ['Sample Illustrator2'],
           publisher: ['Sample Publisher2'],
           translator: ['Sample Translator2'],
-          citation: { default: '123' }
+          citation: { default: '123' },
+          pagination: '100-102',
+          isPartOf: {
+            title: 'journal of something else',
+            issueNumber: '1a',
+            volumeNumber: '2a'
+          }
         })
       )
     await tap.equal(res.status, 200)
@@ -163,6 +176,11 @@ const test = async app => {
     await tap.equal(body.translator[0].name, 'Sample Translator2')
     await tap.ok(body.citation)
     await tap.equal(body.citation.default, '123')
+    await tap.equal(body.pagination, '100-102')
+    await tap.ok(body.isPartOf)
+    await tap.equal(body.isPartOf.title, 'journal of something else')
+    await tap.equal(body.isPartOf.issueNumber, '1a')
+    await tap.equal(body.isPartOf.volumeNumber, '2a')
   })
 
   await tap.test('Update a single property', async () => {

--- a/tests/integration/source/source-post.test.js
+++ b/tests/integration/source/source-post.test.js
@@ -74,7 +74,14 @@ const test = async app => {
       }
     ],
     json: { property: 'value' },
-    citation: 'default citation'
+    citation: 'default citation',
+    pagination: '100-101',
+    isPartOf: {
+      title: 'journal of something',
+      datePublished: now,
+      issueNumber: '1',
+      volumeNumber: '2'
+    }
   }
 
   const tag1 = await createTag(app, token, { name: 'tag1' })
@@ -143,6 +150,12 @@ const test = async app => {
     await tap.equal(body.copyrightHolder[0].name, 'Joe Smith')
     await tap.ok(body.citation)
     await tap.equal(body.citation.default, 'default citation')
+    await tap.equal(body.pagination, '100-101')
+    await tap.ok(body.isPartOf)
+    await tap.equal(body.isPartOf.title, 'journal of something')
+    await tap.equal(body.isPartOf.issueNumber, '1')
+    await tap.equal(body.isPartOf.volumeNumber, '2')
+    await tap.ok(body.isPartOf.datePublished)
 
     await tap.type(res.get('Location'), 'string')
     await tap.equal(res.get('Location'), body.id)


### PR DESCRIPTION
Doesn't change the database. 

Now you can create / update sources with properties:
- pagination (string, something like '100-110')
- isPartOf (object)
    - title (title of journal)
    - datePublished (date)
    - issueNumber (string)
    - volumeNumber (string)
That information is also returned on endpoints:
GET /sources/:id
GET /library